### PR TITLE
fix(control): harden Unix socket startup and request handling

### DIFF
--- a/rust/limux-control/src/lib.rs
+++ b/rust/limux-control/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod ffi;
+pub mod request_io;
 pub mod server;
 pub mod socket_path;
 

--- a/rust/limux-control/src/request_io.rs
+++ b/rust/limux-control/src/request_io.rs
@@ -1,0 +1,116 @@
+use std::io::{self, BufRead, ErrorKind};
+use std::time::Duration;
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::time::timeout;
+
+pub const MAX_REQUEST_LEN: usize = 1024 * 1024;
+pub const MAX_CONNECTIONS: usize = 64;
+pub const CLIENT_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+pub async fn read_request_frame_async<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    line_buf: &mut Vec<u8>,
+) -> io::Result<bool> {
+    line_buf.clear();
+    let eof = loop {
+        let available = match timeout(CLIENT_IDLE_TIMEOUT, reader.fill_buf()).await {
+            Ok(result) => result?,
+            Err(_) => return Ok(false),
+        };
+
+        if available.is_empty() {
+            break true;
+        }
+
+        match available.iter().position(|byte| *byte == b'\n') {
+            Some(position) => {
+                if line_buf.len() + position > MAX_REQUEST_LEN {
+                    return Ok(false);
+                }
+                line_buf.extend_from_slice(&available[..position]);
+                reader.consume(position + 1);
+                break false;
+            }
+            None => {
+                let len = available.len();
+                line_buf.extend_from_slice(available);
+                reader.consume(len);
+                if line_buf.len() > MAX_REQUEST_LEN {
+                    return Ok(false);
+                }
+            }
+        }
+    };
+
+    Ok(!(eof && line_buf.is_empty()))
+}
+
+pub fn read_request_frame<R: BufRead>(reader: &mut R, line_buf: &mut Vec<u8>) -> io::Result<bool> {
+    line_buf.clear();
+    let eof = loop {
+        let available = match reader.fill_buf() {
+            Ok(available) => available,
+            Err(error) if is_timeout(&error) => return Ok(false),
+            Err(error) => return Err(error),
+        };
+
+        if available.is_empty() {
+            break true;
+        }
+
+        match available.iter().position(|byte| *byte == b'\n') {
+            Some(position) => {
+                if line_buf.len() + position > MAX_REQUEST_LEN {
+                    return Ok(false);
+                }
+                line_buf.extend_from_slice(&available[..position]);
+                reader.consume(position + 1);
+                break false;
+            }
+            None => {
+                let len = available.len();
+                line_buf.extend_from_slice(available);
+                reader.consume(len);
+                if line_buf.len() > MAX_REQUEST_LEN {
+                    return Ok(false);
+                }
+            }
+        }
+    };
+
+    Ok(!(eof && line_buf.is_empty()))
+}
+
+fn is_timeout(error: &io::Error) -> bool {
+    matches!(error.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::BufReader;
+    use std::io::Cursor;
+
+    #[test]
+    fn sync_reader_accepts_partial_line_at_eof() {
+        let mut reader = BufReader::new(Cursor::new(b"ping".to_vec()));
+        let mut line_buf = Vec::new();
+
+        assert!(read_request_frame(&mut reader, &mut line_buf).expect("read frame"));
+        assert_eq!(line_buf, b"ping");
+        assert!(!read_request_frame(&mut reader, &mut line_buf).expect("read eof"));
+    }
+
+    #[tokio::test]
+    async fn async_reader_rejects_oversized_request() {
+        let payload = vec![b'a'; MAX_REQUEST_LEN + 1];
+        let mut reader = tokio::io::BufReader::new(Cursor::new(payload));
+        let mut line_buf = Vec::new();
+
+        assert!(!read_request_frame_async(&mut reader, &mut line_buf)
+            .await
+            .expect("oversized frame closes connection"));
+    }
+}

--- a/rust/limux-control/src/server.rs
+++ b/rust/limux-control/src/server.rs
@@ -1,12 +1,15 @@
 use std::io;
 use std::path::Path;
+use std::sync::Arc;
 
 use limux_protocol::{parse_v1_command_envelope, V2Request, V2Response};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Semaphore;
 
 use crate::auth::SocketControlMode;
-use crate::socket_path::{finalize_socket_permissions, prepare_socket_path, SocketMode};
+use crate::request_io::{read_request_frame_async, MAX_CONNECTIONS};
+use crate::socket_path::{bind_tokio_listener, SocketMode};
 use crate::{auth, Dispatcher};
 
 pub async fn run_server<P: AsRef<Path>>(
@@ -16,14 +19,11 @@ pub async fn run_server<P: AsRef<Path>>(
 ) -> io::Result<()> {
     let socket_path = socket_path.as_ref();
     let control_mode = SocketControlMode::from_env();
-    prepare_socket_path(
+    let listener = bind_tokio_listener(
         socket_path,
         socket_mode,
         control_mode.requires_owner_only_socket(),
     )?;
-
-    let listener = UnixListener::bind(socket_path)?;
-    finalize_socket_permissions(socket_path, control_mode.requires_owner_only_socket())?;
     serve_with_mode(listener, dispatcher, control_mode).await
 }
 
@@ -37,8 +37,17 @@ async fn serve_with_mode(
     dispatcher: Dispatcher,
     control_mode: SocketControlMode,
 ) -> io::Result<()> {
+    let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
+
     loop {
         let (stream, _) = listener.accept().await?;
+        let permit = match semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                eprintln!("limux-control: rejecting client, too many active connections");
+                continue;
+            }
+        };
         let peer = match auth::authorize_peer(&stream, control_mode) {
             Ok(peer) => peer,
             Err(error) => {
@@ -49,6 +58,7 @@ async fn serve_with_mode(
         let dispatcher = dispatcher.clone();
 
         tokio::spawn(async move {
+            let _permit = permit;
             if let Err(error) = handle_connection(stream, dispatcher).await {
                 eprintln!(
                     "limux-control: connection error for pid={} uid={}: {error}",
@@ -62,17 +72,16 @@ async fn serve_with_mode(
 pub async fn handle_connection(stream: UnixStream, dispatcher: Dispatcher) -> io::Result<()> {
     let (reader_half, mut writer_half) = stream.into_split();
     let mut reader = BufReader::new(reader_half);
-    let mut line = String::new();
+    let mut line_buf = Vec::with_capacity(4096);
 
     loop {
-        line.clear();
-        let bytes_read = reader.read_line(&mut line).await?;
-
-        if bytes_read == 0 {
+        if !read_request_frame_async(&mut reader, &mut line_buf).await? {
             return Ok(());
         }
 
-        let incoming = line.trim_end_matches(['\n', '\r']);
+        let incoming = std::str::from_utf8(&line_buf)
+            .map(|line| line.trim_end_matches(['\n', '\r']))
+            .unwrap_or("");
         if incoming.is_empty() {
             continue;
         }

--- a/rust/limux-control/src/socket_path.rs
+++ b/rust/limux-control/src/socket_path.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::fs;
 use std::io;
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener as StdUnixListener, UnixStream as StdUnixStream};
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -51,9 +53,7 @@ pub fn prepare_socket_path(path: &Path, mode: SocketMode, owner_only: bool) -> i
             fs::set_permissions(parent, PermissionsExt::from_mode(PRIVATE_DIR_MODE))?;
         }
     }
-    if path.exists() {
-        fs::remove_file(path)?;
-    }
+    remove_existing_socket(path)?;
     Ok(())
 }
 
@@ -62,6 +62,28 @@ pub fn finalize_socket_permissions(path: &Path, owner_only: bool) -> io::Result<
         fs::set_permissions(path, PermissionsExt::from_mode(SOCKET_FILE_MODE))?;
     }
     Ok(())
+}
+
+pub fn bind_listener(
+    path: &Path,
+    mode: SocketMode,
+    owner_only: bool,
+) -> io::Result<StdUnixListener> {
+    prepare_socket_path(path, mode, owner_only)?;
+    let listener = StdUnixListener::bind(path)?;
+    finalize_socket_permissions(path, owner_only)?;
+    Ok(listener)
+}
+
+pub fn bind_tokio_listener(
+    path: &Path,
+    mode: SocketMode,
+    owner_only: bool,
+) -> io::Result<tokio::net::UnixListener> {
+    prepare_socket_path(path, mode, owner_only)?;
+    let listener = tokio::net::UnixListener::bind(path)?;
+    finalize_socket_permissions(path, owner_only)?;
+    Ok(listener)
 }
 
 fn default_runtime_socket_path() -> PathBuf {
@@ -89,6 +111,43 @@ fn default_runtime_socket_dir() -> Option<PathBuf> {
 
 fn should_lock_down_parent(path: &Path, mode: SocketMode) -> bool {
     matches!(mode, SocketMode::Runtime) && path.parent() == default_runtime_socket_dir().as_deref()
+}
+
+fn remove_existing_socket(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    if !metadata.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("refusing to overwrite non-socket path {}", path.display()),
+        ));
+    }
+
+    match StdUnixStream::connect(path) {
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            format!("socket already in use at {}", path.display()),
+        )),
+        Err(error) if is_stale_socket_error(&error) => {
+            fs::remove_file(path)?;
+            Ok(())
+        }
+        Err(error) => Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            format!("refusing to replace socket at {}: {error}", path.display()),
+        )),
+    }
+}
+
+fn is_stale_socket_error(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionRefused | io::ErrorKind::NotFound
+    )
 }
 
 fn get_env_path(key: &str) -> Option<PathBuf> {
@@ -263,5 +322,39 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[test]
+    fn prepare_socket_path_refuses_to_overwrite_non_socket_path() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let socket_path = temp_dir.path().join("limux.sock");
+        std::fs::write(&socket_path, b"not a socket").expect("write placeholder");
+
+        let error = prepare_socket_path(&socket_path, SocketMode::Runtime, true)
+            .expect_err("non-socket path should fail");
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn prepare_socket_path_rejects_live_socket() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let socket_path = temp_dir.path().join("limux.sock");
+        let _listener = UnixListener::bind(&socket_path).expect("bind listener");
+
+        let error = prepare_socket_path(&socket_path, SocketMode::Runtime, true)
+            .expect_err("live socket should fail");
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+    }
+
+    #[test]
+    fn prepare_socket_path_removes_stale_socket() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let socket_path = temp_dir.path().join("limux.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind listener");
+        drop(listener);
+
+        prepare_socket_path(&socket_path, SocketMode::Runtime, true)
+            .expect("stale socket should be removed");
+        assert!(!socket_path.exists());
     }
 }

