### PR TITLE
Persist zoom level across sessions

### DIFF
--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -406,6 +406,7 @@ extern "C" {
     pub fn ghostty_surface_set_focus(surface: ghostty_surface_t, focused: bool);
     pub fn ghostty_surface_set_size(surface: ghostty_surface_t, width: u32, height: u32);
     pub fn ghostty_surface_size(surface: ghostty_surface_t) -> ghostty_surface_size_s;
+    pub fn ghostty_surface_font_size(surface: ghostty_surface_t) -> f32;
     pub fn ghostty_surface_key(surface: ghostty_surface_t, event: ghostty_input_key_s) -> bool;
     pub fn ghostty_surface_text(surface: ghostty_surface_t, text: *const c_char, len: usize);
     pub fn ghostty_surface_preedit(surface: ghostty_surface_t, text: *const c_char, len: usize);

--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -36,12 +36,14 @@ impl ColorScheme {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
     pub focus: FocusConfig,
     #[serde(skip)]
     pub appearance: AppearanceConfig,
+    #[serde(skip)]
+    pub font_size: Option<f32>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -56,7 +58,7 @@ pub struct FocusConfig {
     pub hover_terminal_focus: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct LoadedAppConfig {
     pub config: AppConfig,
     pub warnings: Vec<String>,
@@ -147,6 +149,12 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .and_then(ColorScheme::from_str)
         .unwrap_or(color_scheme);
 
+    let font_size = root
+        .get("font_size")
+        .and_then(Value::as_f64)
+        .map(|v| v as f32)
+        .filter(|&v| v >= 1.0 && v <= 255.0);
+
     AppConfig {
         focus: FocusConfig {
             hover_terminal_focus,
@@ -155,6 +163,7 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
             color_scheme,
             ghostty_color_scheme,
         },
+        font_size,
     }
 }
 
@@ -182,9 +191,31 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
         json!({ "hover_terminal_focus": config.focus.hover_terminal_focus }),
     );
 
+    if let Some(size) = config.font_size {
+        root.insert("font_size".to_string(), json!(size));
+    } else {
+        root.remove("font_size");
+    }
+
     let serialized =
         serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
     write_config_root_atomically(path, &serialized)
+}
+
+pub fn save_font_size(font_size: f32) -> Result<(), String> {
+    let Some(path) = settings_path() else {
+        return Err("config_dir unavailable; cannot save font size".to_string());
+    };
+
+    let mut root = read_existing_config_root_for_save(&path)
+        .map_err(|err| format!("failed to save font size to `{}`: {err}", path.display()))?;
+
+    root.insert("font_size".to_string(), json!(font_size));
+
+    let serialized =
+        serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
+    write_config_root_atomically(&path, &serialized)
+        .map_err(|err| format!("failed to save font size to `{}`: {err}", path.display()))
 }
 
 fn read_existing_config_root_for_save(

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -202,6 +202,10 @@ impl TerminalShortcutTarget {
         self.handle.perform_binding_action(action)
     }
 
+    pub fn font_size(&self) -> Option<f32> {
+        self.handle.font_size()
+    }
+
     pub fn show_find(&self) -> bool {
         self.handle.show_find()
     }
@@ -1030,7 +1034,10 @@ fn add_terminal_tab_inner(
 
     let term = terminal::create_terminal(
         working_directory,
-        terminal::TerminalOptions { hover_focus },
+        terminal::TerminalOptions {
+            hover_focus,
+            saved_font_size: (internals.callbacks.current_config)().borrow().font_size,
+        },
         term_callbacks,
     );
     let widget: gtk::Widget = term.overlay.clone().upcast();

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -165,6 +165,11 @@ impl TerminalHandle {
         surface.is_some()
     }
 
+    pub fn font_size(&self) -> Option<f32> {
+        let surface = (*self.surface_cell.borrow())?;
+        Some(unsafe { ghostty_surface_font_size(surface) })
+    }
+
     /// Inject text into the terminal surface for control-socket requests and
     /// drag/drop payloads. Ghostty treats this as pasted text, which matches
     /// the current control protocol semantics.
@@ -810,6 +815,7 @@ pub struct TerminalCallbacks {
 
 pub struct TerminalOptions {
     pub hover_focus: Rc<dyn Fn() -> bool>,
+    pub saved_font_size: Option<f32>,
 }
 
 /// Create a new Ghostty-powered terminal widget.
@@ -833,6 +839,7 @@ pub fn create_terminal(
     });
 
     let wd = working_directory.map(|s| s.to_string());
+    let saved_font_size = options.saved_font_size;
     let hover_focus = options.hover_focus;
     let callbacks = Rc::new(RefCell::new(callbacks));
     let surface_cell: Rc<RefCell<Option<ghostty_surface_t>>> = Rc::new(RefCell::new(None));
@@ -965,6 +972,10 @@ pub fn create_terminal(
             let scale = gl_area.scale_factor() as f64;
             config.scale_factor = scale;
             config.context = GHOSTTY_SURFACE_CONTEXT_WINDOW;
+
+            if let Some(size) = saved_font_size {
+                config.font_size = size;
+            }
 
             let c_wd = wd.as_ref().and_then(|s| CString::new(s.as_str()).ok());
             if let Some(ref cwd) = c_wd {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3758,13 +3758,29 @@ fn dispatch_terminal_command(state: &State, command: ShortcutCommand) -> bool {
         ShortcutCommand::TerminalCopy => target.perform_binding_action("copy_to_clipboard"),
         ShortcutCommand::TerminalPaste => target.perform_binding_action("paste_from_clipboard"),
         ShortcutCommand::TerminalIncreaseFontSize => {
-            target.perform_binding_action("increase_font_size:1")
+            let ok = target.perform_binding_action("increase_font_size:1");
+            persist_font_size(&target);
+            ok
         }
         ShortcutCommand::TerminalDecreaseFontSize => {
-            target.perform_binding_action("decrease_font_size:1")
+            let ok = target.perform_binding_action("decrease_font_size:1");
+            persist_font_size(&target);
+            ok
         }
-        ShortcutCommand::TerminalResetFontSize => target.perform_binding_action("reset_font_size"),
+        ShortcutCommand::TerminalResetFontSize => {
+            let ok = target.perform_binding_action("reset_font_size");
+            persist_font_size(&target);
+            ok
+        }
         _ => false,
+    }
+}
+
+fn persist_font_size(terminal: &pane::TerminalShortcutTarget) {
+    if let Some(size) = terminal.font_size() {
+        if let Err(err) = app_config::save_font_size(size) {
+            eprintln!("limux: {err}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Save font size to `~/.config/limux/settings.json` when user zooms (Ctrl+/-, Ctrl+Shift+0)
- Restore saved font size when creating new terminal surfaces
- Reads default font size from ghostty config, tracks deltas on the Rust side (no ghostty submodule changes)