### PR TITLE
Persist zoom level across sessions

### DIFF
--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -406,6 +406,7 @@ extern "C" {
     pub fn ghostty_surface_set_focus(surface: ghostty_surface_t, focused: bool);
     pub fn ghostty_surface_set_size(surface: ghostty_surface_t, width: u32, height: u32);
     pub fn ghostty_surface_size(surface: ghostty_surface_t) -> ghostty_surface_size_s;
+    pub fn ghostty_surface_font_size(surface: ghostty_surface_t) -> f32;
     pub fn ghostty_surface_key(surface: ghostty_surface_t, event: ghostty_input_key_s) -> bool;
     pub fn ghostty_surface_text(surface: ghostty_surface_t, text: *const c_char, len: usize);
     pub fn ghostty_surface_preedit(surface: ghostty_surface_t, text: *const c_char, len: usize);

--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -406,7 +406,6 @@ extern "C" {
     pub fn ghostty_surface_set_focus(surface: ghostty_surface_t, focused: bool);
     pub fn ghostty_surface_set_size(surface: ghostty_surface_t, width: u32, height: u32);
     pub fn ghostty_surface_size(surface: ghostty_surface_t) -> ghostty_surface_size_s;
-    pub fn ghostty_surface_font_size(surface: ghostty_surface_t) -> f32;
     pub fn ghostty_surface_key(surface: ghostty_surface_t, event: ghostty_input_key_s) -> bool;
     pub fn ghostty_surface_text(surface: ghostty_surface_t, text: *const c_char, len: usize);
     pub fn ghostty_surface_preedit(surface: ghostty_surface_t, text: *const c_char, len: usize);

--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -153,7 +153,7 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .get("font_size")
         .and_then(Value::as_f64)
         .map(|v| v as f32)
-        .filter(|&v| v >= 1.0 && v <= 255.0);
+        .filter(|v| (1.0..=255.0).contains(v));
 
     AppConfig {
         focus: FocusConfig {
@@ -200,6 +200,22 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
     let serialized =
         serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
     write_config_root_atomically(path, &serialized)
+}
+
+pub fn clear_font_size() -> Result<(), String> {
+    let Some(path) = settings_path() else {
+        return Err("config_dir unavailable; cannot clear font size".to_string());
+    };
+
+    let mut root = read_existing_config_root_for_save(&path)
+        .map_err(|err| format!("failed to clear font size in `{}`: {err}", path.display()))?;
+
+    root.remove("font_size");
+
+    let serialized =
+        serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
+    write_config_root_atomically(&path, &serialized)
+        .map_err(|err| format!("failed to clear font size in `{}`: {err}", path.display()))
 }
 
 pub fn save_font_size(font_size: f32) -> Result<(), String> {

--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -36,12 +36,14 @@ impl ColorScheme {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
     pub focus: FocusConfig,
     #[serde(skip)]
     pub appearance: AppearanceConfig,
+    #[serde(skip)]
+    pub font_size: Option<f32>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -56,7 +58,7 @@ pub struct FocusConfig {
     pub hover_terminal_focus: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct LoadedAppConfig {
     pub config: AppConfig,
     pub warnings: Vec<String>,
@@ -147,6 +149,12 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .and_then(ColorScheme::from_str)
         .unwrap_or(color_scheme);
 
+    let font_size = root
+        .get("font_size")
+        .and_then(Value::as_f64)
+        .map(|v| v as f32)
+        .filter(|&v| v >= 1.0 && v <= 255.0);
+
     AppConfig {
         focus: FocusConfig {
             hover_terminal_focus,
@@ -155,6 +163,7 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
             color_scheme,
             ghostty_color_scheme,
         },
+        font_size,
     }
 }
 
@@ -182,9 +191,31 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
         json!({ "hover_terminal_focus": config.focus.hover_terminal_focus }),
     );
 
+    if let Some(size) = config.font_size {
+        root.insert("font_size".to_string(), json!(size));
+    } else {
+        root.remove("font_size");
+    }
+
     let serialized =
         serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
     write_config_root_atomically(path, &serialized)
+}
+
+pub fn save_font_size(font_size: f32) -> Result<(), String> {
+    let Some(path) = settings_path() else {
+        return Err("config_dir unavailable; cannot save font size".to_string());
+    };
+
+    let mut root = read_existing_config_root_for_save(&path)
+        .map_err(|err| format!("failed to save font size to `{}`: {err}", path.display()))?;
+
+    root.insert("font_size".to_string(), json!(font_size));
+
+    let serialized =
+        serde_json::to_string_pretty(&Value::Object(root)).expect("config should serialize");
+    write_config_root_atomically(&path, &serialized)
+        .map_err(|err| format!("failed to save font size to `{}`: {err}", path.display()))
 }
 
 fn read_existing_config_root_for_save(

--- a/rust/limux-host-linux/src/ghostty_config.rs
+++ b/rust/limux-host-linux/src/ghostty_config.rs
@@ -1,0 +1,42 @@
+const DEFAULT_FONT_SIZE: f32 = 12.0;
+
+fn ghostty_config_contents() -> Option<String> {
+    let path = dirs::config_dir()
+        .map(|d| d.join("ghostty/config"))
+        .filter(|p| p.exists())?;
+    std::fs::read_to_string(&path).ok()
+}
+
+fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix(key) {
+            let rest = rest.trim();
+            if let Some(value) = rest.strip_prefix('=') {
+                return Some(value.trim().to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Read background-opacity from the Ghostty config file.
+/// Returns a value between 0.0 and 1.0 (default: 1.0 = fully opaque).
+#[allow(dead_code)]
+pub fn read_background_opacity() -> f64 {
+    ghostty_config_contents()
+        .and_then(|c| read_ghostty_value(&c, "background-opacity"))
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|v| v.clamp(0.0, 1.0))
+        .unwrap_or(1.0)
+}
+
+/// Read font-size from the Ghostty config file.
+/// Returns the configured size in points (default: 12.0).
+pub fn read_font_size() -> f32 {
+    ghostty_config_contents()
+        .and_then(|c| read_ghostty_value(&c, "font-size"))
+        .and_then(|v| v.parse::<f32>().ok())
+        .map(|v| v.clamp(1.0, 255.0))
+        .unwrap_or(DEFAULT_FONT_SIZE)
+}

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -1,5 +1,6 @@
 mod app_config;
 mod control_bridge;
+mod ghostty_config;
 mod keybind_editor;
 mod layout_state;
 mod pane;

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -202,6 +202,10 @@ impl TerminalShortcutTarget {
         self.handle.perform_binding_action(action)
     }
 
+    pub fn font_size(&self) -> Option<f32> {
+        self.handle.font_size()
+    }
+
     pub fn show_find(&self) -> bool {
         self.handle.show_find()
     }
@@ -1030,7 +1034,10 @@ fn add_terminal_tab_inner(
 
     let term = terminal::create_terminal(
         working_directory,
-        terminal::TerminalOptions { hover_focus },
+        terminal::TerminalOptions {
+            hover_focus,
+            saved_font_size: (internals.callbacks.current_config)().borrow().font_size,
+        },
         term_callbacks,
     );
     let widget: gtk::Widget = term.overlay.clone().upcast();

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -202,10 +202,6 @@ impl TerminalShortcutTarget {
         self.handle.perform_binding_action(action)
     }
 
-    pub fn font_size(&self) -> Option<f32> {
-        self.handle.font_size()
-    }
-
     pub fn show_find(&self) -> bool {
         self.handle.show_find()
     }

--- a/rust/limux-host-linux/src/shortcut_config.rs
+++ b/rust/limux-host-linux/src/shortcut_config.rs
@@ -797,7 +797,7 @@ const SHORTCUT_DEFINITIONS: [ShortcutDefinition; 47] = [
         id: ShortcutId::TerminalIncreaseFontSize,
         config_key: "terminal_increase_font_size",
         action_name: "win.terminal-increase-font-size",
-        default_accel: "<Ctrl>plus",
+        default_accel: "<Ctrl>equal",
         label: "Terminal Increase Font Size",
         registers_gtk_accel: false,
         command: ShortcutCommand::TerminalIncreaseFontSize,

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -165,11 +165,6 @@ impl TerminalHandle {
         surface.is_some()
     }
 
-    pub fn font_size(&self) -> Option<f32> {
-        let surface = (*self.surface_cell.borrow())?;
-        Some(unsafe { ghostty_surface_font_size(surface) })
-    }
-
     /// Inject text into the terminal surface for control-socket requests and
     /// drag/drop payloads. Ghostty treats this as pasted text, which matches
     /// the current control protocol semantics.
@@ -818,6 +813,13 @@ pub struct TerminalOptions {
     pub saved_font_size: Option<f32>,
 }
 
+/// Default font-size from ghostty config (cached on first access).
+pub(crate) fn default_font_size() -> f32 {
+    use std::sync::OnceLock;
+    static SIZE: OnceLock<f32> = OnceLock::new();
+    *SIZE.get_or_init(crate::ghostty_config::read_font_size)
+}
+
 /// Create a new Ghostty-powered terminal widget.
 /// Returns an Overlay (GLArea + toast layer) for embedding in the pane.
 pub fn create_terminal(
@@ -973,10 +975,6 @@ pub fn create_terminal(
             config.scale_factor = scale;
             config.context = GHOSTTY_SURFACE_CONTEXT_WINDOW;
 
-            if let Some(size) = saved_font_size {
-                config.font_size = size;
-            }
-
             let c_wd = wd.as_ref().and_then(|s| CString::new(s.as_str()).ok());
             if let Some(ref cwd) = c_wd {
                 config.working_directory = cwd.as_ptr();
@@ -995,6 +993,18 @@ pub fn create_terminal(
                 ghostty_surface_set_color_scheme(surface, current_ghostty_color_scheme());
             }
             clipboard_context_cell.set(clipboard_context);
+
+            // Apply saved font size (if different from ghostty default)
+            if let Some(size) = saved_font_size {
+                let action = format!("set_font_size:{size}");
+                unsafe {
+                    ghostty_surface_binding_action(
+                        surface,
+                        action.as_ptr() as *const c_char,
+                        action.len(),
+                    );
+                }
+            }
 
             // Set initial size — GLArea gives unscaled CSS pixels,
             // Ghostty handles scaling internally via content_scale.

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -1441,6 +1441,22 @@ pub fn create_terminal(
 // Context menu
 // ---------------------------------------------------------------------------
 
+/// Send a binding action to every live surface.
+pub(crate) fn broadcast_binding_action(action: &str) {
+    SURFACE_MAP.with(|map| {
+        for &key in map.borrow().keys() {
+            let surface = key as ghostty_surface_t;
+            unsafe {
+                ghostty_surface_binding_action(
+                    surface,
+                    action.as_ptr() as *const c_char,
+                    action.len(),
+                );
+            }
+        }
+    });
+}
+
 fn surface_action(surface: Option<ghostty_surface_t>, action: &str) {
     if let Some(surface) = surface {
         unsafe {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -165,6 +165,11 @@ impl TerminalHandle {
         surface.is_some()
     }
 
+    pub fn font_size(&self) -> Option<f32> {
+        let surface = (*self.surface_cell.borrow())?;
+        Some(unsafe { ghostty_surface_font_size(surface) })
+    }
+
     /// Inject text into the terminal surface for control-socket requests and
     /// drag/drop payloads. Ghostty treats this as pasted text, which matches
     /// the current control protocol semantics.
@@ -810,6 +815,7 @@ pub struct TerminalCallbacks {
 
 pub struct TerminalOptions {
     pub hover_focus: Rc<dyn Fn() -> bool>,
+    pub saved_font_size: Option<f32>,
 }
 
 /// Create a new Ghostty-powered terminal widget.
@@ -833,6 +839,7 @@ pub fn create_terminal(
     });
 
     let wd = working_directory.map(|s| s.to_string());
+    let saved_font_size = options.saved_font_size;
     let hover_focus = options.hover_focus;
     let callbacks = Rc::new(RefCell::new(callbacks));
     let surface_cell: Rc<RefCell<Option<ghostty_surface_t>>> = Rc::new(RefCell::new(None));
@@ -965,6 +972,10 @@ pub fn create_terminal(
             let scale = gl_area.scale_factor() as f64;
             config.scale_factor = scale;
             config.context = GHOSTTY_SURFACE_CONTEXT_WINDOW;
+
+            if let Some(size) = saved_font_size {
+                config.font_size = size;
+            }
 
             let c_wd = wd.as_ref().and_then(|s| CString::new(s.as_str()).ok());
             if let Some(ref cwd) = c_wd {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3758,13 +3758,29 @@ fn dispatch_terminal_command(state: &State, command: ShortcutCommand) -> bool {
         ShortcutCommand::TerminalCopy => target.perform_binding_action("copy_to_clipboard"),
         ShortcutCommand::TerminalPaste => target.perform_binding_action("paste_from_clipboard"),
         ShortcutCommand::TerminalIncreaseFontSize => {
-            target.perform_binding_action("increase_font_size:1")
+            let ok = target.perform_binding_action("increase_font_size:1");
+            persist_font_size(&target);
+            ok
         }
         ShortcutCommand::TerminalDecreaseFontSize => {
-            target.perform_binding_action("decrease_font_size:1")
+            let ok = target.perform_binding_action("decrease_font_size:1");
+            persist_font_size(&target);
+            ok
         }
-        ShortcutCommand::TerminalResetFontSize => target.perform_binding_action("reset_font_size"),
+        ShortcutCommand::TerminalResetFontSize => {
+            let ok = target.perform_binding_action("reset_font_size");
+            persist_font_size(&target);
+            ok
+        }
         _ => false,
+    }
+}
+
+fn persist_font_size(terminal: &pane::TerminalShortcutTarget) {
+    if let Some(size) = terminal.font_size() {
+        if let Err(err) = app_config::save_font_size(size) {
+            eprintln!("limux: {err}");
+        }
     }
 }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3758,25 +3758,19 @@ fn dispatch_terminal_command(state: &State, command: ShortcutCommand) -> bool {
         ShortcutCommand::TerminalCopy => target.perform_binding_action("copy_to_clipboard"),
         ShortcutCommand::TerminalPaste => target.perform_binding_action("paste_from_clipboard"),
         ShortcutCommand::TerminalIncreaseFontSize => {
-            let ok = target.perform_binding_action("increase_font_size:1");
-            if ok {
-                persist_font_size_delta(1.0);
-            }
-            ok
+            persist_font_size_delta(1.0);
+            broadcast_font_size();
+            true
         }
         ShortcutCommand::TerminalDecreaseFontSize => {
-            let ok = target.perform_binding_action("decrease_font_size:1");
-            if ok {
-                persist_font_size_delta(-1.0);
-            }
-            ok
+            persist_font_size_delta(-1.0);
+            broadcast_font_size();
+            true
         }
         ShortcutCommand::TerminalResetFontSize => {
-            let ok = target.perform_binding_action("reset_font_size");
-            if ok {
-                persist_font_size_reset();
-            }
-            ok
+            persist_font_size_reset();
+            crate::terminal::broadcast_binding_action("reset_font_size");
+            true
         }
         _ => false,
     }
@@ -3797,6 +3791,15 @@ fn persist_font_size_reset() {
     if let Err(err) = app_config::clear_font_size() {
         eprintln!("limux: {err}");
     }
+}
+
+fn broadcast_font_size() {
+    let size = app_config::load()
+        .config
+        .font_size
+        .unwrap_or_else(crate::terminal::default_font_size);
+    let action = format!("set_font_size:{size}");
+    crate::terminal::broadcast_binding_action(&action);
 }
 
 fn dispatch_browser_command(state: &State, command: ShortcutCommand) -> bool {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3759,28 +3759,43 @@ fn dispatch_terminal_command(state: &State, command: ShortcutCommand) -> bool {
         ShortcutCommand::TerminalPaste => target.perform_binding_action("paste_from_clipboard"),
         ShortcutCommand::TerminalIncreaseFontSize => {
             let ok = target.perform_binding_action("increase_font_size:1");
-            persist_font_size(&target);
+            if ok {
+                persist_font_size_delta(1.0);
+            }
             ok
         }
         ShortcutCommand::TerminalDecreaseFontSize => {
             let ok = target.perform_binding_action("decrease_font_size:1");
-            persist_font_size(&target);
+            if ok {
+                persist_font_size_delta(-1.0);
+            }
             ok
         }
         ShortcutCommand::TerminalResetFontSize => {
             let ok = target.perform_binding_action("reset_font_size");
-            persist_font_size(&target);
+            if ok {
+                persist_font_size_reset();
+            }
             ok
         }
         _ => false,
     }
 }
 
-fn persist_font_size(terminal: &pane::TerminalShortcutTarget) {
-    if let Some(size) = terminal.font_size() {
-        if let Err(err) = app_config::save_font_size(size) {
-            eprintln!("limux: {err}");
-        }
+fn persist_font_size_delta(delta: f32) {
+    let current = app_config::load()
+        .config
+        .font_size
+        .unwrap_or_else(crate::terminal::default_font_size);
+    let new_size = (current + delta).clamp(1.0, 255.0);
+    if let Err(err) = app_config::save_font_size(new_size) {
+        eprintln!("limux: {err}");
+    }
+}
+
+fn persist_font_size_reset() {
+    if let Err(err) = app_config::clear_font_size() {
+        eprintln!("limux: {err}");
     }
 }
 


### PR DESCRIPTION
## Summary

- Save font size to `~/.config/limux/settings.json` when user zooms (Ctrl+/-, Ctrl+Shift+0)
- Restore saved font size when creating new terminal surfaces
- Reads default font size from ghostty config, tracks deltas on the Rust side (no ghostty submodule changes)

Closes #43