### PR TITLE
fix: build libghostty with -Dcpu=x86_64_v3

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build libghostty for embedding
         run: |
           cd ghostty
-          zig build -Dapp-runtime=none -Doptimize=ReleaseFast
+          zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=x86_64_v3
 
       - name: Run repository quality checks
         run: ./scripts/check.sh

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -102,8 +102,10 @@ fi
 
 # Always build libghostty with ReleaseFast to guarantee optimized output.
 # A Debug build (Zig's default) causes ~7x slower terminal IO throughput.
-echo "Building libghostty (ReleaseFast)..."
-(cd "${ROOT_DIR}/ghostty" && zig build -Dapp-runtime=none -Doptimize=ReleaseFast)
+# Use x86_64_v3 so release artifacts don't pick up ISA extensions from the
+# build machine (e.g. AVX-512) while still targeting modern x86_64 CPUs.
+echo "Building libghostty (ReleaseFast, cpu=x86_64_v3)..."
+(cd "${ROOT_DIR}/ghostty" && zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=x86_64_v3)
 
 if [ ! -f "$GHOSTTY_SO" ]; then
     echo "ERROR: libghostty.so not found at ${GHOSTTY_SO} after build"


### PR DESCRIPTION
## Summary
- build bundled `libghostty.so` with `-Dcpu=x86_64_v3` in release packaging
- keep CI's embedding build aligned with the same CPU target

## Problem
The published Linux x86_64 release artifact can inherit ISA extensions from the build machine when `zig build` is invoked without `-Dcpu=...`.

On machines without those extensions, the bundled `libghostty.so` crashes immediately with `SIGILL` at startup. In my case, the shipped v0.1.12 artifact contained AVX-512 `zmm` instructions while the target machine only had AVX2.

## Why this fix
`-Dcpu=x86_64_v3` prevents the release artifact from depending on the build machine's ISA extensions while still targeting modern x86_64 CPUs with AVX2/FMA support.

## Validation
- reproduced the crash from the published v0.1.12 artifact
- rebuilt `libghostty.so` with `-Dcpu=x86_64_v3`
- verified the rebuilt library no longer contains AVX-512 `zmm` instructions
- verified the rebuilt bundle launches successfully on the affected machine

Fixes #42.
