### PR TITLE
ci: add AUR publish workflow

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,54 @@
+name: Publish to AUR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (without v prefix)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  aur-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate AUR PKGBUILD
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          TARBALL_URL="https://github.com/am-will/limux/releases/download/v${VERSION}/limux-${VERSION}-linux-x86_64.tar.gz"
+
+          curl -fL "$TARBALL_URL" -o /tmp/limux.tar.gz
+          SHA256=$(sha256sum /tmp/limux.tar.gz | awk '{print $1}')
+
+          sed -e "s/@@VERSION@@/$VERSION/" \
+              -e "s/@@SHA256@@/$SHA256/" \
+              PKGBUILD.template > PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: limux-bin
+          pkgbuild: PKGBUILD
+          commit_username: "Anton Barchukov"
+          commit_email: anton@barchukov.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "chore: bump to ${{ steps.version.outputs.version }}"
+          force_push: true

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -1,0 +1,32 @@
+# Maintainer: Anton Barchukov <anton@barchukov.com>
+pkgname=limux-bin
+pkgver=@@VERSION@@
+pkgrel=1
+pkgdesc="GPU-accelerated terminal workspace manager for Linux, powered by Ghostty's rendering engine (cmux port)"
+arch=('x86_64')
+url="https://github.com/am-will/limux"
+license=('MIT')
+depends=('gtk4' 'libadwaita' 'webkitgtk-6.0')
+provides=('limux')
+conflicts=('limux')
+options=(!debug !strip)
+source=("limux-${pkgver}.tar.gz::https://github.com/am-will/limux/releases/download/v${pkgver}/limux-${pkgver}-linux-x86_64.tar.gz")
+sha256sums=('@@SHA256@@')
+
+package() {
+    cd "limux-${pkgver}-linux-x86_64"
+
+    install -Dm755 limux "${pkgdir}/usr/bin/limux"
+    install -Dm755 lib/libghostty.so "${pkgdir}/usr/lib/libghostty.so"
+    install -Dm644 share/applications/limux.desktop "${pkgdir}/usr/share/applications/limux.desktop"
+
+    for size in 16x16 32x32 128x128 256x256 512x512; do
+        install -Dm644 "share/icons/hicolor/${size}/apps/limux.png" \
+            "${pkgdir}/usr/share/icons/hicolor/${size}/apps/limux.png"
+    done
+
+    find share/icons/hicolor/scalable -type f -name '*.svg' -exec \
+        install -Dm644 {} "${pkgdir}/usr/{}" \;
+
+    cp -r share/limux "${pkgdir}/usr/share/limux"
+}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes to AUR when a release is created.

- Triggers on `release: published` or manual `workflow_dispatch`
- Downloads the release tarball, computes sha256, generates PKGBUILD from template
- Pushes to AUR via a dedicated co-maintainer bot account (`limux-aurbot`)

### Setup required
Add `AUR_SSH_PRIVATE_KEY` as a repository secret. Email me at anton@barchukov.com and I'll send a Bitwarden link with the key. Please confirm in this thread after emailing so I can verify it's you.

Ref #5