### PR TITLE
fix: handle localhost URLs in browser pane

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2659,16 +2659,7 @@ fn create_browser_widget(
     {
         let wv = webview.clone();
         url_entry.connect_activate(move |entry| {
-            let mut url = entry.text().to_string();
-            if !url.starts_with("http://") && !url.starts_with("https://") {
-                if url.starts_with("localhost") {
-                    url = format!("http://{url}");
-                } else if url.contains('.') {
-                    url = format!("https://{url}");
-                } else {
-                    url = format!("https://www.google.com/search?q={}", url.replace(' ', "+"));
-                }
-            }
+            let url = normalize_browser_entry_input(&entry.text());
             wv.load_uri(&url);
         });
     }
@@ -2770,6 +2761,31 @@ fn create_browser_widget(
     (vbox.upcast(), "Browser".to_string(), browser_handles)
 }
 
+fn normalize_browser_entry_input(input: &str) -> String {
+    if input.starts_with("http://") || input.starts_with("https://") {
+        return input.to_string();
+    }
+
+    if is_localhost_input(input) {
+        format!("http://{input}")
+    } else if input.contains('.') {
+        format!("https://{input}")
+    } else {
+        format!(
+            "https://www.google.com/search?q={}",
+            input.replace(' ', "+")
+        )
+    }
+}
+
+fn is_localhost_input(input: &str) -> bool {
+    input == "localhost"
+        || input
+            .strip_prefix("localhost")
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|ch| matches!(ch, ':' | '/' | '?' | '#'))
+}
+
 #[cfg(not(feature = "webkit"))]
 fn create_browser_widget(
     initial_uri: Option<&str>,
@@ -2809,8 +2825,8 @@ fn create_browser_widget(
 mod tests {
     use super::{
         classify_content_drop_zone, content_drop_preview_rect, effective_drop_target_dimensions,
-        next_active_after_tab_removal, normalize_reorder_insert_index, pane_action_tooltip,
-        ContentDropZone, TabDragPayload,
+        is_localhost_input, next_active_after_tab_removal, normalize_browser_entry_input,
+        normalize_reorder_insert_index, pane_action_tooltip, ContentDropZone, TabDragPayload,
     };
     use crate::shortcut_config::{default_shortcuts, resolve_shortcuts_from_str, ShortcutId};
 
@@ -2977,5 +2993,54 @@ mod tests {
             Some((320.0, 180.0))
         );
         assert_eq!(effective_drop_target_dimensions(0, 0, 0, 180), None);
+    }
+
+    #[test]
+    fn localhost_inputs_only_match_real_localhost_hosts() {
+        for input in [
+            "localhost",
+            "localhost:3000",
+            "localhost/path",
+            "localhost?q=1",
+        ] {
+            assert!(is_localhost_input(input), "{input} should be localhost");
+        }
+
+        for input in [
+            "localhost.run",
+            "localhost.example.com",
+            "localhost docs",
+            "mylocalhost:3000",
+        ] {
+            assert!(
+                !is_localhost_input(input),
+                "{input} should not be treated as localhost"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_browser_entry_input_preserves_search_and_domain_behavior() {
+        let cases = [
+            ("https://example.com", "https://example.com"),
+            ("localhost", "http://localhost"),
+            ("localhost:3000", "http://localhost:3000"),
+            ("localhost/path", "http://localhost/path"),
+            ("localhost.run", "https://localhost.run"),
+            ("localhost.example.com", "https://localhost.example.com"),
+            (
+                "localhost docs",
+                "https://www.google.com/search?q=localhost+docs",
+            ),
+            ("example.com", "https://example.com"),
+            (
+                "example search",
+                "https://www.google.com/search?q=example+search",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(normalize_browser_entry_input(input), expected, "{input}");
+        }
     }
 }


### PR DESCRIPTION
Treat localhost URLs (e.g. localhost:3000) as http:// by default, rather than treating them as search queries.

This fixes the issue where entering `localhost:3000` in the browser URL bar would be treated as a search query (no dot detected).