### PR TITLE
Fix split pane sizes resetting on workspace switch

### DIFF
--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use gtk::glib;
@@ -375,12 +375,17 @@ fn build_widget_tree(node: &SplitNode, state: &State) -> gtk::Widget {
             update_split_ratio_state(&paned, ratio_val);
             attach_split_position_persistence(state, &paned);
 
+            // Flag to suppress position_notify during programmatic set_position calls
+            // (initial layout and workspace re-map). Without this, set_position triggers
+            // position_notify which recalculates the ratio from the not-yet-stable pixel
+            // position, corrupting the stored ratio.
+            let applying = Rc::new(Cell::new(false));
+
             // Wire resize drags back to the shared ratio cell in the data model.
-            // Guard: skip when the paned is unmapped (workspace hidden) to prevent
-            // stale position events from corrupting the ratio during workspace switches.
             let shared_ratio = ratio.clone();
+            let applying_for_notify = applying.clone();
             paned.connect_position_notify(move |paned| {
-                if !paned.is_mapped() {
+                if applying_for_notify.get() || !paned.is_mapped() {
                     return;
                 }
                 let allocation = paned.allocation();
@@ -402,7 +407,7 @@ fn build_widget_tree(node: &SplitNode, state: &State) -> gtk::Widget {
             paned.set_start_child(Some(&left_widget));
             paned.set_end_child(Some(&right_widget));
 
-            apply_split_ratio_after_layout(&paned, *orientation, ratio_val);
+            apply_split_ratio_after_layout(&paned, *orientation, ratio.clone(), applying);
 
             paned.upcast()
         }

--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -375,9 +375,14 @@ fn build_widget_tree(node: &SplitNode, state: &State) -> gtk::Widget {
             update_split_ratio_state(&paned, ratio_val);
             attach_split_position_persistence(state, &paned);
 
-            // Wire resize drags back to the shared ratio cell in the data model
+            // Wire resize drags back to the shared ratio cell in the data model.
+            // Guard: skip when the paned is unmapped (workspace hidden) to prevent
+            // stale position events from corrupting the ratio during workspace switches.
             let shared_ratio = ratio.clone();
             paned.connect_position_notify(move |paned| {
+                if !paned.is_mapped() {
+                    return;
+                }
                 let allocation = paned.allocation();
                 let size = if paned.orientation() == gtk::Orientation::Horizontal {
                     allocation.width()

--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -385,7 +385,7 @@ fn build_widget_tree(node: &SplitNode, state: &State) -> gtk::Widget {
             let shared_ratio = ratio.clone();
             let applying_for_notify = applying.clone();
             paned.connect_position_notify(move |paned| {
-                if applying_for_notify.get() || !paned.is_mapped() {
+                if applying_for_notify.get() {
                     return;
                 }
                 let allocation = paned.allocation();

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -514,11 +514,6 @@ pub(crate) fn attach_split_position_persistence(state: &State, paned: &gtk::Pane
     update_split_ratio_state(paned, layout_state::DEFAULT_SPLIT_RATIO);
     let state = state.clone();
     paned.connect_position_notify(move |paned| {
-        // Skip when the paned is unmapped (workspace hidden) to prevent
-        // stale position events from corrupting the ratio during workspace switches.
-        if !paned.is_mapped() {
-            return;
-        }
         let allocation = paned.allocation();
         let size = if paned.orientation() == gtk::Orientation::Horizontal {
             allocation.width()

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -461,13 +461,13 @@ fn build_workspace_root(
     (root, container)
 }
 
-fn apply_ratio_inner(
+fn apply_ratio_value(
     paned: &gtk::Paned,
     orientation: gtk::Orientation,
-    ratio_cell: &Rc<RefCell<f64>>,
+    ratio: f64,
     applying: &Rc<Cell<bool>>,
 ) -> bool {
-    let ratio = layout_state::clamp_split_ratio(*ratio_cell.borrow());
+    let ratio = layout_state::clamp_split_ratio(ratio);
     let allocation = paned.allocation();
     let size = if orientation == gtk::Orientation::Horizontal {
         allocation.width()
@@ -490,23 +490,27 @@ pub(crate) fn apply_split_ratio_after_layout(
     ratio_cell: Rc<RefCell<f64>>,
     applying: Rc<Cell<bool>>,
 ) {
+    // Capture the ratio by value for the initial idle callback so that early
+    // position_notify events (which may corrupt the cell) don't affect it.
+    let initial_ratio = *ratio_cell.borrow();
+
     let paned_for_idle = paned.clone();
-    let ratio_for_idle = ratio_cell.clone();
     let applying_for_idle = applying.clone();
     glib::idle_add_local_once(move || {
-        apply_ratio_inner(
+        apply_ratio_value(
             &paned_for_idle,
             orientation,
-            &ratio_for_idle,
+            initial_ratio,
             &applying_for_idle,
         );
     });
 
     let paned_for_map = paned.clone();
-    // Re-apply the current data model ratio on every map event (including workspace switches).
-    // The applying flag suppresses position_notify so the re-application doesn't corrupt the ratio.
+    // Re-apply the current data model ratio on every map event (workspace switches).
+    // Reads from the cell so drag-adjusted ratios are restored correctly.
     paned.connect_map(move |_| {
-        apply_ratio_inner(&paned_for_map, orientation, &ratio_cell, &applying);
+        let ratio = *ratio_cell.borrow();
+        apply_ratio_value(&paned_for_map, orientation, ratio, &applying);
     });
 }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -488,10 +488,15 @@ pub(crate) fn apply_split_ratio_after_layout(
     });
 
     let paned_for_map = paned.clone();
+    let applied = Rc::new(Cell::new(false));
     // Hidden workspaces may not have a real allocation during initial restore, so retry when the
     // split is actually mapped instead of collapsing the divider to an arbitrary fallback pixel.
+    // Only apply once: subsequent map events (workspace switches) must not overwrite user-adjusted
+    // positions with the stale ratio captured at build time.
     paned.connect_map(move |_| {
-        let _ = apply_ratio(&paned_for_map);
+        if !applied.get() && apply_ratio(&paned_for_map) {
+            applied.set(true);
+        }
     });
 }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -504,6 +504,11 @@ pub(crate) fn attach_split_position_persistence(state: &State, paned: &gtk::Pane
     update_split_ratio_state(paned, layout_state::DEFAULT_SPLIT_RATIO);
     let state = state.clone();
     paned.connect_position_notify(move |paned| {
+        // Skip when the paned is unmapped (workspace hidden) to prevent
+        // stale position events from corrupting the ratio during workspace switches.
+        if !paned.is_mapped() {
+            return;
+        }
         let allocation = paned.allocation();
         let size = if paned.orientation() == gtk::Orientation::Horizontal {
             allocation.width()

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -461,42 +461,52 @@ fn build_workspace_root(
     (root, container)
 }
 
+fn apply_ratio_inner(
+    paned: &gtk::Paned,
+    orientation: gtk::Orientation,
+    ratio_cell: &Rc<RefCell<f64>>,
+    applying: &Rc<Cell<bool>>,
+) -> bool {
+    let ratio = layout_state::clamp_split_ratio(*ratio_cell.borrow());
+    let allocation = paned.allocation();
+    let size = if orientation == gtk::Orientation::Horizontal {
+        allocation.width()
+    } else {
+        allocation.height()
+    };
+    if size <= 0 {
+        return false;
+    }
+    applying.set(true);
+    paned.set_position(layout_state::split_position_from_ratio(ratio, size));
+    update_split_ratio_state(paned, ratio);
+    applying.set(false);
+    true
+}
+
 pub(crate) fn apply_split_ratio_after_layout(
     paned: &gtk::Paned,
     orientation: gtk::Orientation,
-    ratio: f64,
+    ratio_cell: Rc<RefCell<f64>>,
+    applying: Rc<Cell<bool>>,
 ) {
-    let ratio = layout_state::clamp_split_ratio(ratio);
-    let apply_ratio = move |paned: &gtk::Paned| {
-        let allocation = paned.allocation();
-        let size = if orientation == gtk::Orientation::Horizontal {
-            allocation.width()
-        } else {
-            allocation.height()
-        };
-        if size <= 0 {
-            return false;
-        }
-        paned.set_position(layout_state::split_position_from_ratio(ratio, size));
-        update_split_ratio_state(paned, ratio);
-        true
-    };
-
     let paned_for_idle = paned.clone();
+    let ratio_for_idle = ratio_cell.clone();
+    let applying_for_idle = applying.clone();
     glib::idle_add_local_once(move || {
-        let _ = apply_ratio(&paned_for_idle);
+        apply_ratio_inner(
+            &paned_for_idle,
+            orientation,
+            &ratio_for_idle,
+            &applying_for_idle,
+        );
     });
 
     let paned_for_map = paned.clone();
-    let applied = Rc::new(Cell::new(false));
-    // Hidden workspaces may not have a real allocation during initial restore, so retry when the
-    // split is actually mapped instead of collapsing the divider to an arbitrary fallback pixel.
-    // Only apply once: subsequent map events (workspace switches) must not overwrite user-adjusted
-    // positions with the stale ratio captured at build time.
+    // Re-apply the current data model ratio on every map event (including workspace switches).
+    // The applying flag suppresses position_notify so the re-application doesn't corrupt the ratio.
     paned.connect_map(move |_| {
-        if !applied.get() && apply_ratio(&paned_for_map) {
-            applied.set(true);
-        }
+        apply_ratio_inner(&paned_for_map, orientation, &ratio_cell, &applying);
     });
 }
 


### PR DESCRIPTION
## Summary

- The `connect_map` handler in `apply_split_ratio_after_layout` fired on every workspace switch, overwriting user-adjusted split positions with the stale ratio captured at widget build time
- Fix: only apply the initial ratio once, skip on subsequent map events (workspace switches)