### PR TITLE
feat: restore agent sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.py[cod]
 *.deb
 *.AppImage
+save-sesh-plan.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,12 @@ version = "0.1.14"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "limux-control",
  "limux-protocol",
+ "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/rust/limux-cli/Cargo.toml
+++ b/rust/limux-cli/Cargo.toml
@@ -8,7 +8,12 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+dirs = "6"
 limux-control = { path = "../limux-control" }
 limux-protocol = { path = "../limux-protocol" }
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/rust/limux-cli/src/agent_hooks.rs
+++ b/rust/limux-cli/src/agent_hooks.rs
@@ -1,0 +1,556 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentKind {
+    Claude,
+    Codex,
+    OpenCode,
+    Gemini,
+}
+
+impl AgentKind {
+    pub(crate) fn from_hook_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "claude" | "claude-code" | "claudecode" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "opencode" | "open-code" => Some(Self::OpenCode),
+            "gemini" => Some(Self::Gemini),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn store_name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+            Self::Gemini => "gemini",
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+            Self::OpenCode => "OpenCode",
+            Self::Gemini => "Gemini",
+        }
+    }
+
+    fn fallback_executable(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+            Self::Gemini => "gemini",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct AgentLaunchCommandRecord {
+    pub(crate) executable: String,
+    pub(crate) arguments: Vec<String>,
+    #[serde(default)]
+    pub(crate) cwd: Option<String>,
+    #[serde(default)]
+    pub(crate) environment: BTreeMap<String, String>,
+    pub(crate) captured_at: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct AgentHookSessionRecord {
+    pub(crate) session_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) surface_id: String,
+    #[serde(default)]
+    pub(crate) cwd: Option<String>,
+    #[serde(default)]
+    pub(crate) pid: Option<u32>,
+    #[serde(default)]
+    pub(crate) launch_command: Option<AgentLaunchCommandRecord>,
+    pub(crate) updated_at: f64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct AgentHookSessionFile {
+    version: u32,
+    #[serde(default)]
+    sessions: BTreeMap<String, AgentHookSessionRecord>,
+}
+
+pub(crate) struct AgentHookSessionStore {
+    path: PathBuf,
+}
+
+impl AgentHookSessionStore {
+    pub(crate) fn new(agent: AgentKind) -> Self {
+        Self::new_for_agent_name(agent.store_name())
+    }
+
+    pub(crate) fn new_for_agent_name(agent: &str) -> Self {
+        let filename = format!("{}-hook-sessions.json", safe_store_name(agent));
+        if let Some(dir) = std::env::var_os("LIMUX_AGENT_HOOK_STATE_DIR") {
+            let dir = PathBuf::from(dir);
+            return Self {
+                path: dir.join(filename),
+            };
+        }
+        Self {
+            path: state_dir().join(filename),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_dir(agent: &str, dir: &Path) -> Self {
+        Self {
+            path: dir.join(format!("{}-hook-sessions.json", safe_store_name(agent))),
+        }
+    }
+
+    pub(crate) fn lookup(&self, session_id: &str) -> Result<Option<AgentHookSessionRecord>> {
+        let session_id = normalized(session_id);
+        if session_id.is_none() {
+            return Ok(None);
+        }
+        let file = self.load()?;
+        Ok(file.sessions.get(session_id.as_deref().unwrap()).cloned())
+    }
+
+    pub(crate) fn upsert(&self, record: AgentHookSessionRecord) -> Result<()> {
+        let Some(session_id) = normalized(&record.session_id) else {
+            return Ok(());
+        };
+        let mut file = self.load()?;
+        file.version = 1;
+        file.sessions.insert(session_id, record);
+        self.save(&file)
+    }
+
+    pub(crate) fn remove(&self, session_id: &str) -> Result<()> {
+        let Some(session_id) = normalized(session_id) else {
+            return Ok(());
+        };
+        let mut file = self.load()?;
+        file.sessions.remove(&session_id);
+        self.save(&file)
+    }
+
+    fn load(&self) -> Result<AgentHookSessionFile> {
+        if !self.path.exists() {
+            return Ok(AgentHookSessionFile {
+                version: 1,
+                sessions: BTreeMap::new(),
+            });
+        }
+        let raw = fs::read_to_string(&self.path)
+            .with_context(|| format!("failed to read {}", self.path.display()))?;
+        let mut file: AgentHookSessionFile = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse {}", self.path.display()))?;
+        if file.version == 0 {
+            file.version = 1;
+        }
+        Ok(file)
+    }
+
+    fn save(&self, file: &AgentHookSessionFile) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        let temp = self
+            .path
+            .with_extension(format!("json.{}.tmp", std::process::id()));
+        let json = serde_json::to_vec_pretty(file).context("failed to encode hook store")?;
+        fs::write(&temp, json).with_context(|| format!("failed to write {}", temp.display()))?;
+        fs::rename(&temp, &self.path)
+            .with_context(|| format!("failed to replace {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+pub(crate) fn sanitize_launch_arguments(kind: AgentKind, arguments: &[String]) -> Vec<String> {
+    if arguments.is_empty() {
+        return vec![kind.fallback_executable().to_string()];
+    }
+
+    let mut result = Vec::new();
+    let mut index = 0;
+    while index < arguments.len() {
+        let arg = &arguments[index];
+        if index == 0 {
+            result.push(arg.clone());
+            index += 1;
+            continue;
+        }
+        if is_resume_selector(kind, arg) {
+            index += 1;
+            if index < arguments.len() && !arguments[index].starts_with('-') {
+                index += 1;
+            }
+            continue;
+        }
+        if option_takes_secret_value(arg) {
+            index += 1;
+            if index < arguments.len() && !arguments[index].starts_with('-') {
+                index += 1;
+            }
+            continue;
+        }
+        if option_is_secret_assignment(arg) {
+            index += 1;
+            continue;
+        }
+        if option_takes_safe_value(arg) {
+            result.push(arg.clone());
+            if index + 1 < arguments.len() {
+                result.push(arguments[index + 1].clone());
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if option_is_safe_flag_or_assignment(arg) {
+            result.push(arg.clone());
+            index += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+
+    if result.is_empty() {
+        vec![kind.fallback_executable().to_string()]
+    } else {
+        result
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn build_resume_command(
+    kind: AgentKind,
+    session_id: &str,
+    launch: Option<&AgentLaunchCommandRecord>,
+    cwd: Option<&str>,
+) -> Option<String> {
+    let session_id = normalized(session_id)?;
+    let fallback = kind.fallback_executable().to_string();
+    let raw_args = launch
+        .map(|launch| launch.arguments.clone())
+        .filter(|args| !args.is_empty())
+        .unwrap_or_else(|| vec![fallback.clone()]);
+    let sanitized = sanitize_launch_arguments(kind, &raw_args);
+    let executable = launch
+        .and_then(|launch| normalized(&launch.executable))
+        .or_else(|| sanitized.first().cloned())
+        .unwrap_or(fallback);
+    let preserved_tail = sanitized
+        .get(1..)
+        .map(|tail| tail.to_vec())
+        .unwrap_or_default();
+
+    let mut parts = vec![executable];
+    match kind {
+        AgentKind::Codex => {
+            parts.push("resume".to_string());
+            parts.extend(preserved_tail);
+            parts.push(session_id);
+        }
+        AgentKind::OpenCode => {
+            parts.push("--session".to_string());
+            parts.push(session_id);
+            parts.extend(preserved_tail);
+        }
+        AgentKind::Claude | AgentKind::Gemini => {
+            parts.push("--resume".to_string());
+            parts.push(session_id);
+            parts.extend(preserved_tail);
+        }
+    }
+
+    let command = parts
+        .iter()
+        .map(|part| shell_single_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let cwd = cwd.and_then(normalized).or_else(|| {
+        launch
+            .and_then(|launch| launch.cwd.as_deref())
+            .and_then(normalized)
+    });
+    Some(match cwd {
+        Some(cwd) => format!("cd {} && {command}", shell_single_quote(&cwd)),
+        None => command,
+    })
+}
+
+pub(crate) fn launch_record_from_env(
+    kind: AgentKind,
+    payload_cwd: Option<&str>,
+) -> Option<AgentLaunchCommandRecord> {
+    let args = std::env::var("LIMUX_AGENT_LAUNCH_ARGV")
+        .ok()
+        .map(split_nul_or_space_separated)
+        .filter(|args| !args.is_empty())
+        .unwrap_or_else(|| vec![kind.fallback_executable().to_string()]);
+    let sanitized = sanitize_launch_arguments(kind, &args);
+    let executable = std::env::var("LIMUX_AGENT_LAUNCH_EXECUTABLE")
+        .ok()
+        .and_then(|value| normalized(&value))
+        .or_else(|| sanitized.first().cloned())?;
+    Some(AgentLaunchCommandRecord {
+        executable,
+        arguments: sanitized,
+        cwd: std::env::var("LIMUX_AGENT_LAUNCH_CWD")
+            .ok()
+            .and_then(|value| normalized(&value))
+            .or_else(|| payload_cwd.and_then(normalized))
+            .or_else(|| {
+                std::env::var("PWD")
+                    .ok()
+                    .and_then(|value| normalized(&value))
+            }),
+        environment: selected_environment(),
+        captured_at: now_seconds(),
+    })
+}
+
+pub(crate) fn now_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .unwrap_or_default()
+}
+
+fn state_dir() -> PathBuf {
+    if let Some(dir) = dirs::state_dir() {
+        return dir.join("limux");
+    }
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".local/state/limux");
+    }
+    PathBuf::from(".limux")
+}
+
+fn safe_store_name(agent: &str) -> String {
+    agent
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+        .collect::<String>()
+}
+
+fn normalized(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn is_resume_selector(kind: AgentKind, arg: &str) -> bool {
+    match kind {
+        AgentKind::Codex => arg == "resume" || arg == "--resume" || arg.starts_with("--resume="),
+        AgentKind::OpenCode => arg == "--session" || arg.starts_with("--session="),
+        AgentKind::Claude | AgentKind::Gemini => {
+            arg == "--resume" || arg.starts_with("--resume=") || arg == "--continue"
+        }
+    }
+}
+
+fn option_takes_secret_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--api-key"
+            | "--apikey"
+            | "--token"
+            | "--auth-token"
+            | "--password"
+            | "--credential"
+            | "--credentials"
+    )
+}
+
+fn option_is_secret_assignment(arg: &str) -> bool {
+    let lower = arg.to_ascii_lowercase();
+    lower.starts_with("--api-key=")
+        || lower.starts_with("--apikey=")
+        || lower.starts_with("--token=")
+        || lower.starts_with("--auth-token=")
+        || lower.starts_with("--password=")
+        || lower.starts_with("--credential=")
+        || lower.starts_with("--credentials=")
+}
+
+fn option_takes_safe_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--model"
+            | "-m"
+            | "--config"
+            | "-c"
+            | "--profile"
+            | "--sandbox"
+            | "--approval-policy"
+            | "--cwd"
+            | "--cd"
+            | "--working-directory"
+            | "--config-dir"
+            | "--home"
+    )
+}
+
+fn option_is_safe_flag_or_assignment(arg: &str) -> bool {
+    if matches!(
+        arg,
+        "--dangerously-bypass-approvals-and-sandbox"
+            | "--dangerously-skip-permissions"
+            | "--full-auto"
+            | "--search"
+            | "--no-search"
+            | "--yolo"
+    ) {
+        return true;
+    }
+
+    let Some((name, _)) = arg.split_once('=') else {
+        return false;
+    };
+    option_takes_safe_value(name)
+}
+
+fn split_nul_or_space_separated(raw: String) -> Vec<String> {
+    if raw.contains('\0') {
+        raw.split('\0').filter_map(normalized).collect::<Vec<_>>()
+    } else {
+        raw.split_whitespace()
+            .filter_map(normalized)
+            .collect::<Vec<_>>()
+    }
+}
+
+fn selected_environment() -> BTreeMap<String, String> {
+    let allowlist: BTreeSet<&'static str> = [
+        "CODEX_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "OPENCODE_CONFIG_DIR",
+        "GEMINI_CONFIG_DIR",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+    ]
+    .into_iter()
+    .collect();
+
+    std::env::vars()
+        .filter(|(key, value)| allowlist.contains(key.as_str()) && !value.trim().is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn hook_store_round_trips_session_records() {
+        let dir = tempdir().expect("tempdir");
+        let store = AgentHookSessionStore::new_for_dir("codex", dir.path());
+        let record = AgentHookSessionRecord {
+            session_id: "codex-session-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            surface_id: "7:tab-a".to_string(),
+            cwd: Some("/tmp/project".to_string()),
+            pid: Some(1234),
+            launch_command: Some(AgentLaunchCommandRecord {
+                executable: "codex".to_string(),
+                arguments: vec![
+                    "codex".to_string(),
+                    "--model".to_string(),
+                    "gpt-5.5".to_string(),
+                ],
+                cwd: Some("/tmp/project".to_string()),
+                environment: Default::default(),
+                captured_at: 10.0,
+            }),
+            updated_at: 11.0,
+        };
+
+        store.upsert(record.clone()).expect("upsert");
+
+        assert_eq!(
+            store.lookup("codex-session-1").expect("lookup"),
+            Some(record)
+        );
+    }
+
+    #[test]
+    fn sanitizer_drops_prompts_credentials_and_existing_resume_selectors() {
+        let args = vec![
+            "codex".to_string(),
+            "--model".to_string(),
+            "gpt-5.5".to_string(),
+            "--api-key".to_string(),
+            "secret".to_string(),
+            "resume".to_string(),
+            "old-session".to_string(),
+            "--dangerously-bypass-approvals-and-sandbox".to_string(),
+            "write a prompt".to_string(),
+        ];
+
+        let sanitized = sanitize_launch_arguments(AgentKind::Codex, &args);
+
+        assert_eq!(
+            sanitized,
+            vec![
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.5".to_string(),
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn resume_command_preserves_safe_launch_flags_and_cwd() {
+        let launch = AgentLaunchCommandRecord {
+            executable: "codex".to_string(),
+            arguments: vec![
+                "codex".to_string(),
+                "--model".to_string(),
+                "gpt-5.5".to_string(),
+                "--config".to_string(),
+                "profile=work".to_string(),
+            ],
+            cwd: Some("/tmp/project one".to_string()),
+            environment: Default::default(),
+            captured_at: 20.0,
+        };
+
+        let command = build_resume_command(
+            AgentKind::Codex,
+            "sess-123",
+            Some(&launch),
+            Some("/tmp/project one"),
+        )
+        .expect("resume command");
+
+        assert_eq!(
+            command,
+            "cd '/tmp/project one' && 'codex' 'resume' '--model' 'gpt-5.5' '--config' 'profile=work' 'sess-123'"
+        );
+    }
+}

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -14,6 +14,8 @@ use serde_json::{json, Map, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
+mod agent_hooks;
+
 const CLI_STATE_LOCK_TIMEOUT: Duration = Duration::from_secs(2);
 const CLI_STATE_LOCK_RETRY: Duration = Duration::from_millis(25);
 
@@ -197,7 +199,7 @@ fn parse_global_args() -> Result<GlobalOptions> {
 
 fn print_help() {
     println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
     );
 }
 
@@ -286,6 +288,29 @@ fn parse_opt(args: &[String], name: &str) -> Option<String> {
 
 fn parse_flag(args: &[String], name: &str) -> bool {
     args.iter().any(|a| a == name)
+}
+
+fn positional_arg(args: &[String], index: usize) -> Option<String> {
+    let mut position = 0usize;
+    let mut skip = false;
+    for arg in args {
+        if skip {
+            skip = false;
+            continue;
+        }
+        if arg == "--agent" {
+            skip = true;
+            continue;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        if position == index {
+            return Some(arg.clone());
+        }
+        position += 1;
+    }
+    None
 }
 
 fn trailing_title(args: &[String]) -> Option<String> {
@@ -776,23 +801,6 @@ async fn run_notify(client: &mut Client, args: &[String]) -> Result<Value> {
 // OpenCode and Gemini use slightly different names; we fall back gracefully
 // when fields are missing.
 
-#[derive(Clone, Copy, Debug)]
-enum AgentKind {
-    Claude,
-    OpenCode,
-    Gemini,
-}
-
-impl AgentKind {
-    fn label(&self) -> &'static str {
-        match self {
-            Self::Claude => "Claude",
-            Self::OpenCode => "OpenCode",
-            Self::Gemini => "Gemini",
-        }
-    }
-}
-
 /// Pull a string field from the hook JSON, trying multiple keys.
 fn hook_str<'a>(payload: &'a Value, keys: &[&str]) -> Option<&'a str> {
     keys.iter()
@@ -813,7 +821,11 @@ fn parse_hook_event(args: &[String], payload: &Value) -> String {
 /// Args:
 ///   [event_name] — optional positional, e.g. "Notification", "Stop".
 ///                  If omitted, we read `hook_event_name` from the JSON.
-async fn run_agent_hook(client: &mut Client, agent: AgentKind, args: &[String]) -> Result<Value> {
+async fn run_agent_hook(
+    client: &mut Client,
+    agent: agent_hooks::AgentKind,
+    args: &[String],
+) -> Result<Value> {
     use std::io::Read;
 
     // Read stdin (hook JSON). If stdin is empty or not JSON, treat as
@@ -832,6 +844,7 @@ async fn run_agent_hook(client: &mut Client, agent: AgentKind, args: &[String]) 
 
     // Build a human-friendly title + body depending on event + agent.
     let agent_label = agent.label();
+    persist_agent_hook_session(agent, args, &payload, &event)?;
     let (title, body) = match event.as_str() {
         "Notification" => (
             format!("{agent_label} needs you"),
@@ -900,13 +913,920 @@ async fn run_agent_hook(client: &mut Client, agent: AgentKind, args: &[String]) 
         params.insert("body".to_string(), Value::String(body));
     }
 
-    call_in_workspace_scope(
+    let _ = call_in_workspace_scope(
         client,
         workspace,
         "notification.create",
         Value::Object(params),
     )
-    .await
+    .await;
+
+    Ok(agent_hook_output(&event, &payload))
+}
+
+fn agent_hook_output(event: &str, payload: &Value) -> Value {
+    let canonical_event = canonical_hook_event_name(event);
+    let mut output = Map::new();
+    output.insert("continue".to_string(), Value::Bool(true));
+    output.insert("suppressOutput".to_string(), Value::Bool(false));
+
+    if matches!(canonical_event, Some("SessionStart" | "UserPromptSubmit")) {
+        let mut specific = Map::new();
+        specific.insert(
+            "hookEventName".to_string(),
+            Value::String(
+                canonical_event
+                    .expect("matched canonical event")
+                    .to_string(),
+            ),
+        );
+        if let Some(context) = hook_additional_context(payload) {
+            specific.insert("additionalContext".to_string(), Value::String(context));
+        }
+        output.insert("hookSpecificOutput".to_string(), Value::Object(specific));
+    }
+
+    Value::Object(output)
+}
+
+fn canonical_hook_event_name(event: &str) -> Option<&'static str> {
+    match event {
+        "SessionStart" | "session-start" => Some("SessionStart"),
+        "UserPromptSubmit" | "prompt-submit" => Some("UserPromptSubmit"),
+        "Stop" | "stop" | "Notification" => Some("Stop"),
+        "SessionEnd" | "session-end" => None,
+        "Cleanup" | "cleanup" | "restore-exit" => None,
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentHookPersistenceAction {
+    Upsert,
+    Preserve,
+    Remove,
+}
+
+fn agent_hook_persistence_action(event: &str) -> AgentHookPersistenceAction {
+    match event {
+        "Cleanup" | "cleanup" | "restore-exit" => AgentHookPersistenceAction::Remove,
+        "SessionEnd" | "session-end" => AgentHookPersistenceAction::Preserve,
+        _ => AgentHookPersistenceAction::Upsert,
+    }
+}
+
+fn hook_additional_context(payload: &Value) -> Option<String> {
+    hook_str(payload, &["additional_context", "additionalContext"])
+        .map(str::to_owned)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn persist_agent_hook_session(
+    agent: agent_hooks::AgentKind,
+    args: &[String],
+    payload: &Value,
+    event: &str,
+) -> Result<()> {
+    let Some(session_id) = hook_session_id(payload) else {
+        write_agent_hook_debug(
+            agent,
+            event,
+            "skip_missing_session_id",
+            &json!({
+                "payload_keys": payload_keys(payload),
+                "has_claude_code_session_env": limux_env_value("CLAUDE_CODE_SESSION_ID").is_some(),
+                "has_claude_session_env": limux_env_value("CLAUDE_SESSION_ID").is_some(),
+            }),
+        );
+        return Ok(());
+    };
+
+    let store = agent_hooks::AgentHookSessionStore::new(agent);
+    match agent_hook_persistence_action(event) {
+        AgentHookPersistenceAction::Remove => {
+            let result = store.remove(&session_id);
+            if result.is_ok() {
+                write_agent_hook_debug(
+                    agent,
+                    event,
+                    "removed",
+                    &json!({
+                        "session_id": session_id,
+                        "payload_keys": payload_keys(payload),
+                    }),
+                );
+            }
+            return result;
+        }
+        AgentHookPersistenceAction::Preserve => {
+            write_agent_hook_debug(
+                agent,
+                event,
+                "preserved",
+                &json!({
+                    "session_id": session_id,
+                    "payload_keys": payload_keys(payload),
+                }),
+            );
+            return Ok(());
+        }
+        AgentHookPersistenceAction::Upsert => {}
+    }
+
+    let workspace_id = parse_opt(args, "--workspace")
+        .or_else(|| limux_env_value("LIMUX_WORKSPACE_ID"))
+        .filter(|value| !value.trim().is_empty());
+    let surface_id = parse_opt(args, "--surface")
+        .or_else(|| limux_env_value("LIMUX_SURFACE_ID"))
+        .filter(|value| !value.trim().is_empty());
+    let (Some(workspace_id), Some(surface_id)) = (workspace_id, surface_id) else {
+        write_agent_hook_debug(
+            agent,
+            event,
+            "skip_missing_limux_target",
+            &json!({
+                "session_id": session_id,
+                "has_workspace_arg": parse_opt(args, "--workspace").is_some(),
+                "has_surface_arg": parse_opt(args, "--surface").is_some(),
+                "has_workspace_env": limux_env_value("LIMUX_WORKSPACE_ID").is_some(),
+                "has_surface_env": limux_env_value("LIMUX_SURFACE_ID").is_some(),
+                "payload_keys": payload_keys(payload),
+            }),
+        );
+        return Ok(());
+    };
+
+    let existing = store.lookup(&session_id)?;
+    let cwd = hook_str(payload, &["cwd", "working_directory", "directory"])
+        .map(str::to_string)
+        .or_else(|| existing.as_ref().and_then(|record| record.cwd.clone()));
+    let pid = hook_str(payload, &["pid"])
+        .and_then(|value| value.parse::<u32>().ok())
+        .or_else(|| agent_ancestor_pid(agent))
+        .or_else(|| existing.as_ref().and_then(|record| record.pid));
+    let launch_command = agent_hooks::launch_record_from_env(agent, cwd.as_deref()).or_else(|| {
+        existing
+            .as_ref()
+            .and_then(|record| record.launch_command.clone())
+    });
+
+    let record = agent_hooks::AgentHookSessionRecord {
+        session_id,
+        workspace_id,
+        surface_id,
+        cwd,
+        pid,
+        launch_command,
+        updated_at: agent_hooks::now_seconds(),
+    };
+    let result = store.upsert(record);
+    if result.is_ok() {
+        write_agent_hook_debug(
+            agent,
+            event,
+            "upserted",
+            &json!({
+                "payload_keys": payload_keys(payload),
+            }),
+        );
+    }
+    result
+}
+
+fn hook_session_id(payload: &Value) -> Option<String> {
+    hook_str(payload, &["session_id", "sessionId", "sessionID"])
+        .map(str::to_string)
+        .or_else(|| limux_env_value("CLAUDE_CODE_SESSION_ID"))
+        .or_else(|| limux_env_value("CLAUDE_SESSION_ID"))
+        .or_else(|| hook_session_id_from_transcript(payload))
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn hook_session_id_from_transcript(payload: &Value) -> Option<String> {
+    let transcript = hook_str(
+        payload,
+        &["transcript_path", "transcriptPath", "transcript"],
+    )?;
+    Path::new(transcript)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn payload_keys(payload: &Value) -> Vec<String> {
+    payload
+        .as_object()
+        .map(|object| object.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn write_agent_hook_debug(
+    agent: agent_hooks::AgentKind,
+    event: &str,
+    outcome: &str,
+    details: &Value,
+) {
+    let Some(dir) = agent_hook_debug_dir() else {
+        return;
+    };
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("agent-hook-debug.jsonl");
+    let line = json!({
+        "time": agent_hooks::now_seconds(),
+        "agent": agent.store_name(),
+        "event": event,
+        "outcome": outcome,
+        "details": details,
+    });
+    if let Ok(mut encoded) = serde_json::to_vec(&line) {
+        encoded.push(b'\n');
+        let _ = append_debug_line(&path, &encoded);
+    }
+}
+
+fn agent_hook_debug_dir() -> Option<PathBuf> {
+    if let Some(dir) = env::var_os("LIMUX_AGENT_HOOK_STATE_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    dirs::state_dir()
+        .map(|dir| dir.join("limux"))
+        .or_else(|| dirs::home_dir().map(|home| home.join(".local/state/limux")))
+}
+
+fn append_debug_line(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to append {}", path.display()))
+}
+
+fn limux_env_value(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| ancestor_env_value(name))
+}
+
+#[cfg(target_os = "linux")]
+fn agent_ancestor_pid(agent: agent_hooks::AgentKind) -> Option<u32> {
+    let needle = agent.store_name();
+    let mut pid = std::process::id();
+    for _ in 0..8 {
+        let parent = proc_parent_pid(pid)?;
+        if parent <= 1 || parent == pid {
+            return None;
+        }
+        if proc_identity_contains(parent, needle) {
+            return Some(parent);
+        }
+        pid = parent;
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn agent_ancestor_pid(_agent: agent_hooks::AgentKind) -> Option<u32> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn proc_identity_contains(pid: u32, needle: &str) -> bool {
+    let needle = needle.to_ascii_lowercase();
+    proc_cmdline(pid)
+        .or_else(|| fs::read_to_string(format!("/proc/{pid}/comm")).ok())
+        .map(|value| value.to_ascii_lowercase().contains(&needle))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn proc_cmdline(pid: u32) -> Option<String> {
+    let raw = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let parts = raw
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| std::str::from_utf8(part).ok())
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
+
+#[cfg(target_os = "linux")]
+fn ancestor_env_value(name: &str) -> Option<String> {
+    let mut pid = std::process::id();
+    for _ in 0..8 {
+        let parent = proc_parent_pid(pid)?;
+        if parent <= 1 || parent == pid {
+            return None;
+        }
+        if let Some(value) = proc_env_value(parent, name) {
+            return Some(value);
+        }
+        pid = parent;
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn ancestor_env_value(_name: &str) -> Option<String> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn proc_parent_pid(pid: u32) -> Option<u32> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_proc_stat_parent_pid(&stat)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_stat_parent_pid(stat: &str) -> Option<u32> {
+    let close = stat.rfind(')')?;
+    let mut fields = stat.get(close + 2..)?.split_whitespace();
+    fields.next()?;
+    fields.next()?.parse().ok()
+}
+
+#[cfg(target_os = "linux")]
+fn proc_env_value(pid: u32, name: &str) -> Option<String> {
+    let environ = fs::read(format!("/proc/{pid}/environ")).ok()?;
+    env_value_from_environ(&environ, name)
+}
+
+fn env_value_from_environ(environ: &[u8], name: &str) -> Option<String> {
+    let prefix = format!("{name}=");
+    environ
+        .split(|byte| *byte == 0)
+        .filter_map(|part| std::str::from_utf8(part).ok())
+        .find_map(|entry| entry.strip_prefix(&prefix).map(str::to_string))
+        .filter(|value| !value.trim().is_empty())
+}
+
+async fn run_hooks_command(
+    client: &mut Client,
+    args: &[String],
+    json_output: bool,
+) -> Result<CommandOutput> {
+    let Some(first) = args.first().map(String::as_str) else {
+        bail!(
+            "Usage: limux hooks setup [agent]|uninstall [agent]|<agent> install|uninstall|<event>"
+        );
+    };
+
+    match first {
+        "setup" | "install" => {
+            let target = parse_opt(args, "--agent").or_else(|| positional_arg(args, 1));
+            let installed = install_hook_targets(target.as_deref())?;
+            return hooks_summary_output("installed", installed, json_output);
+        }
+        "uninstall" => {
+            let target = parse_opt(args, "--agent").or_else(|| positional_arg(args, 1));
+            let changed = uninstall_hook_targets(target.as_deref())?;
+            return hooks_summary_output("uninstalled", changed, json_output);
+        }
+        _ => {}
+    }
+
+    let agent = agent_hooks::AgentKind::from_hook_name(first)
+        .ok_or_else(|| anyhow!("unknown hooks target: {first}"))?;
+    let rest = &args[1..];
+    match rest.first().map(String::as_str) {
+        Some("install") => {
+            install_hook_target(agent)?;
+            hooks_summary_output(
+                "installed",
+                vec![agent.store_name().to_string()],
+                json_output,
+            )
+        }
+        Some("uninstall") => {
+            uninstall_hook_target(agent)?;
+            hooks_summary_output(
+                "uninstalled",
+                vec![agent.store_name().to_string()],
+                json_output,
+            )
+        }
+        _ => {
+            let payload = run_agent_hook(client, agent, rest).await?;
+            if json_output {
+                Ok(CommandOutput::Json(payload))
+            } else {
+                Ok(CommandOutput::Text("OK".to_string()))
+            }
+        }
+    }
+}
+
+fn hooks_summary_output(
+    action: &str,
+    agents: Vec<String>,
+    json_output: bool,
+) -> Result<CommandOutput> {
+    if json_output {
+        Ok(CommandOutput::Json(json!({
+            "action": action,
+            "agents": agents,
+        })))
+    } else {
+        Ok(CommandOutput::Text(format!(
+            "OK {action}: {}",
+            if agents.is_empty() {
+                "none".to_string()
+            } else {
+                agents.join(", ")
+            }
+        )))
+    }
+}
+
+fn install_hook_targets(target: Option<&str>) -> Result<Vec<String>> {
+    let agents = target
+        .map(|name| {
+            agent_hooks::AgentKind::from_hook_name(name)
+                .ok_or_else(|| anyhow!("unknown hooks target: {name}"))
+                .map(|agent| vec![agent])
+        })
+        .transpose()?
+        .unwrap_or_else(|| {
+            vec![
+                agent_hooks::AgentKind::Codex,
+                agent_hooks::AgentKind::Claude,
+                agent_hooks::AgentKind::OpenCode,
+            ]
+        });
+
+    let mut installed = Vec::new();
+    for agent in agents {
+        install_hook_target(agent)?;
+        installed.push(agent.store_name().to_string());
+    }
+    Ok(installed)
+}
+
+fn uninstall_hook_targets(target: Option<&str>) -> Result<Vec<String>> {
+    let agents = target
+        .map(|name| {
+            agent_hooks::AgentKind::from_hook_name(name)
+                .ok_or_else(|| anyhow!("unknown hooks target: {name}"))
+                .map(|agent| vec![agent])
+        })
+        .transpose()?
+        .unwrap_or_else(|| {
+            vec![
+                agent_hooks::AgentKind::Codex,
+                agent_hooks::AgentKind::Claude,
+                agent_hooks::AgentKind::OpenCode,
+            ]
+        });
+
+    let mut changed = Vec::new();
+    for agent in agents {
+        uninstall_hook_target(agent)?;
+        changed.push(agent.store_name().to_string());
+    }
+    Ok(changed)
+}
+
+fn install_hook_target(agent: agent_hooks::AgentKind) -> Result<()> {
+    match agent {
+        agent_hooks::AgentKind::Codex => install_json_hooks(
+            &codex_hooks_path(),
+            agent,
+            &[
+                ("SessionStart", "session-start"),
+                ("UserPromptSubmit", "prompt-submit"),
+                ("Stop", "stop"),
+            ],
+        ),
+        agent_hooks::AgentKind::Claude => install_json_hooks(
+            &claude_settings_path(),
+            agent,
+            &[
+                ("SessionStart", "session-start"),
+                ("UserPromptSubmit", "prompt-submit"),
+                ("Stop", "stop"),
+                ("Notification", "stop"),
+                ("SessionEnd", "session-end"),
+            ],
+        ),
+        agent_hooks::AgentKind::OpenCode => install_opencode_plugin(),
+        agent_hooks::AgentKind::Gemini => install_json_hooks(
+            &gemini_settings_path(),
+            agent,
+            &[
+                ("SessionStart", "session-start"),
+                ("BeforeAgent", "prompt-submit"),
+                ("AfterAgent", "stop"),
+                ("SessionEnd", "session-end"),
+            ],
+        ),
+    }
+}
+
+fn uninstall_hook_target(agent: agent_hooks::AgentKind) -> Result<()> {
+    match agent {
+        agent_hooks::AgentKind::Codex => uninstall_json_hooks(&codex_hooks_path(), agent),
+        agent_hooks::AgentKind::Claude => uninstall_json_hooks(&claude_settings_path(), agent),
+        agent_hooks::AgentKind::OpenCode => {
+            let path = opencode_plugin_path();
+            if path.exists() {
+                fs::remove_file(&path)
+                    .with_context(|| format!("failed to remove {}", path.display()))?;
+            }
+            opencode_config_unregister_plugin()
+        }
+        agent_hooks::AgentKind::Gemini => uninstall_json_hooks(&gemini_settings_path(), agent),
+    }
+}
+
+fn install_json_hooks(
+    path: &Path,
+    agent: agent_hooks::AgentKind,
+    events: &[(&str, &str)],
+) -> Result<()> {
+    let mut root = read_json_object(path)?;
+    let hooks = root
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let hooks = hooks
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("{} has non-object hooks field", path.display()))?;
+    let marker = hook_marker(agent);
+    for value in hooks.values_mut() {
+        if let Some(entries) = value.as_array_mut() {
+            entries.retain(|entry| !json_value_contains(entry, marker));
+        }
+    }
+    hooks.retain(|_, value| {
+        value
+            .as_array()
+            .map(|entries| !entries.is_empty())
+            .unwrap_or(true)
+    });
+
+    for (agent_event, limux_event) in events {
+        let entries = hooks
+            .entry((*agent_event).to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        let entries = entries
+            .as_array_mut()
+            .ok_or_else(|| anyhow!("{} hook {agent_event} is not an array", path.display()))?;
+        entries.retain(|entry| !json_value_contains(entry, marker));
+        let mut entry = json!({
+            "hooks": [{
+                "type": "command",
+                "command": hook_command(agent, limux_event)?,
+                "statusMessage": format!("Limux {} session restore", agent.label()),
+                "timeout": hook_timeout(agent)
+            }]
+        });
+        if matches!(agent, agent_hooks::AgentKind::Claude) {
+            entry["matcher"] = Value::String("*".to_string());
+        }
+        entries.push(entry);
+    }
+
+    write_json_object(path, &root)
+}
+
+fn hook_timeout(agent: agent_hooks::AgentKind) -> u64 {
+    match agent {
+        agent_hooks::AgentKind::Claude => 5,
+        agent_hooks::AgentKind::Codex | agent_hooks::AgentKind::Gemini => 5000,
+        agent_hooks::AgentKind::OpenCode => 0,
+    }
+}
+
+fn uninstall_json_hooks(path: &Path, agent: agent_hooks::AgentKind) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut root = read_json_object(path)?;
+    if let Some(hooks) = root.get_mut("hooks").and_then(Value::as_object_mut) {
+        let marker = hook_marker(agent);
+        for value in hooks.values_mut() {
+            if let Some(entries) = value.as_array_mut() {
+                entries.retain(|entry| !json_value_contains(entry, marker));
+            }
+        }
+        hooks.retain(|_, value| {
+            value
+                .as_array()
+                .map(|entries| !entries.is_empty())
+                .unwrap_or(true)
+        });
+    }
+    write_json_object(path, &root)
+}
+
+fn install_opencode_plugin() -> Result<()> {
+    let path = opencode_plugin_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, opencode_plugin_source()?).context("failed to write OpenCode plugin")?;
+    opencode_config_register_plugin(&path)
+}
+
+fn opencode_config_register_plugin(plugin_path: &Path) -> Result<()> {
+    let config_path = opencode_config_path();
+    let mut root = read_json_object(&config_path)?;
+    let plugins = root
+        .entry("plugin".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let plugins = plugins
+        .as_array_mut()
+        .ok_or_else(|| anyhow!("{} has non-array plugin field", config_path.display()))?;
+    let plugin_str = plugin_path.to_string_lossy().into_owned();
+    if !plugins.iter().any(|v| v.as_str() == Some(&plugin_str)) {
+        plugins.push(Value::String(plugin_str));
+    }
+    write_json_object(&config_path, &root)
+}
+
+fn opencode_config_unregister_plugin() -> Result<()> {
+    let config_path = opencode_config_path();
+    if !config_path.exists() {
+        return Ok(());
+    }
+    let plugin_path = opencode_plugin_path();
+    let plugin_str = plugin_path.to_string_lossy().into_owned();
+    let mut root = read_json_object(&config_path)?;
+    if let Some(plugins) = root.get_mut("plugin").and_then(Value::as_array_mut) {
+        plugins.retain(|v| v.as_str() != Some(&plugin_str));
+    }
+    write_json_object(&config_path, &root)
+}
+
+fn hook_command(agent: agent_hooks::AgentKind, event: &str) -> Result<String> {
+    let disable_var = format!(
+        "LIMUX_{}_HOOKS_DISABLED",
+        agent.store_name().to_ascii_uppercase()
+    );
+    let limux_command = hook_cli_command()?;
+    Ok(format!(
+        "[ \"${{{disable_var}:-}}\" != \"1\" ] && {limux_command} --json hooks {} {} || echo '{{\"continue\":true,\"suppressOutput\":false}}'",
+        agent.store_name(),
+        event
+    ))
+}
+
+fn hook_cli_command() -> Result<String> {
+    let exe = env::current_exe().context("failed to resolve current executable")?;
+    let file_name = exe
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    if file_name == "limux-cli" {
+        return Ok(shell_single_quote(&exe.to_string_lossy()));
+    }
+    Ok("limux".to_string())
+}
+
+fn opencode_plugin_cli_command() -> Result<String> {
+    let exe = env::current_exe().context("failed to resolve current executable")?;
+    let file_name = exe
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    if file_name == "limux-cli" {
+        return Ok(exe.to_string_lossy().to_string());
+    }
+    Ok("limux".to_string())
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn hook_marker(agent: agent_hooks::AgentKind) -> &'static str {
+    match agent {
+        agent_hooks::AgentKind::Claude => "hooks claude",
+        agent_hooks::AgentKind::Codex => "hooks codex",
+        agent_hooks::AgentKind::OpenCode => "hooks opencode",
+        agent_hooks::AgentKind::Gemini => "hooks gemini",
+    }
+}
+
+fn read_json_object(path: &Path) -> Result<Map<String, Value>> {
+    if !path.exists() {
+        return Ok(Map::new());
+    }
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    if raw.trim().is_empty() {
+        return Ok(Map::new());
+    }
+    let value: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| anyhow!("{} must contain a JSON object", path.display()))
+}
+
+fn write_json_object(path: &Path, object: &Map<String, Value>) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let temp = path.with_extension(format!("json.{}.tmp", std::process::id()));
+    let encoded = serde_json::to_vec_pretty(object).context("failed to encode hook config")?;
+    fs::write(&temp, encoded).with_context(|| format!("failed to write {}", temp.display()))?;
+    fs::rename(&temp, path).with_context(|| format!("failed to replace {}", path.display()))
+}
+
+fn json_value_contains(value: &Value, needle: &str) -> bool {
+    match value {
+        Value::String(value) => value.contains(needle),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_contains(value, needle)),
+        Value::Object(map) => map.values().any(|value| json_value_contains(value, needle)),
+        _ => false,
+    }
+}
+
+fn codex_hooks_path() -> PathBuf {
+    env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".codex")))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+        .join("hooks.json")
+}
+
+fn claude_settings_path() -> PathBuf {
+    env::var_os("CLAUDE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".claude")))
+        .unwrap_or_else(|| PathBuf::from(".claude"))
+        .join("settings.json")
+}
+
+fn gemini_settings_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".gemini/settings.json")
+}
+
+fn opencode_config_dir() -> PathBuf {
+    env::var_os("OPENCODE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config/opencode")))
+        .unwrap_or_else(|| PathBuf::from(".config/opencode"))
+}
+
+fn opencode_plugin_path() -> PathBuf {
+    opencode_config_dir().join("plugins/limux-session.js")
+}
+
+fn opencode_config_path() -> PathBuf {
+    opencode_config_dir().join("config.json")
+}
+
+fn opencode_plugin_source() -> Result<String> {
+    opencode_plugin_source_with_command(&opencode_plugin_cli_command()?)
+}
+
+fn opencode_plugin_source_with_command(limux_command: &str) -> Result<String> {
+    let limux_command_json =
+        serde_json::to_string(limux_command).context("failed to encode OpenCode hook command")?;
+    Ok(
+        r#"// limux-opencode-session-plugin v2
+// Installed by `limux hooks opencode install`. Do not edit manually.
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const LIMUX_COMMAND = __LIMUX_COMMAND__;
+
+function debug(outcome, details = {}) {
+  if (process.env.LIMUX_OPENCODE_HOOK_DEBUG !== "1" && outcome !== "spawn_failed") return;
+  try {
+    const dir = process.env.LIMUX_AGENT_HOOK_STATE_DIR || (process.env.XDG_STATE_HOME ? join(process.env.XDG_STATE_HOME, "limux") : join(process.env.HOME || ".", ".local/state/limux"));
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, "opencode-plugin-debug.jsonl"), JSON.stringify({
+      time: Date.now() / 1000,
+      outcome,
+      details
+    }) + "\n");
+  } catch (_) {}
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function props(event) {
+  return (event && typeof event === "object" && event.properties) || {};
+}
+
+function data(event) {
+  return (event && typeof event === "object" && event.data) || {};
+}
+
+function info(event) {
+  const p = props(event);
+  const d = data(event);
+  return (p.info && typeof p.info === "object" && p.info) || (d.info && typeof d.info === "object" && d.info) || {};
+}
+
+function eventType(event) {
+  const raw = firstString(event && event.type, event && event.name);
+  if (!raw) return null;
+  if (raw === "sync") return firstString(event && event.name);
+  return raw.endsWith(".1") ? raw.slice(0, -2) : raw;
+}
+
+function sessionId(event) {
+  const p = props(event);
+  const d = data(event);
+  const i = info(event);
+  return firstString(p.sessionID, p.sessionId, p.session_id, d.sessionID, d.sessionId, d.session_id, i.id, event && event.sessionID, event && event.sessionId);
+}
+
+function cwd(ctx, event) {
+  const p = props(event);
+  const d = data(event);
+  const i = info(event);
+  return firstString(p.cwd, p.directory, d.cwd, d.directory, i.directory, i.path, ctx && ctx.directory, process.cwd());
+}
+
+function launchExecutable() {
+  return firstString(process.env.LIMUX_OPENCODE_EXECUTABLE, "opencode");
+}
+
+function send(kind, ctx, event) {
+  if (process.env.LIMUX_OPENCODE_HOOKS_DISABLED === "1") {
+    debug("skip_disabled", { kind });
+    return;
+  }
+  if (!process.env.LIMUX_SURFACE_ID) {
+    debug("skip_missing_surface", { kind, type: eventType(event), hasWorkspace: !!process.env.LIMUX_WORKSPACE_ID });
+    return;
+  }
+  const sid = sessionId(event);
+  if (!sid) {
+    debug("skip_missing_session", { kind, type: eventType(event), keys: Object.keys(event || {}) });
+    return;
+  }
+  const type = eventType(event);
+  const payload = {
+    session_id: sid,
+    cwd: cwd(ctx, event),
+    hook_event_name: type,
+    event: type
+  };
+  try {
+    const command = process.env.LIMUX_BIN || LIMUX_COMMAND;
+    const result = spawnSync(command, ["hooks", "opencode", kind], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: 5000,
+      env: {
+        ...process.env,
+        LIMUX_AGENT_LAUNCH_ARGV: launchExecutable(),
+        LIMUX_AGENT_LAUNCH_EXECUTABLE: launchExecutable(),
+        LIMUX_AGENT_LAUNCH_CWD: cwd(ctx, event)
+      }
+    });
+    debug("spawned", { kind, type, status: result.status, error: result.error && String(result.error), command });
+  } catch (error) {
+    debug("spawn_failed", { kind, type, error: String(error) });
+  }
+}
+
+const limuxSessionRestore = async (ctx) => {
+  debug("plugin_started", { directory: ctx && ctx.directory, hasSurface: !!process.env.LIMUX_SURFACE_ID, hasWorkspace: !!process.env.LIMUX_WORKSPACE_ID });
+  return {
+    event: async ({ event }) => {
+    const type = eventType(event);
+    debug("event", { type, rawType: event && event.type, rawName: event && event.name });
+    if (!type) return;
+    if (type === "session.created") send("session-start", ctx, event);
+    if (type === "session.idle" || type === "session.updated" || type === "session.status" || type === "session.compacted") send("prompt-submit", ctx, event);
+    if (type === "session.error") send("session-end", ctx, event);
+    if (type === "session.deleted") send("cleanup", ctx, event);
+    }
+  };
+};
+
+export const LimuxSessionRestore = limuxSessionRestore;
+export default limuxSessionRestore;
+"#
+        .replace("__LIMUX_COMMAND__", &limux_command_json),
+    )
 }
 
 async fn run_new_workspace(client: &mut Client, args: &[String]) -> Result<Value> {
@@ -2446,9 +3366,9 @@ async fn execute_command(client: &mut Client, opts: &GlobalOptions) -> Result<Co
         }
         "claude-hook" | "opencode-hook" | "gemini-hook" => {
             let agent = match command {
-                "claude-hook" => AgentKind::Claude,
-                "opencode-hook" => AgentKind::OpenCode,
-                "gemini-hook" => AgentKind::Gemini,
+                "claude-hook" => agent_hooks::AgentKind::Claude,
+                "opencode-hook" => agent_hooks::AgentKind::OpenCode,
+                "gemini-hook" => agent_hooks::AgentKind::Gemini,
                 _ => unreachable!(),
             };
             let payload = run_agent_hook(client, agent, args).await?;
@@ -2458,6 +3378,7 @@ async fn execute_command(client: &mut Client, opts: &GlobalOptions) -> Result<Co
                 CommandOutput::Text("OK".to_string())
             }
         }
+        "hooks" => return run_hooks_command(client, args, opts.json_output).await,
         "new-workspace" => {
             let payload = run_new_workspace(client, args).await?;
             if opts.json_output {
@@ -2699,6 +3620,178 @@ mod cli_arg_tests {
         let payload = json!({ "hook_event_name": "Notification" });
 
         assert_eq!(parse_hook_event(&args, &payload), "Stop");
+    }
+
+    #[test]
+    fn external_session_end_preserves_restorable_hook_session() {
+        assert_eq!(
+            agent_hook_persistence_action("SessionEnd"),
+            AgentHookPersistenceAction::Preserve
+        );
+        assert_eq!(
+            agent_hook_persistence_action("session-end"),
+            AgentHookPersistenceAction::Preserve
+        );
+    }
+
+    #[test]
+    fn internal_cleanup_removes_restorable_hook_session() {
+        assert_eq!(
+            agent_hook_persistence_action("cleanup"),
+            AgentHookPersistenceAction::Remove
+        );
+        assert_eq!(
+            agent_hook_persistence_action("restore-exit"),
+            AgentHookPersistenceAction::Remove
+        );
+    }
+
+    #[test]
+    fn opencode_plugin_embeds_installer_cli_command() {
+        let source = opencode_plugin_source_with_command("/tmp/limux-cli").expect("plugin source");
+
+        assert!(source.contains("const LIMUX_COMMAND = \"/tmp/limux-cli\";"));
+        assert!(source.contains("process.env.LIMUX_BIN || LIMUX_COMMAND"));
+        assert!(!source.contains("process.env.LIMUX_BIN || \"limux\""));
+    }
+
+    #[test]
+    fn opencode_plugin_removes_only_deleted_sessions() {
+        let source = opencode_plugin_source_with_command("/tmp/limux-cli").expect("plugin source");
+
+        assert!(
+            source.contains("if (type === \"session.error\") send(\"session-end\", ctx, event);")
+        );
+        assert!(source.contains("if (type === \"session.deleted\") send(\"cleanup\", ctx, event);"));
+        assert!(source.contains("type === \"session.status\""));
+        assert!(source.contains("type === \"session.compacted\""));
+    }
+
+    #[test]
+    fn stop_hook_output_matches_codex_schema_shape() {
+        let output = agent_hook_output("stop", &json!({ "session_id": "session-a" }));
+
+        assert_eq!(
+            output,
+            json!({
+                "continue": true,
+                "suppressOutput": false
+            })
+        );
+    }
+
+    #[test]
+    fn session_start_hook_output_uses_camel_case_specific_output() {
+        let output = agent_hook_output(
+            "session-start",
+            &json!({ "additionalContext": "Limux session restore tracking active." }),
+        );
+
+        assert_eq!(
+            output,
+            json!({
+                "continue": true,
+                "suppressOutput": false,
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": "Limux session restore tracking active."
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn claude_hook_install_writes_required_matcher() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+
+        install_json_hooks(
+            &path,
+            agent_hooks::AgentKind::Claude,
+            &[("SessionStart", "session-start")],
+        )
+        .expect("install hooks");
+
+        let root: Value =
+            serde_json::from_slice(&fs::read(&path).expect("read settings")).expect("json");
+        let entry = &root["hooks"]["SessionStart"][0];
+        assert_eq!(entry["matcher"], "*");
+        assert_eq!(entry["hooks"][0]["timeout"], 5);
+        assert!(entry["hooks"][0]["command"]
+            .as_str()
+            .expect("command")
+            .contains("hooks claude session-start"));
+    }
+
+    #[test]
+    fn codex_hook_install_keeps_codex_schema_without_matcher() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("hooks.json");
+
+        install_json_hooks(
+            &path,
+            agent_hooks::AgentKind::Codex,
+            &[("SessionStart", "session-start")],
+        )
+        .expect("install hooks");
+
+        let root: Value =
+            serde_json::from_slice(&fs::read(&path).expect("read hooks")).expect("json");
+        let entry = &root["hooks"]["SessionStart"][0];
+        assert!(entry.get("matcher").is_none());
+        assert_eq!(entry["hooks"][0]["timeout"], 5000);
+        assert!(entry["hooks"][0]["command"]
+            .as_str()
+            .expect("command")
+            .contains("hooks codex session-start"));
+    }
+
+    #[test]
+    fn environ_parser_reads_requested_limux_value() {
+        let environ = b"PATH=/bin\0LIMUX_WORKSPACE_ID=ws-1\0LIMUX_SURFACE_ID=7:tab-a\0";
+
+        assert_eq!(
+            env_value_from_environ(environ, "LIMUX_WORKSPACE_ID").as_deref(),
+            Some("ws-1")
+        );
+        assert_eq!(
+            env_value_from_environ(environ, "LIMUX_SURFACE_ID").as_deref(),
+            Some("7:tab-a")
+        );
+        assert_eq!(env_value_from_environ(environ, "LIMUX_PANE_ID"), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_stat_parser_handles_process_names_with_spaces() {
+        let stat = "1234 (claude hook sh) S 987 1 1 0 -1 4194560";
+
+        assert_eq!(parse_proc_stat_parent_pid(stat), Some(987));
+    }
+
+    #[test]
+    fn hook_session_id_falls_back_to_transcript_stem() {
+        let payload = json!({
+            "transcript_path": "/home/amwill/.claude/projects/-home-amwill-Applications-limux/268746f1-5a8f-471c-85db-dc50649c2f9c.jsonl"
+        });
+
+        assert_eq!(
+            hook_session_id(&payload).as_deref(),
+            Some("268746f1-5a8f-471c-85db-dc50649c2f9c")
+        );
+    }
+
+    #[test]
+    fn hook_session_id_prefers_explicit_session_id() {
+        let payload = json!({
+            "session_id": "explicit-session",
+            "transcript_path": "/tmp/transcript-session.jsonl"
+        });
+
+        assert_eq!(
+            hook_session_id(&payload).as_deref(),
+            Some("explicit-session")
+        );
     }
 }
 

--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -48,6 +50,8 @@ pub struct AppSessionState {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct WorkspaceState {
+    #[serde(default)]
+    pub id: Option<String>,
     pub name: String,
     #[serde(default)]
     pub favorite: bool,
@@ -84,6 +88,8 @@ pub enum SplitOrientation {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct PaneState {
     #[serde(default)]
+    pub pane_id: Option<u32>,
+    #[serde(default)]
     pub active_tab_id: Option<String>,
     #[serde(default)]
     pub tabs: Vec<TabState>,
@@ -100,12 +106,90 @@ pub struct TabState {
     pub content: TabContentState,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RestorableAgentKind {
+    Claude,
+    Codex,
+    OpenCode,
+    Gemini,
+}
+
+impl RestorableAgentKind {
+    pub fn resume_command(
+        self,
+        session_id: &str,
+        launch_command: Option<&AgentLaunchCommandState>,
+        cwd: Option<&str>,
+    ) -> Option<String> {
+        build_resume_command(self, session_id, launch_command, cwd)
+    }
+
+    fn fallback_executable(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+            Self::Gemini => "gemini",
+        }
+    }
+
+    fn store_name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::OpenCode => "opencode",
+            Self::Gemini => "gemini",
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct AgentLaunchCommandState {
+    pub executable: String,
+    #[serde(default)]
+    pub arguments: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub environment: BTreeMap<String, String>,
+    #[serde(default)]
+    pub captured_at: Option<f64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct RestorableAgentState {
+    pub kind: RestorableAgentKind,
+    pub session_id: String,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub launch_command: Option<AgentLaunchCommandState>,
+    #[serde(default)]
+    pub restore_on_startup: bool,
+}
+
+impl RestorableAgentState {
+    pub fn resume_command(&self) -> Option<String> {
+        if !self.restore_on_startup {
+            return None;
+        }
+        self.kind.resume_command(
+            &self.session_id,
+            self.launch_command.as_ref(),
+            self.cwd.as_deref(),
+        )
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "tab_kind", rename_all = "snake_case")]
 pub enum TabContentState {
     Terminal {
         #[serde(default)]
         cwd: Option<String>,
+        #[serde(default)]
+        agent: Option<RestorableAgentState>,
     },
     Browser {
         #[serde(default)]
@@ -150,6 +234,7 @@ impl PaneState {
     pub fn fallback(working_directory: Option<&str>) -> Self {
         let tab = TabState::terminal(default_tab_id("terminal"), working_directory);
         Self {
+            pane_id: None,
             active_tab_id: Some(tab.id.clone()),
             tabs: vec![tab],
         }
@@ -158,6 +243,7 @@ impl PaneState {
     pub fn browser_only(uri: Option<&str>) -> Self {
         let tab = TabState::browser(default_tab_id("browser"), uri);
         Self {
+            pane_id: None,
             active_tab_id: Some(tab.id.clone()),
             tabs: vec![tab],
         }
@@ -172,6 +258,7 @@ impl TabState {
             pinned: false,
             content: TabContentState::Terminal {
                 cwd: cwd.map(|value| value.to_string()),
+                agent: None,
             },
         }
     }
@@ -346,6 +433,7 @@ impl AppSessionState {
                     .or(workspace.cwd.as_deref());
                 let tab = TabState::terminal(default_tab_id("legacy-terminal"), working_directory);
                 WorkspaceState {
+                    id: None,
                     name: workspace.name,
                     favorite: workspace.favorite,
                     cwd: workspace.cwd,
@@ -354,6 +442,7 @@ impl AppSessionState {
                     // last known directory instead of pretending process state can be restored.
                     layout: LayoutNodeState::Pane(PaneState {
                         active_tab_id: Some(tab.id.clone()),
+                        pane_id: None,
                         tabs: vec![tab],
                     }),
                 }
@@ -364,6 +453,192 @@ impl AppSessionState {
             ..Self::default()
         })
     }
+}
+
+#[derive(serde::Deserialize)]
+struct HookSessionRecord {
+    session_id: String,
+    workspace_id: String,
+    surface_id: String,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    launch_command: Option<AgentLaunchCommandState>,
+    updated_at: f64,
+}
+
+#[derive(serde::Deserialize)]
+struct HookSessionFile {
+    #[serde(default)]
+    sessions: BTreeMap<String, HookSessionRecord>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RestorableAgentIndex {
+    by_surface: HashMap<(String, String), (RestorableAgentState, f64)>,
+    by_any_workspace_surface: HashMap<String, (RestorableAgentState, f64)>,
+    by_tab_id: HashMap<String, (RestorableAgentState, f64)>,
+}
+
+impl RestorableAgentIndex {
+    pub fn load() -> Self {
+        Self::load_from_dir(&agent_hook_state_dir())
+    }
+
+    pub fn load_from_dir(dir: &Path) -> Self {
+        let mut index = Self::default();
+        for (kind, file_name) in [
+            (RestorableAgentKind::Claude, "claude-hook-sessions.json"),
+            (RestorableAgentKind::Codex, "codex-hook-sessions.json"),
+            (RestorableAgentKind::OpenCode, "opencode-hook-sessions.json"),
+            (RestorableAgentKind::Gemini, "gemini-hook-sessions.json"),
+        ] {
+            let path = dir.join(file_name);
+            let Ok(raw) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(file) = serde_json::from_str::<HookSessionFile>(&raw) else {
+                continue;
+            };
+            for record in file.sessions.values() {
+                let Some(session_id) = normalized_str(&record.session_id) else {
+                    continue;
+                };
+                let Some(workspace_id) = normalized_str(&record.workspace_id) else {
+                    continue;
+                };
+                let Some(surface_id) = normalized_str(&record.surface_id) else {
+                    continue;
+                };
+                let tab_id = surface_id
+                    .rsplit_once(':')
+                    .map(|(_, tab_id)| tab_id.to_string());
+                let key = (workspace_id, surface_id);
+                if index
+                    .by_surface
+                    .get(&key)
+                    .is_some_and(|(_, updated_at)| *updated_at > record.updated_at)
+                {
+                    continue;
+                }
+                index.by_surface.insert(
+                    key.clone(),
+                    (
+                        RestorableAgentState {
+                            kind,
+                            session_id: session_id.clone(),
+                            cwd: record.cwd.clone(),
+                            launch_command: record.launch_command.clone(),
+                            restore_on_startup: true,
+                        },
+                        record.updated_at,
+                    ),
+                );
+                let latest_for_surface = index
+                    .by_any_workspace_surface
+                    .get(&key.1)
+                    .is_some_and(|(_, updated_at)| *updated_at > record.updated_at);
+                if !latest_for_surface {
+                    index.by_any_workspace_surface.insert(
+                        key.1,
+                        (
+                            RestorableAgentState {
+                                kind,
+                                session_id: session_id.clone(),
+                                cwd: record.cwd.clone(),
+                                launch_command: record.launch_command.clone(),
+                                restore_on_startup: true,
+                            },
+                            record.updated_at,
+                        ),
+                    );
+                }
+                if let Some(tab_id) = tab_id {
+                    let latest_for_tab = index
+                        .by_tab_id
+                        .get(&tab_id)
+                        .is_some_and(|(_, updated_at)| *updated_at > record.updated_at);
+                    if !latest_for_tab {
+                        index.by_tab_id.insert(
+                            tab_id,
+                            (
+                                RestorableAgentState {
+                                    kind,
+                                    session_id: session_id.clone(),
+                                    cwd: record.cwd.clone(),
+                                    launch_command: record.launch_command.clone(),
+                                    restore_on_startup: true,
+                                },
+                                record.updated_at,
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+        index
+    }
+
+    pub fn agent_for_surface(
+        &self,
+        workspace_id: &str,
+        pane_id: Option<u32>,
+        tab_id: &str,
+    ) -> Option<RestorableAgentState> {
+        let surface_id = pane_id.map(|pane_id| format!("{pane_id}:{tab_id}"));
+        surface_id
+            .as_ref()
+            .and_then(|surface_id| {
+                self.by_surface
+                    .get(&(workspace_id.to_string(), surface_id.clone()))
+                    .or_else(|| self.by_any_workspace_surface.get(surface_id))
+            })
+            .or_else(|| self.by_tab_id.get(tab_id))
+            .map(|(agent, _)| agent.clone())
+    }
+}
+
+pub fn attach_restorable_agents_to_layout(
+    layout: &mut LayoutNodeState,
+    workspace_id: &str,
+    index: &RestorableAgentIndex,
+) {
+    match layout {
+        LayoutNodeState::Pane(pane) => {
+            for tab in &mut pane.tabs {
+                if let TabContentState::Terminal { agent, .. } = &mut tab.content {
+                    if agent
+                        .as_ref()
+                        .is_some_and(|agent| !agent.restore_on_startup)
+                    {
+                        continue;
+                    }
+                    if let Some(restored_agent) =
+                        index.agent_for_surface(workspace_id, pane.pane_id, &tab.id)
+                    {
+                        *agent = Some(restored_agent);
+                    }
+                }
+            }
+        }
+        LayoutNodeState::Split(split) => {
+            attach_restorable_agents_to_layout(&mut split.start, workspace_id, index);
+            attach_restorable_agents_to_layout(&mut split.end, workspace_id, index);
+        }
+    }
+}
+
+fn agent_hook_state_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("LIMUX_AGENT_HOOK_STATE_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Some(dir) = dirs::state_dir() {
+        return dir.join(PERSISTENCE_DIR_NAME);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".local/state")
+        .join(PERSISTENCE_DIR_NAME)
 }
 
 fn temp_session_path(path: &Path) -> PathBuf {
@@ -399,6 +674,207 @@ fn default_split_ratio() -> f64 {
 
 fn default_tab_id(prefix: &str) -> String {
     format!("{prefix}-0")
+}
+
+fn build_resume_command(
+    kind: RestorableAgentKind,
+    session_id: &str,
+    launch: Option<&AgentLaunchCommandState>,
+    cwd: Option<&str>,
+) -> Option<String> {
+    let session_id = normalized_str(session_id)?;
+    let fallback = kind.fallback_executable().to_string();
+    let args = launch
+        .map(|launch| launch.arguments.clone())
+        .filter(|args| !args.is_empty())
+        .unwrap_or_else(|| vec![fallback.clone()]);
+    let sanitized = sanitize_launch_arguments(kind, &args);
+    let executable = launch
+        .and_then(|launch| normalized_str(&launch.executable))
+        .or_else(|| sanitized.first().cloned())
+        .unwrap_or(fallback);
+    let preserved_tail = sanitized
+        .get(1..)
+        .map(|tail| tail.to_vec())
+        .unwrap_or_default();
+
+    let mut parts = vec![executable];
+    match kind {
+        RestorableAgentKind::Codex => {
+            parts.push("resume".to_string());
+            parts.extend(preserved_tail);
+            parts.push(session_id.clone());
+        }
+        RestorableAgentKind::OpenCode => {
+            parts.push("--session".to_string());
+            parts.push(session_id.clone());
+            parts.extend(preserved_tail);
+        }
+        RestorableAgentKind::Claude | RestorableAgentKind::Gemini => {
+            parts.push("--resume".to_string());
+            parts.push(session_id.clone());
+            parts.extend(preserved_tail);
+        }
+    }
+
+    let command = parts
+        .iter()
+        .map(|part| shell_single_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let cwd = cwd.and_then(normalized_str).or_else(|| {
+        launch
+            .and_then(|launch| launch.cwd.as_deref())
+            .and_then(normalized_str)
+    });
+    let run_command = match cwd {
+        Some(cwd) => format!("cd {} && {command}", shell_single_quote(&cwd)),
+        None => command,
+    };
+    Some(wrap_restored_agent_command(kind, &session_id, &run_command))
+}
+
+fn wrap_restored_agent_command(
+    kind: RestorableAgentKind,
+    session_id: &str,
+    run_command: &str,
+) -> String {
+    let payload = format!(
+        "{{\"session_id\":{},\"hook_event_name\":\"Cleanup\"}}",
+        serde_json::to_string(session_id).unwrap_or_else(|_| "\"\"".to_string())
+    );
+    let cleanup = format!(
+        "printf %s {} | {} --json hooks {} cleanup >/dev/null 2>&1 || true",
+        shell_single_quote(&payload),
+        shell_single_quote(&limux_cli_executable()),
+        kind.store_name()
+    );
+    format!("{run_command}; limux_agent_status=$?; {cleanup}; exec \"${{SHELL:-/bin/sh}}\" -l")
+}
+
+fn limux_cli_executable() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| {
+            let candidate = path.with_file_name("limux-cli");
+            candidate.exists().then_some(candidate)
+        })
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| "limux-cli".to_string())
+}
+
+fn sanitize_launch_arguments(kind: RestorableAgentKind, arguments: &[String]) -> Vec<String> {
+    if arguments.is_empty() {
+        return vec![kind.fallback_executable().to_string()];
+    }
+    let mut result = Vec::new();
+    let mut index = 0;
+    while index < arguments.len() {
+        let arg = &arguments[index];
+        if index == 0 {
+            result.push(arg.clone());
+            index += 1;
+            continue;
+        }
+        if is_resume_selector(kind, arg) || option_takes_secret_value(arg) {
+            index += 1;
+            if index < arguments.len() && !arguments[index].starts_with('-') {
+                index += 1;
+            }
+            continue;
+        }
+        if option_is_secret_assignment(arg) {
+            index += 1;
+            continue;
+        }
+        if option_takes_safe_value(arg) {
+            result.push(arg.clone());
+            if index + 1 < arguments.len() {
+                result.push(arguments[index + 1].clone());
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if option_is_safe_flag_or_assignment(arg) {
+            result.push(arg.clone());
+            index += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+    result
+}
+
+fn is_resume_selector(kind: RestorableAgentKind, arg: &str) -> bool {
+    match kind {
+        RestorableAgentKind::Codex => {
+            arg == "resume" || arg == "--resume" || arg.starts_with("--resume=")
+        }
+        RestorableAgentKind::OpenCode => arg == "--session" || arg.starts_with("--session="),
+        RestorableAgentKind::Claude | RestorableAgentKind::Gemini => {
+            arg == "--resume" || arg.starts_with("--resume=") || arg == "--continue"
+        }
+    }
+}
+
+fn option_takes_secret_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--api-key" | "--apikey" | "--token" | "--auth-token" | "--password"
+    )
+}
+
+fn option_is_secret_assignment(arg: &str) -> bool {
+    let lower = arg.to_ascii_lowercase();
+    lower.starts_with("--api-key=")
+        || lower.starts_with("--apikey=")
+        || lower.starts_with("--token=")
+        || lower.starts_with("--auth-token=")
+        || lower.starts_with("--password=")
+}
+
+fn option_takes_safe_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--model"
+            | "-m"
+            | "--config"
+            | "-c"
+            | "--profile"
+            | "--sandbox"
+            | "--approval-policy"
+            | "--cwd"
+            | "--cd"
+            | "--working-directory"
+    )
+}
+
+fn option_is_safe_flag_or_assignment(arg: &str) -> bool {
+    if matches!(
+        arg,
+        "--dangerously-bypass-approvals-and-sandbox" | "--dangerously-skip-permissions"
+    ) {
+        return true;
+    }
+    let Some((name, _)) = arg.split_once('=') else {
+        return false;
+    };
+    option_takes_safe_value(name)
+}
+
+fn normalized_str(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]
@@ -465,6 +941,7 @@ mod tests {
 
         let canonical = AppSessionState {
             workspaces: vec![WorkspaceState {
+                id: Some("11111111-1111-4111-8111-111111111111".to_string()),
                 name: "canonical".to_string(),
                 favorite: true,
                 cwd: Some("/canonical".to_string()),
@@ -520,7 +997,7 @@ mod tests {
         };
         assert_eq!(pane.tabs.len(), 1);
         match &pane.tabs[0].content {
-            TabContentState::Terminal { cwd } => {
+            TabContentState::Terminal { cwd, .. } => {
                 assert_eq!(cwd.as_deref(), Some("/tmp/project"));
             }
             other => panic!("expected terminal tab, got {other:?}"),
@@ -565,6 +1042,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let state = AppSessionState {
             workspaces: vec![WorkspaceState {
+                id: Some("22222222-2222-4222-8222-222222222222".to_string()),
                 name: "workspace".to_string(),
                 favorite: false,
                 cwd: Some("/tmp".to_string()),
@@ -580,12 +1058,337 @@ mod tests {
         let decoded: AppSessionState =
             serde_json::from_str(&raw).expect("decode canonical session");
         assert_eq!(decoded.version, SESSION_VERSION);
+        assert_eq!(
+            decoded.workspaces[0].id.as_deref(),
+            Some("22222222-2222-4222-8222-222222222222")
+        );
         assert_eq!(decoded.workspaces[0].name, "workspace");
+    }
+
+    #[test]
+    fn workspace_id_defaults_for_legacy_session_json() {
+        let raw = r#"{
+            "version": 1,
+            "workspaces": [{
+                "name": "legacy-shape",
+                "favorite": false,
+                "layout": {
+                    "kind": "pane",
+                    "active_tab_id": "terminal-0",
+                    "tabs": [{
+                        "id": "terminal-0",
+                        "tab_kind": "terminal",
+                        "cwd": "/tmp/project"
+                    }]
+                }
+            }]
+        }"#;
+
+        let decoded: AppSessionState = serde_json::from_str(raw).expect("decode legacy shape");
+        assert_eq!(decoded.workspaces[0].id, None);
+    }
+
+    #[test]
+    fn hook_index_attaches_agent_to_matching_workspace_surface() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("codex-hook-sessions.json"),
+            r#"{
+                "version": 1,
+                "sessions": {
+                    "session-a": {
+                        "session_id": "session-a",
+                        "workspace_id": "workspace-a",
+                        "surface_id": "42:tab-a",
+                        "cwd": "/tmp/project",
+                        "pid": 1,
+                        "launch_command": {
+                            "executable": "codex",
+                            "arguments": ["codex"],
+                            "cwd": "/tmp/project",
+                            "environment": {},
+                            "captured_at": 10.0
+                        },
+                        "updated_at": 10.0
+                    }
+                }
+            }"#,
+        )
+        .expect("write hook state");
+        let index = RestorableAgentIndex::load_from_dir(dir.path());
+        let mut layout = LayoutNodeState::Pane(PaneState {
+            pane_id: Some(42),
+            active_tab_id: Some("tab-a".to_string()),
+            tabs: vec![TabState::terminal("tab-a", Some("/tmp/project"))],
+        });
+
+        attach_restorable_agents_to_layout(&mut layout, "workspace-a", &index);
+
+        let LayoutNodeState::Pane(pane) = layout else {
+            panic!("expected pane");
+        };
+        match &pane.tabs[0].content {
+            TabContentState::Terminal { agent, .. } => {
+                let agent = agent.as_ref().expect("agent metadata");
+                assert_eq!(agent.kind, RestorableAgentKind::Codex);
+                assert_eq!(agent.session_id, "session-a");
+                let command = agent.resume_command().expect("resume command");
+                assert!(command.contains("cd '/tmp/project' && 'codex' 'resume' 'session-a'"));
+                assert!(command.contains("hooks codex cleanup"));
+            }
+            other => panic!("expected terminal tab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hook_index_falls_back_to_surface_when_workspace_id_drifted() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("codex-hook-sessions.json"),
+            r#"{
+                "version": 1,
+                "sessions": {
+                    "session-a": {
+                        "session_id": "session-a",
+                        "workspace_id": "old-workspace",
+                        "surface_id": "42:tab-a",
+                        "cwd": "/tmp/project",
+                        "pid": 1,
+                        "launch_command": {
+                            "executable": "codex",
+                            "arguments": ["codex"],
+                            "cwd": "/tmp/project",
+                            "environment": {},
+                            "captured_at": 10.0
+                        },
+                        "updated_at": 10.0
+                    }
+                }
+            }"#,
+        )
+        .expect("write hook state");
+        let index = RestorableAgentIndex::load_from_dir(dir.path());
+
+        let agent = index
+            .agent_for_surface("new-workspace", Some(42), "tab-a")
+            .expect("agent by surface fallback");
+        assert_eq!(agent.kind, RestorableAgentKind::Codex);
+        assert_eq!(agent.session_id, "session-a");
+    }
+
+    #[test]
+    fn hook_index_falls_back_to_tab_id_when_pane_id_is_missing() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("codex-hook-sessions.json"),
+            r#"{
+                "version": 1,
+                "sessions": {
+                    "session-a": {
+                        "session_id": "session-a",
+                        "workspace_id": "old-workspace",
+                        "surface_id": "42:tab-a",
+                        "cwd": "/tmp/project",
+                        "pid": 1,
+                        "launch_command": {
+                            "executable": "codex",
+                            "arguments": ["codex"],
+                            "cwd": "/tmp/project",
+                            "environment": {},
+                            "captured_at": 10.0
+                        },
+                        "updated_at": 10.0
+                    }
+                }
+            }"#,
+        )
+        .expect("write hook state");
+        let index = RestorableAgentIndex::load_from_dir(dir.path());
+
+        let agent = index
+            .agent_for_surface("new-workspace", None, "tab-a")
+            .expect("agent by tab id fallback");
+        assert_eq!(agent.kind, RestorableAgentKind::Codex);
+        assert_eq!(agent.session_id, "session-a");
+    }
+
+    #[test]
+    fn hook_merge_preserves_persisted_agent_when_index_misses() {
+        let index = RestorableAgentIndex::default();
+        let mut layout = LayoutNodeState::Pane(PaneState {
+            pane_id: Some(42),
+            active_tab_id: Some("tab-a".to_string()),
+            tabs: vec![TabState {
+                id: "tab-a".to_string(),
+                custom_name: None,
+                pinned: false,
+                content: TabContentState::Terminal {
+                    cwd: Some("/tmp/project".to_string()),
+                    agent: Some(RestorableAgentState {
+                        kind: RestorableAgentKind::Codex,
+                        session_id: "persisted-session".to_string(),
+                        cwd: Some("/tmp/project".to_string()),
+                        launch_command: None,
+                        restore_on_startup: true,
+                    }),
+                },
+            }],
+        });
+
+        attach_restorable_agents_to_layout(&mut layout, "workspace-a", &index);
+
+        let LayoutNodeState::Pane(pane) = layout else {
+            panic!("expected pane");
+        };
+        match &pane.tabs[0].content {
+            TabContentState::Terminal { agent, .. } => {
+                assert_eq!(
+                    agent.as_ref().map(|agent| agent.session_id.as_str()),
+                    Some("persisted-session")
+                );
+            }
+            other => panic!("expected terminal tab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hook_merge_recovers_agent_without_workspace_or_pane_id() {
+        let dir = tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("codex-hook-sessions.json"),
+            r#"{
+                "version": 1,
+                "sessions": {
+                    "session-a": {
+                        "session_id": "session-a",
+                        "workspace_id": "old-workspace",
+                        "surface_id": "42:tab-a",
+                        "cwd": "/tmp/project",
+                        "pid": 1,
+                        "launch_command": {
+                            "executable": "codex",
+                            "arguments": ["codex"],
+                            "cwd": "/tmp/project",
+                            "environment": {},
+                            "captured_at": 10.0
+                        },
+                        "updated_at": 10.0
+                    }
+                }
+            }"#,
+        )
+        .expect("write hook state");
+        let index = RestorableAgentIndex::load_from_dir(dir.path());
+        let mut layout = LayoutNodeState::Pane(PaneState {
+            pane_id: None,
+            active_tab_id: Some("tab-a".to_string()),
+            tabs: vec![TabState::terminal("tab-a", Some("/tmp/project"))],
+        });
+
+        attach_restorable_agents_to_layout(&mut layout, "", &index);
+
+        let LayoutNodeState::Pane(pane) = layout else {
+            panic!("expected pane");
+        };
+        match &pane.tabs[0].content {
+            TabContentState::Terminal { agent, .. } => {
+                assert_eq!(
+                    agent.as_ref().map(|agent| agent.session_id.as_str()),
+                    Some("session-a")
+                );
+            }
+            other => panic!("expected terminal tab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn terminal_tab_state_round_trips_restorable_agent_metadata() {
+        let tab = TabState {
+            id: "tab-a".to_string(),
+            custom_name: None,
+            pinned: false,
+            content: TabContentState::Terminal {
+                cwd: Some("/tmp/project".to_string()),
+                agent: Some(RestorableAgentState {
+                    kind: RestorableAgentKind::Codex,
+                    session_id: "sess-123".to_string(),
+                    cwd: Some("/tmp/project".to_string()),
+                    launch_command: Some(AgentLaunchCommandState {
+                        executable: "codex".to_string(),
+                        arguments: vec![
+                            "codex".to_string(),
+                            "--model".to_string(),
+                            "gpt-5.5".to_string(),
+                        ],
+                        cwd: Some("/tmp/project".to_string()),
+                        environment: Default::default(),
+                        captured_at: Some(12.0),
+                    }),
+                    restore_on_startup: true,
+                }),
+            },
+        };
+
+        let raw = serde_json::to_string(&tab).expect("encode tab");
+        let decoded: TabState = serde_json::from_str(&raw).expect("decode tab");
+
+        match decoded.content {
+            TabContentState::Terminal { agent, .. } => {
+                let agent = agent.expect("agent metadata");
+                assert_eq!(agent.kind, RestorableAgentKind::Codex);
+                assert_eq!(agent.session_id, "sess-123");
+                assert_eq!(
+                    agent
+                        .launch_command
+                        .expect("launch command")
+                        .arguments
+                        .as_slice(),
+                    ["codex", "--model", "gpt-5.5"]
+                );
+            }
+            other => panic!("expected terminal tab, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn restorable_agent_resume_command_runs_from_cwd() {
+        let agent = RestorableAgentState {
+            kind: RestorableAgentKind::Codex,
+            session_id: "sess-123".to_string(),
+            cwd: Some("/tmp/project".to_string()),
+            launch_command: Some(AgentLaunchCommandState {
+                executable: "codex".to_string(),
+                arguments: vec!["codex".to_string()],
+                cwd: Some("/tmp/project".to_string()),
+                environment: Default::default(),
+                captured_at: Some(12.0),
+            }),
+            restore_on_startup: true,
+        };
+
+        let command = agent.resume_command().expect("resume command");
+        assert!(command.contains("cd '/tmp/project' && 'codex' 'resume' 'sess-123'"));
+        assert!(command.contains("hooks codex cleanup"));
+        assert!(command.contains("exec \"${SHELL:-/bin/sh}\" -l"));
+    }
+
+    #[test]
+    fn legacy_restorable_agent_without_restore_marker_does_not_resume() {
+        let agent = RestorableAgentState {
+            kind: RestorableAgentKind::Codex,
+            session_id: "old-stale-session".to_string(),
+            cwd: Some("/tmp/project".to_string()),
+            launch_command: None,
+            restore_on_startup: false,
+        };
+
+        assert_eq!(agent.resume_command(), None);
     }
 
     #[test]
     fn normalize_layout_falls_back_to_first_tab_when_active_tab_is_stale() {
         let mut layout = LayoutNodeState::Pane(PaneState {
+            pane_id: None,
             active_tab_id: Some("missing".to_string()),
             tabs: vec![TabState {
                 id: "browser-1".to_string(),
@@ -608,6 +1411,7 @@ mod tests {
     #[test]
     fn normalize_layout_rebuilds_empty_pane_from_working_directory() {
         let mut layout = LayoutNodeState::Pane(PaneState {
+            pane_id: None,
             active_tab_id: None,
             tabs: Vec::new(),
         });
@@ -619,7 +1423,7 @@ mod tests {
         };
         assert_eq!(pane.tabs.len(), 1);
         match &pane.tabs[0].content {
-            TabContentState::Terminal { cwd } => {
+            TabContentState::Terminal { cwd, .. } => {
                 assert_eq!(cwd.as_deref(), Some("/tmp/project"));
             }
             other => panic!("expected terminal fallback, got {other:?}"),
@@ -645,11 +1449,13 @@ mod tests {
         let state = AppSessionState {
             top_bar_visible: false,
             workspaces: vec![WorkspaceState {
+                id: Some("33333333-3333-4333-8333-333333333333".to_string()),
                 name: "workspace".to_string(),
                 favorite: false,
                 cwd: None,
                 folder_path: None,
                 layout: LayoutNodeState::Pane(PaneState {
+                    pane_id: None,
                     active_tab_id: Some("keybinds-1".to_string()),
                     tabs: vec![TabState {
                         id: "keybinds-1".to_string(),

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -17,7 +17,9 @@ use webkit6::prelude::*;
 
 use crate::app_config::AppConfig;
 use crate::keybind_editor;
-use crate::layout_state::{PaneState, TabContentState, TabState as SavedTabState};
+use crate::layout_state::{
+    PaneState, RestorableAgentState, TabContentState, TabState as SavedTabState,
+};
 use crate::settings_editor;
 use crate::shortcut_config::{NormalizedShortcut, ResolvedShortcutConfig, ShortcutId};
 use crate::terminal::{self, TerminalCallbacks};
@@ -868,6 +870,7 @@ struct TerminalTabOptions<'a> {
     custom_name: Option<&'a str>,
     pinned: bool,
     cwd: Option<&'a str>,
+    agent: Option<RestorableAgentState>,
 }
 
 struct BrowserTabOptions<'a> {
@@ -901,7 +904,7 @@ fn restore_tabs_from_state(
 
     for saved_tab in &saved_state.tabs {
         match &saved_tab.content {
-            TabContentState::Terminal { cwd } => add_terminal_tab_inner(
+            TabContentState::Terminal { cwd, agent } => add_terminal_tab_inner(
                 internals,
                 cwd.as_deref().or(working_directory),
                 Some(TerminalTabOptions {
@@ -909,6 +912,7 @@ fn restore_tabs_from_state(
                     custom_name: saved_tab.custom_name.as_deref(),
                     pinned: saved_tab.pinned,
                     cwd: cwd.as_deref().or(working_directory),
+                    agent: agent.clone(),
                 }),
             ),
             TabContentState::Browser { uri } => add_browser_tab_inner(
@@ -1124,12 +1128,23 @@ fn add_terminal_tab_inner(
     {
         extra_env.push(("LIMUX_SOCKET".to_string(), sock.to_string()));
     }
+    let startup_command = options
+        .as_ref()
+        .and_then(|value| value.agent.as_ref())
+        .and_then(|agent| agent.resume_command());
+    if let Some(command) = startup_command.as_deref() {
+        eprintln!(
+            "limux: restoring agent terminal surface={}:{} command={}",
+            internals.pane_id, tab_id, command
+        );
+    }
 
     let term = terminal::create_terminal(
         working_directory,
         terminal::TerminalOptions {
             hover_focus,
             saved_font_size: (internals.callbacks.current_config)().borrow().font_size,
+            startup_command,
             extra_env,
         },
         term_callbacks,
@@ -1450,6 +1465,7 @@ pub fn snapshot_pane_state(pane_widget: &gtk::Widget) -> Option<PaneState> {
             let content = match &entry.kind {
                 TabKind::Terminal { state } => TabContentState::Terminal {
                     cwd: state.cwd.borrow().clone(),
+                    agent: None,
                 },
                 TabKind::Browser { state } => TabContentState::Browser {
                     uri: state.uri.borrow().clone(),
@@ -1465,6 +1481,7 @@ pub fn snapshot_pane_state(pane_widget: &gtk::Widget) -> Option<PaneState> {
         })
         .collect();
     Some(PaneState {
+        pane_id: Some(internals.pane_id),
         active_tab_id: ts.active_tab.clone(),
         tabs,
     })

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -857,6 +857,7 @@ pub struct TerminalCallbacks {
 pub struct TerminalOptions {
     pub hover_focus: Rc<dyn Fn() -> bool>,
     pub saved_font_size: Option<f32>,
+    pub startup_command: Option<String>,
     /// Extra environment variables to expose to the spawned shell
     /// (e.g. `LIMUX_WORKSPACE_ID`, `LIMUX_SURFACE_ID`, `LIMUX_PANE_ID`, `LIMUX_SOCKET`).
     ///
@@ -872,6 +873,7 @@ impl Default for TerminalOptions {
         Self {
             hover_focus: Rc::new(|| false),
             saved_font_size: None,
+            startup_command: None,
             extra_env: Vec::new(),
         }
     }
@@ -906,6 +908,7 @@ pub fn create_terminal(
 
     let wd = working_directory.map(|s| s.to_string());
     let saved_font_size = options.saved_font_size;
+    let startup_command = options.startup_command;
     let hover_focus = options.hover_focus;
     let extra_env = options.extra_env;
     let callbacks = Rc::new(RefCell::new(callbacks));
@@ -1067,6 +1070,17 @@ pub fn create_terminal(
             if !env_vars_raw.is_empty() {
                 config.env_vars = env_vars_raw.as_mut_ptr();
                 config.env_var_count = env_vars_raw.len();
+            }
+
+            let c_startup_command = startup_command
+                .as_ref()
+                .and_then(|command| CString::new(command.as_str()).ok());
+            if let Some(ref command) = c_startup_command {
+                config.command = command.as_ptr();
+                eprintln!(
+                    "limux: starting restored terminal command={}",
+                    command.to_string_lossy()
+                );
             }
 
             let surface = unsafe { ghostty_surface_new(app, &config) };

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -739,13 +739,21 @@ fn suspend_persistence(state: &State, suspended: bool) {
     state.borrow_mut().persistence_suspended = suspended;
 }
 
-fn apply_loaded_session(state: &State, loaded: LoadedSession) {
+fn apply_loaded_session(state: &State, mut loaded: LoadedSession) {
     suspend_persistence(state, true);
 
     apply_top_bar_state_immediately(state, loaded.state.top_bar_visible);
 
     let restored_any = !loaded.state.workspaces.is_empty();
     if restored_any {
+        let restorable_agents = layout_state::RestorableAgentIndex::load();
+        for workspace in &mut loaded.state.workspaces {
+            layout_state::attach_restorable_agents_to_layout(
+                &mut workspace.layout,
+                workspace.id.as_deref().unwrap_or(""),
+                &restorable_agents,
+            );
+        }
         for workspace in &loaded.state.workspaces {
             add_workspace_from_state(state, workspace);
         }
@@ -810,6 +818,7 @@ fn apply_top_bar_state_immediately(state: &State, visible: bool) {
 
 fn snapshot_session_state(state: &State) -> AppSessionState {
     let s = state.borrow();
+    let restorable_agents = layout_state::RestorableAgentIndex::load();
     let sidebar_visible = sidebar_is_visible(&s);
     let sidebar_width = if sidebar_visible {
         s.paned.position()
@@ -825,15 +834,22 @@ fn snapshot_session_state(state: &State) -> AppSessionState {
             let cwd = workspace.cwd.borrow().clone();
             let folder_path = workspace.folder_path.clone();
             let working_directory = folder_path.clone().or(cwd.clone());
+            let mut layout = workspace
+                .split_container
+                .tree()
+                .snapshot(working_directory.as_deref());
+            layout_state::attach_restorable_agents_to_layout(
+                &mut layout,
+                &workspace.id,
+                &restorable_agents,
+            );
             WorkspaceState {
+                id: Some(workspace.id.clone()),
                 name: workspace.name.clone(),
                 favorite: workspace.favorite,
                 cwd,
                 folder_path,
-                layout: workspace
-                    .split_container
-                    .tree()
-                    .snapshot(working_directory.as_deref()),
+                layout,
             }
         })
         .collect();
@@ -3271,6 +3287,7 @@ fn show_legacy_workspace_folder_dialog(state: &State, window: Option<&gtk::Windo
 
 fn create_workspace_with_folder(state: &State, name: &str, folder_path: &str) {
     let workspace = WorkspaceState {
+        id: None,
         name: name.to_string(),
         favorite: false,
         cwd: Some(folder_path.to_string()),
@@ -3808,7 +3825,12 @@ fn add_workspace_from_state(state: &State, workspace: &WorkspaceState) {
         let s = state.borrow();
         (s.stack.clone(), s.sidebar_list.clone())
     };
-    let id = uuid::Uuid::new_v4().to_string();
+    let id = workspace
+        .id
+        .as_deref()
+        .filter(|id| uuid::Uuid::parse_str(id).is_ok())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let stack_name = format!("ws-{id}");
     let working_dir = workspace
         .folder_path


### PR DESCRIPTION
**Why**
- Preserve agent hook session metadata so restored Limux workspaces can resume active agent sessions.
- Include the new agent_hooks module so the CLI crate builds from a clean checkout.

**How**
- Adds hook session storage and install/uninstall helpers for supported agents.
- Persists restorable agent metadata into session layout state and starts restored terminal commands.
- Includes focused tests for hook storage, config installation, and session restore behavior.

**Tests**
- cargo fmt --check
- cargo test -p limux-cli
- cargo test -p limux-host-linux
- cargo check -p limux-host-linux