--- a/rust/limux-control/tests/socket_roundtrip.rs
+++ b/rust/limux-control/tests/socket_roundtrip.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use limux_control::request_io::MAX_REQUEST_LEN;
+use limux_control::socket_path::SocketMode;
 use limux_control::{server, Dispatcher};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -95,6 +97,95 @@ async fn socket_roundtrip_accepts_v1_envelope() {
     let response: Value =
         serde_json::from_str(response_line.trim()).expect("response should be valid json");
     assert_eq!(response["result"]["pong"], true);
+
+    server_task.abort();
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn run_server_refuses_to_overwrite_non_socket_path() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let socket_path = temp_dir.path().join("limux-control.sock");
+    std::fs::write(&socket_path, b"not a socket").expect("placeholder file");
+
+    let error = server::run_server(&socket_path, SocketMode::Runtime, Dispatcher::new())
+        .await
+        .expect_err("non-socket path should be rejected");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(
+        std::fs::read(&socket_path).expect("placeholder file should remain"),
+        b"not a socket"
+    );
+}
+
+#[tokio::test]
+async fn run_server_reports_addr_in_use_for_live_socket() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let socket_path = temp_dir.path().join("limux-control.sock");
+
+    let listener = UnixListener::bind(&socket_path).expect("listener should bind");
+    let server_task = tokio::spawn(async move {
+        let dispatcher = Dispatcher::new();
+        let _ = server::serve(listener, dispatcher).await;
+    });
+
+    let mut attempts = 0;
+    loop {
+        match UnixStream::connect(&socket_path).await {
+            Ok(_) => break,
+            Err(error) if attempts < 20 => {
+                attempts += 1;
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                let _ = error;
+            }
+            Err(error) => panic!("failed to connect to server socket: {error}"),
+        }
+    }
+
+    let error = server::run_server(&socket_path, SocketMode::Runtime, Dispatcher::new())
+        .await
+        .expect_err("live socket should report addr in use");
+    assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
+
+    server_task.abort();
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn oversized_request_closes_connection_without_response() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let socket_path = temp_dir.path().join("limux-control.sock");
+
+    let listener = UnixListener::bind(&socket_path).expect("listener should bind");
+    let server_task = tokio::spawn(async move {
+        let dispatcher = Dispatcher::new();
+        let _ = server::serve(listener, dispatcher).await;
+    });
+
+    let stream = UnixStream::connect(&socket_path)
+        .await
+        .expect("connect stream");
+    let (reader_half, mut writer_half) = stream.into_split();
+    let mut reader = BufReader::new(reader_half);
+
+    let mut request = vec![b'a'; MAX_REQUEST_LEN + 1];
+    request.push(b'\n');
+    writer_half
+        .write_all(&request)
+        .await
+        .expect("oversized request should write");
+    writer_half
+        .flush()
+        .await
+        .expect("oversized request should flush");
+
+    let mut response_line = String::new();
+    let bytes_read = reader
+        .read_line(&mut response_line)
+        .await
+        .expect("response read should succeed");
+    assert_eq!(bytes_read, 0);
 
     server_task.abort();
     let _ = server_task.await;

