### PR TITLE
Support Ghostty background opacity

### DIFF
--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -369,6 +369,12 @@ extern "C" {
     pub fn ghostty_config_load_default_files(config: ghostty_config_t);
     pub fn ghostty_config_load_recursive_files(config: ghostty_config_t);
     pub fn ghostty_config_finalize(config: ghostty_config_t);
+    pub fn ghostty_config_get(
+        config: ghostty_config_t,
+        out: *mut c_void,
+        key: *const c_char,
+        key_len: usize,
+    ) -> bool;
 
     // App
     pub fn ghostty_app_new(

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -21,6 +21,7 @@ use limux_ghostty_sys::*;
 
 struct GhosttyState {
     app: ghostty_app_t,
+    background_opacity: f64,
 }
 
 // Safety: ghostty_app_t is thread-safe for the operations we perform
@@ -183,6 +184,7 @@ pub fn init_ghostty() {
             ghostty_config_finalize(c);
             c
         };
+        let background_opacity = load_background_opacity(config);
 
         let runtime_config = ghostty_runtime_config_s {
             userdata: ptr::null_mut(),
@@ -208,12 +210,42 @@ pub fn init_ghostty() {
             glib::ControlFlow::Continue
         });
 
-        GhosttyState { app }
+        GhosttyState {
+            app,
+            background_opacity,
+        }
     });
 }
 
 fn ghostty_app() -> ghostty_app_t {
     GHOSTTY.get().expect("ghostty not initialized").app
+}
+
+pub fn ghostty_background_opacity() -> f64 {
+    init_ghostty();
+    GHOSTTY
+        .get()
+        .map(|state| state.background_opacity)
+        .unwrap_or(1.0)
+}
+
+fn load_background_opacity(config: ghostty_config_t) -> f64 {
+    let mut opacity = 1.0_f64;
+    let key = b"background-opacity";
+    let loaded = unsafe {
+        ghostty_config_get(
+            config,
+            (&mut opacity as *mut f64).cast::<c_void>(),
+            key.as_ptr().cast::<c_char>(),
+            key.len(),
+        )
+    };
+
+    if loaded && opacity.is_finite() {
+        opacity.clamp(0.0, 1.0)
+    } else {
+        1.0
+    }
 }
 
 fn ghostty_color_scheme_for_dark_mode(dark: bool) -> c_int {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -484,7 +484,7 @@ fn attach_split_position_persistence(state: &State, paned: &gtk::Paned) {
 // CSS
 // ---------------------------------------------------------------------------
 
-const CSS: &str = r#"
+const BASE_CSS: &str = r#"
 .limux-sidebar {
     background-color: rgba(25, 25, 25, 1);
 }
@@ -618,6 +618,8 @@ row:selected .limux-ws-path {
 }
 "#;
 
+const CONTENT_BACKGROUND_RGB: (u8, u8, u8) = (23, 23, 23);
+
 // ---------------------------------------------------------------------------
 // Window construction
 // ---------------------------------------------------------------------------
@@ -629,6 +631,8 @@ pub fn build_window(app: &adw::Application) {
         eprintln!("limux: {warning}");
     }
     let config = Rc::new(loaded_config.config);
+    let background_opacity =
+        sanitize_background_opacity(crate::terminal::ghostty_background_opacity());
 
     let shortcuts = Rc::new(shortcut_config::load_shortcuts_for_display(&display));
     for warning in &shortcuts.warnings {
@@ -638,7 +642,8 @@ pub fn build_window(app: &adw::Application) {
     // Load CSS
     let provider = gtk::CssProvider::new();
     let all_css = format!(
-        "{CSS}\n{}\n{}",
+        "{}\n{}\n{}",
+        build_window_css(background_opacity),
         pane::PANE_CSS,
         keybind_editor::KEYBIND_EDITOR_CSS
     );
@@ -686,6 +691,7 @@ pub fn build_window(app: &adw::Application) {
         .default_width(1400)
         .default_height(900)
         .build();
+    apply_window_background_class(&window, background_opacity);
 
     // On Wayland compositors with xdg-decoration support, the compositor
     // already provides the window chrome, so keep Limux from rendering a
@@ -952,6 +958,34 @@ pub fn build_window(app: &adw::Application) {
 
     apply_loaded_session(&state, layout_state::load_session());
     window.present();
+}
+
+fn build_window_css(background_opacity: f64) -> String {
+    let background_opacity = sanitize_background_opacity(background_opacity);
+    let (r, g, b) = CONTENT_BACKGROUND_RGB;
+    format!(
+        "{BASE_CSS}\n.limux-content {{\n    background-color: rgba({r}, {g}, {b}, {background_opacity:.3});\n}}\n"
+    )
+}
+
+fn sanitize_background_opacity(background_opacity: f64) -> f64 {
+    if background_opacity.is_finite() {
+        background_opacity.clamp(0.0, 1.0)
+    } else {
+        1.0
+    }
+}
+
+fn use_opaque_window_background(background_opacity: f64) -> bool {
+    sanitize_background_opacity(background_opacity) >= 1.0
+}
+
+fn apply_window_background_class(window: &adw::ApplicationWindow, background_opacity: f64) {
+    if use_opaque_window_background(background_opacity) {
+        window.add_css_class("background");
+    } else {
+        window.remove_css_class("background");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3321,10 +3355,13 @@ mod tests {
     use super::glib;
     use super::gtk::gdk;
     use super::{
+        build_window_css,
         clamp_workspace_insert_index_for_pinning, favorites_prefix_len,
         next_active_workspace_index, queue_session_save_request,
+        sanitize_background_opacity,
         shortcut_allowed_while_browser_find_active, shortcut_blocked_by_editable,
         shortcut_command_from_key_event, shortcut_dispatch_propagation, tab_drag_workspace_seed,
+        use_opaque_window_background,
         workspace_drop_layout_path, workspace_notification_message, EditableCaptureContext,
         SessionSaveAccess, SessionSaveRequest, WorkspaceSeedSource,
     };
@@ -3357,6 +3394,29 @@ mod tests {
     fn favorites_prefix_len_counts_only_leading_favorites() {
         let flags = [true, true, false, true, false];
         assert_eq!(favorites_prefix_len(&flags), 2);
+    }
+
+    #[test]
+    fn sanitize_background_opacity_clamps_invalid_values() {
+        assert_eq!(sanitize_background_opacity(f64::NAN), 1.0);
+        assert_eq!(sanitize_background_opacity(-0.2), 0.0);
+        assert_eq!(sanitize_background_opacity(1.7), 1.0);
+        assert_eq!(sanitize_background_opacity(0.42), 0.42);
+    }
+
+    #[test]
+    fn transparent_window_background_only_applies_below_full_opacity() {
+        assert!(!use_opaque_window_background(0.8));
+        assert!(use_opaque_window_background(1.0));
+        assert!(use_opaque_window_background(5.0));
+        assert!(use_opaque_window_background(f64::NAN));
+    }
+
+    #[test]
+    fn build_window_css_uses_resolved_background_opacity() {
+        let css = build_window_css(0.42);
+        assert!(css.contains(".limux-content"));
+        assert!(css.contains("background-color: rgba(23, 23, 23, 0.420);"));
     }
 
     #[test]


### PR DESCRIPTION
Read background-opacity from the loaded Ghostty config and mirror Ghostty's GTK window background behavior in Limux.

Add host-side regression coverage for the opacity sanitization and CSS rendering helpers.