### PR TITLE
Fix Alt key triggering search in GTK4 SearchBar

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2701,7 +2701,6 @@ fn create_browser_widget(
     search_bar.set_show_close_button(true);
     search_bar.connect_entry(&search_entry);
     search_bar.set_child(Some(&search_entry));
-    search_bar.set_key_capture_widget(Some(&webview));
     {
         let search_bar = search_bar.clone();
         let find_controller = find_controller.clone();

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -616,7 +616,6 @@ pub fn create_terminal(
     search_bar.set_show_close_button(true);
     search_bar.connect_entry(&search_entry);
     search_bar.set_child(Some(&search_entry));
-    search_bar.set_key_capture_widget(Some(&gl_area));
     search_bar.set_valign(gtk::Align::Start);
     search_bar.set_halign(gtk::Align::Fill);
     search_bar.set_margin_top(8);


### PR DESCRIPTION
GTK4 SearchBar's set_key_capture_widget() intercepts all key events from the target widget, causing modifier-only keys like Alt (used for Korean/English input switching) to activate search mode unintentionally. Remove set_key_capture_widget() calls in both terminal and browser panes. Search is still accessible via the existing Ctrl+F shortcut (show_find).