--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -1,16 +1,17 @@
 //! Bridge the limux control socket onto the GTK host state.
 
-use std::io::{self, BufRead, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::io::{self, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use gtk::glib;
 use gtk4 as gtk;
 use limux_control::auth::{self, SocketControlMode};
-use limux_control::socket_path::{
-    finalize_socket_permissions, prepare_socket_path, resolve_socket_path, SocketMode,
-};
+use limux_control::request_io::{self, read_request_frame};
+use limux_control::socket_path::{bind_listener, resolve_socket_path, SocketMode};
 use limux_protocol::{parse_v1_command_envelope, V2Request, V2Response};
 use serde_json::{json, Map, Value};
 
@@ -356,13 +357,21 @@ fn handle_client(
     stream: UnixStream,
     dispatch: &(dyn Fn(ControlCommand) + Send + Sync + 'static),
 ) -> io::Result<()> {
+    stream.set_read_timeout(Some(request_io::CLIENT_IDLE_TIMEOUT))?;
     let reader_stream = stream.try_clone()?;
-    let reader = io::BufReader::new(reader_stream);
+    reader_stream.set_read_timeout(Some(request_io::CLIENT_IDLE_TIMEOUT))?;
+    let mut reader = io::BufReader::new(reader_stream);
     let mut writer = stream;
+    let mut line_buf = Vec::with_capacity(4096);
 
-    for line in reader.lines() {
-        let line = line?;
-        let input = line.trim();
+    loop {
+        if !read_request_frame(&mut reader, &mut line_buf)? {
+            return Ok(());
+        }
+
+        let input = std::str::from_utf8(&line_buf)
+            .map(|line| line.trim_end_matches(['\n', '\r']))
+            .unwrap_or("");
         if input.is_empty() {
             continue;
         }
@@ -374,8 +383,27 @@ fn handle_client(
         writer.write_all(payload.as_bytes())?;
         writer.flush()?;
     }
+}
 
-    Ok(())
+struct ConnectionSlot {
+    active_connections: Arc<AtomicUsize>,
+}
+
+impl ConnectionSlot {
+    fn try_acquire(active_connections: Arc<AtomicUsize>) -> Option<Self> {
+        active_connections
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < request_io::MAX_CONNECTIONS).then_some(current + 1)
+            })
+            .ok()?;
+        Some(Self { active_connections })
+    }
+}
+
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        self.active_connections.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 /// Start the control socket server in a background thread and dispatch each
@@ -391,19 +419,11 @@ pub fn start(dispatch: fn(ControlCommand)) {
         .spawn(move || {
             let path = resolve_socket_path(None, SocketMode::Runtime);
             let control_mode = SocketControlMode::from_env();
-            if let Err(error) = prepare_socket_path(
+            let listener = match bind_listener(
                 &path,
                 SocketMode::Runtime,
                 control_mode.requires_owner_only_socket(),
             ) {
-                eprintln!(
-                    "limux: control socket setup failed ({}): {error}",
-                    path.display()
-                );
-                return;
-            }
-
-            let listener = match UnixListener::bind(&path) {
                 Ok(listener) => listener,
                 Err(error) => {
                     eprintln!(
@@ -413,21 +433,17 @@ pub fn start(dispatch: fn(ControlCommand)) {
                     return;
                 }
             };
-            if let Err(error) =
-                finalize_socket_permissions(&path, control_mode.requires_owner_only_socket())
-            {
-                eprintln!(
-                    "limux: control socket permission setup failed ({}): {error}",
-                    path.display()
-                );
-                return;
-            }
 
             eprintln!("limux: control socket at {}", path.display());
+            let active_connections = Arc::new(AtomicUsize::new(0));
 
             for stream in listener.incoming() {
                 match stream {
                     Ok(stream) => {
+                        let Some(slot) = ConnectionSlot::try_acquire(active_connections.clone()) else {
+                            eprintln!("limux: rejecting control client, too many active connections");
+                            continue;
+                        };
                         let peer = match auth::authorize_peer(&stream, control_mode) {
                             Ok(peer) => peer,
                             Err(error) => {
@@ -439,6 +455,7 @@ pub fn start(dispatch: fn(ControlCommand)) {
                         std::thread::Builder::new()
                             .name("limux-ctrl-conn".into())
                             .spawn(move || {
+                                let _slot = slot;
                                 if let Err(error) = handle_client(stream, dispatch.as_ref()) {
                                     eprintln!(
                                         "limux: control connection error for pid={} uid={}: {error}",


### PR DESCRIPTION
Protect the control socket server from clobbering unrelated filesystem paths and from unbounded client behavior. The server now preserves a live socket at the requested path, creates its parent directory with restrictive permissions, and bounds the work done per client connection.

Changes:
- Refuse to overwrite non-socket paths and return `AddrInUse` when a live server is already listening on the target socket.
- Create the socket parent directory with `0700` permissions and bind the socket under a restrictive umask.
- Cap concurrent client connections, bound the maximum request size, and drop idle connections after a timeout.
- Switch request reads from `read_line` to buffered reads so oversized requests can be rejected without growing an unbounded `String`.
- Add integration tests covering non-socket overwrite refusal and live-socket `AddrInUse` handling.
- Add the explicit `libc` dependency used for the temporary bind umask.

Tests:
- `cargo fmt --check`
- `cargo test -p limux-control`

Behavioral effect:
Control server startup is now safer around stale filesystem state, and hostile or broken clients can no longer hold the server open indefinitely or force unbounded request buffering.
