### PR TITLE
Respect compositor xdg-decoration support to avoid double header bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk4-wayland"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7027433b8f19075ab22f01d0e0ba4373e303ffdb4ce4f846a2763cb020ea9bdc"
+dependencies = [
+ "gdk4",
+ "gdk4-wayland-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk4-wayland-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653cafb8715f2ac1c56edaf8060d9360ae3acbe3c6fb61b676a2917d42b668cf"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +785,7 @@ name = "limux-host-linux"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "gdk4-wayland",
  "gtk4",
  "libadwaita",
  "limux-ghostty-sys",

--- a/rust/limux-host-linux/Cargo.toml
+++ b/rust/limux-host-linux/Cargo.toml
@@ -15,6 +15,7 @@ webkit = ["dep:webkit6"]
 
 [dependencies]
 gtk4 = { version = "0.11", features = ["v4_10"] }
+gdk4-wayland = "0.11"
 libadwaita = "0.9"
 uuid = { version = "1", features = ["v4"] }
 webkit6 = { version = "0.6", optional = true }

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -306,8 +306,23 @@ pub fn build_window(app: &adw::Application) {
         .default_height(900)
         .build();
 
-    let header = adw::HeaderBar::new();
-    header.set_title_widget(Some(&gtk::Label::builder().label(&title).build()));
+    // GTK4/libadwaita always uses CSD and ignores the xdg-decoration negotiation.
+    // Skip the header bar when the display provides its own window decorations:
+    // - X11: WMs always provide SSD (downcast to WaylandDisplay fails → default to true).
+    // - Wayland: if the compositor advertises xdg-decoration.
+    let provides_decorations = gtk::gdk::Display::default()
+        .and_then(|d| d.downcast::<gdk4_wayland::WaylandDisplay>().ok())
+        .map(|d| d.query_registry("zxdg_decoration_manager_v1"))
+        // Not a Wayland display (X11) → default to showing header bar
+        .unwrap_or(false);
+
+    let header = if provides_decorations {
+        None
+    } else {
+        let bar = adw::HeaderBar::new();
+        bar.set_title_widget(Some(&gtk::Label::builder().label(&title).build()));
+        Some(bar)
+    };
 
     let stack = gtk::Stack::new();
     stack.set_transition_type(gtk::StackTransitionType::None);
@@ -407,7 +422,9 @@ pub fn build_window(app: &adw::Application) {
     content_overlay.add_overlay(&expand_btn);
 
     let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    vbox.append(&header);
+    if let Some(ref header) = header {
+        vbox.append(header);
+    }
     vbox.append(&content_overlay);
     window.set_content(Some(&vbox));
 


### PR DESCRIPTION
GTK4/libadwaita always uses CSD and ignores the xdg-decoration SSD negotiation, so compositors like niri and Hyprland end up with double decorations (their own + the header bar).

This checks whether the compositor advertises  in its Wayland globals. If it does, we skip the header bar and let the compositor handle window decorations.