### PR TITLE
docs: add agent hook templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Repository maintainability rules live in [`docs/maintainability.md`](docs/mainta
 
 ## Agent integrations
 
-Limux ships first-class hooks for coding agents (Codex, Claude Code,
-OpenCode, Gemini CLI). Every terminal limux spawns auto-exports
+Limux ships first-class hooks for coding agents (Codex, Claude Code, and
+Gemini CLI). Every terminal limux spawns auto-exports
 `LIMUX_WORKSPACE_ID` / `LIMUX_SURFACE_ID` / `LIMUX_PANE_ID` /
 `LIMUX_TAB_ID` / `LIMUX_SOCKET`, so the CLI auto-targets the right place
 with no flags needed from inside the agent's own terminal.
@@ -117,9 +117,11 @@ with no flags needed from inside the agent's own terminal.
 # Fire a libadwaita toast + sidebar unread badge from any agent
 limux notify --subtitle "needs review" --body "blocked on auth choice" "Input needed"
 
-# Drop-in hook handlers — translate hook JSON on stdin into notify/send
+# Install Limux session-restore hooks for supported agents
+limux hooks setup
+
+# Drop-in hook handlers translate hook JSON on stdin into notify/session state
 echo '{"event":"stop"}' | limux claude-hook --event stop
-echo '{"event":"tool_use","tool":"bash"}' | limux opencode-hook --event tool_use
 echo '{"event":"finished"}' | limux gemini-hook --event finished
 
 # Spin up a multi-agent collaboration team — one workspace per agent,
@@ -147,6 +149,10 @@ limux send --workspace "$LIMUX_WORKSPACE_ID" --surface "<peer-surface-id>" \
 
 See the auto-generated `AGENTS.md` (written into the shared cwd) for
 the full protocol spec, peer table, and editable Policies section.
+
+Checked-in hook templates live in [`hooks/`](hooks/). They mirror
+`limux hooks setup` for Codex, Claude Code, and Gemini CLI; OpenCode is
+omitted until its hook integration is ready.
 
 Coding agents working on **limux itself** should read [`AGENTS.md`](AGENTS.md)
 and [`CLAUDE.md`](CLAUDE.md) in the repo root — those cover the build

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,35 @@
+# Limux Agent Hooks
+
+These templates wire supported coding-agent hook systems into Limux session
+restore tracking. They are intentionally limited to Codex, Claude Code, and
+Gemini CLI until the OpenCode hook path is ready.
+
+The preferred install path is the CLI installer:
+
+```bash
+limux hooks setup
+```
+
+That writes the equivalent configuration into each agent's user config:
+
+| Agent | Destination |
+|---|---|
+| Codex | `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json` |
+| Claude Code | `$CLAUDE_CONFIG_DIR/settings.json` or `~/.claude/settings.json` |
+| Gemini CLI | `~/.gemini/settings.json` |
+
+Use the files in this directory as canonical examples when reviewing or
+manually repairing an agent config:
+
+- `codex-hooks.json`
+- `claude-settings.json`
+- `gemini-settings.json`
+
+Each command calls `limux --json hooks <agent> <event>` and is guarded by a
+per-agent disable variable:
+
+```bash
+LIMUX_CODEX_HOOKS_DISABLED=1
+LIMUX_CLAUDE_HOOKS_DISABLED=1
+LIMUX_GEMINI_HOOKS_DISABLED=1
+```

--- a/hooks/claude-settings.json
+++ b/hooks/claude-settings.json
@@ -1,0 +1,69 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CLAUDE_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks claude session-start || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Claude session restore",
+            "timeout": 5
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CLAUDE_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks claude prompt-submit || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Claude session restore",
+            "timeout": 5
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CLAUDE_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks claude stop || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Claude session restore",
+            "timeout": 5
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CLAUDE_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks claude stop || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Claude session restore",
+            "timeout": 5
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CLAUDE_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks claude session-end || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Claude session restore",
+            "timeout": 5
+          }
+        ],
+        "matcher": "*"
+      }
+    ]
+  }
+}

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CODEX_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks codex session-start || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Codex session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CODEX_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks codex prompt-submit || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Codex session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_CODEX_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks codex stop || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Codex session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/gemini-settings.json
+++ b/hooks/gemini-settings.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_GEMINI_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks gemini session-start || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Gemini session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_GEMINI_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks gemini prompt-submit || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Gemini session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_GEMINI_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks gemini stop || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Gemini session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ \"${LIMUX_GEMINI_HOOKS_DISABLED:-}\" != \"1\" ] && limux --json hooks gemini session-end || echo '{\"continue\":true,\"suppressOutput\":false}'",
+            "statusMessage": "Limux Gemini session restore",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -1352,13 +1352,7 @@ fn install_hook_targets(target: Option<&str>) -> Result<Vec<String>> {
                 .map(|agent| vec![agent])
         })
         .transpose()?
-        .unwrap_or_else(|| {
-            vec![
-                agent_hooks::AgentKind::Codex,
-                agent_hooks::AgentKind::Claude,
-                agent_hooks::AgentKind::OpenCode,
-            ]
-        });
+        .unwrap_or_else(default_hook_targets);
 
     let mut installed = Vec::new();
     for agent in agents {
@@ -1376,13 +1370,7 @@ fn uninstall_hook_targets(target: Option<&str>) -> Result<Vec<String>> {
                 .map(|agent| vec![agent])
         })
         .transpose()?
-        .unwrap_or_else(|| {
-            vec![
-                agent_hooks::AgentKind::Codex,
-                agent_hooks::AgentKind::Claude,
-                agent_hooks::AgentKind::OpenCode,
-            ]
-        });
+        .unwrap_or_else(default_hook_targets);
 
     let mut changed = Vec::new();
     for agent in agents {
@@ -1390,6 +1378,14 @@ fn uninstall_hook_targets(target: Option<&str>) -> Result<Vec<String>> {
         changed.push(agent.store_name().to_string());
     }
     Ok(changed)
+}
+
+fn default_hook_targets() -> Vec<agent_hooks::AgentKind> {
+    vec![
+        agent_hooks::AgentKind::Codex,
+        agent_hooks::AgentKind::Claude,
+        agent_hooks::AgentKind::Gemini,
+    ]
 }
 
 fn install_hook_target(agent: agent_hooks::AgentKind) -> Result<()> {
@@ -3644,6 +3640,19 @@ mod cli_arg_tests {
             agent_hook_persistence_action("restore-exit"),
             AgentHookPersistenceAction::Remove
         );
+    }
+
+    #[test]
+    fn default_hook_setup_omits_opencode_until_supported() {
+        assert_eq!(
+            default_hook_targets(),
+            vec![
+                agent_hooks::AgentKind::Codex,
+                agent_hooks::AgentKind::Claude,
+                agent_hooks::AgentKind::Gemini,
+            ]
+        );
+        assert!(!default_hook_targets().contains(&agent_hooks::AgentKind::OpenCode));
     }
 
     #[test]


### PR DESCRIPTION
**Why**
- Check in canonical hook templates for supported Limux agent session-restore integrations.
- Avoid advertising OpenCode hooks until that path is working.

**How**
- Adds hooks/ templates for Codex, Claude Code, and Gemini CLI.
- Documents limux hooks setup and template locations in README docs.
- Updates default hook setup/uninstall targets to Codex, Claude, and Gemini.

**Tests**
- jq empty hooks/codex-hooks.json hooks/claude-settings.json hooks/gemini-settings.json
- cargo fmt --check
- cargo test -p limux-cli
- git diff --check