### PR TITLE
feat: add drag-and-drop file support for terminal

### DIFF
--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -736,8 +736,10 @@ pub fn create_terminal(
     // shell-escaped paths into the terminal.
     {
         let surface_cell = surface_cell.clone();
-        let drop_target =
-            gtk::DropTarget::new(gtk::gdk::FileList::static_type(), gtk::gdk::DragAction::COPY);
+        let drop_target = gtk::DropTarget::new(
+            gtk::gdk::FileList::static_type(),
+            gtk::gdk::DragAction::COPY,
+        );
         drop_target.connect_drop(move |_target, value, _x, _y| {
             let Some(surface) = *surface_cell.borrow() else {
                 return false;
@@ -1094,9 +1096,9 @@ fn show_clipboard_toast(overlay: &gtk::Overlay) {
 
 /// Shell-escape a path so it can be safely pasted into a terminal.
 fn shell_escape(s: &str) -> String {
-    if s.bytes().all(|b| {
-        b.is_ascii_alphanumeric() || b == b'/' || b == b'.' || b == b'-' || b == b'_'
-    }) {
+    if s.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'.' || b == b'-' || b == b'_')
+    {
         return s.to_string();
     }
     format!("'{}'", s.replace('\'', "'\\''"))


### PR DESCRIPTION
## Summary

- Add a GTK `DropTarget` on the terminal `GLArea` that accepts `gdk::FileList` from file managers
- Dropped file paths are shell-escaped and pasted into the terminal via `ghostty_surface_text()`
- Paths with spaces or special characters are safely wrapped in single quotes

This enables dragging files (images, documents, etc.) from Nautilus/Thunar/etc. directly into the terminal, useful for CLI tools like Claude Code that accept file paths as input.

## Test plan

- [ ] CI passes (cargo fmt, clippy, tests)
- [ ] Drag a single file from a file manager → path appears in terminal
- [ ] Drag a file with spaces in its name → path is properly quoted
- [ ] Drag multiple files → space-separated paths appear
- [ ] Drag an image file → file path (not image data) is inserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)