### PR TITLE
Add browser action to terminal context menu

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -149,6 +149,7 @@ type PaneSignalCallback = dyn Fn();
 type PanePathCallback = dyn Fn(&str);
 type PaneDesktopNotificationCallback = dyn Fn(&str, &str);
 type PaneEmptyCallback = dyn Fn(&gtk::Widget, PaneEmptyReason);
+type PaneOpenBrowserHereCallback = dyn Fn(&gtk::Widget);
 type PaneShortcutStateCallback = dyn Fn() -> Rc<ResolvedShortcutConfig>;
 type PaneShortcutCaptureCallback =
     dyn Fn(ShortcutId, Option<NormalizedShortcut>) -> Result<ResolvedShortcutConfig, String>;
@@ -159,6 +160,7 @@ pub struct PaneCallbacks {
     pub on_close_pane: Box<PaneWidgetCallback>,
     pub on_bell: Box<PaneSignalCallback>,
     pub on_desktop_notification: Box<PaneDesktopNotificationCallback>,
+    pub on_open_browser_here: Box<PaneOpenBrowserHereCallback>,
     pub on_open_keybinds: Box<PaneWidgetCallback>,
     pub current_shortcuts: Box<PaneShortcutStateCallback>,
     pub on_capture_shortcut: Rc<PaneShortcutCaptureCallback>,
@@ -799,6 +801,7 @@ fn make_terminal_callbacks(
     let callbacks_for_bell = internals.callbacks.clone();
     let callbacks_for_pwd = internals.callbacks.clone();
     let callbacks_for_close = internals.callbacks.clone();
+    let callbacks_for_browser_here = internals.callbacks.clone();
     let callbacks_for_split_right = internals.callbacks.clone();
     let callbacks_for_split_down = internals.callbacks.clone();
     let callbacks_for_keybinds = internals.callbacks.clone();
@@ -858,6 +861,13 @@ fn make_terminal_callbacks(
                     PaneEmptyReason::ClosedLastTab,
                 );
             });
+        }),
+        on_open_browser_here: Box::new({
+            let pane_outer = internals.pane_outer.clone();
+            move || {
+                let pane_widget: gtk::Widget = pane_outer.clone().upcast();
+                (callbacks_for_browser_here.on_open_browser_here)(&pane_widget);
+            }
         }),
         on_split_right: Box::new({
             let pane_outer = internals.pane_outer.clone();

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -513,6 +513,7 @@ pub struct TerminalCallbacks {
     pub on_desktop_notification: Box<DesktopNotificationCallback>,
     pub on_bell: Box<VoidCallback>,
     pub on_close: Box<VoidCallback>,
+    pub on_open_browser_here: Box<VoidCallback>,
     pub on_split_right: Box<VoidCallback>,
     pub on_split_down: Box<VoidCallback>,
     pub on_open_keybinds: Box<WidgetCallback>,
@@ -1039,6 +1040,7 @@ fn show_terminal_context_menu(
         ("Copy", has_selection),
         ("Paste", true),
         ("---", false),
+        ("Browser", true),
         ("Split Right", true),
         ("Split Down", true),
         ("Keybinds", true),
@@ -1085,6 +1087,10 @@ fn show_terminal_context_menu(
                 match label.as_str() {
                     "Copy" => surface_action(surface, "copy_to_clipboard"),
                     "Paste" => surface_action(surface, "paste_from_clipboard"),
+                    "Browser" => {
+                        let callbacks = cb.borrow();
+                        (callbacks.on_open_browser_here)();
+                    }
                     "Split Right" => {
                         let callbacks = cb.borrow();
                         (callbacks.on_split_right)();

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -2400,6 +2400,9 @@ fn create_pane_for_workspace(
                 mark_workspace_unread_with_message(&state, &ws_id, &message);
             });
         }),
+        on_open_browser_here: Box::new(move |pane_widget| {
+            pane::add_browser_tab_to_pane(pane_widget);
+        }),
         on_open_keybinds: Box::new(move |anchor| {
             open_keybind_editor_tab(&state_for_keybinds, anchor);
         }),


### PR DESCRIPTION
## Summary

Add a terminal context-menu action to open a browser in the current pane.

This makes the browser action easier to discover from terminal-focused workflows without changing split semantics.

https://github.com/user-attachments/assets/12d8b593-12f6-4bdc-ba1a-d2d42e286325

## Changes

- add `Browser` to the terminal right-click menu
- wire the new menu item to the existing current-pane browser-tab path
- keep behavior simple: it opens a browser tab in the currently clicked pane

## Why

Limux already had:

- split actions in the terminal context menu
- a browser button in the pane header

But there was no terminal context-menu entry for opening a browser directly in the active pane. This adds that missing affordance.

## Validation

- `cargo check -p limux-host-linux`