### PR TITLE
fix: clarify AppImage release compatibility floor

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   packages:
+    name: Build tarball, deb, and AppImage on Ubuntu 24.04
     runs-on: ubuntu-24.04
 
     steps:
@@ -67,6 +68,16 @@ jobs:
           meson setup /tmp/blueprint-compiler/_build /tmp/blueprint-compiler --prefix /tmp/blueprint-prefix
           meson install -C /tmp/blueprint-compiler/_build
           echo "/tmp/blueprint-prefix/bin" >> "$GITHUB_PATH"
+
+      - name: Verify release glibc floor
+        run: |
+          set -euo pipefail
+          expected="2.39"
+          actual="$(ldd --version | sed -n '1s/.* //p')"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Linux release packages must be built on the Ubuntu 24.04 GLIBC_${expected} floor, got GLIBC_${actual}."
+            exit 1
+          fi
 
       - name: Install appimagetool
         run: |

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ Download the latest release from [GitHub Releases](https://github.com/am-will/li
 sudo dpkg -i ./limux_0.1.14_amd64.deb
 ```
 
-**AppImage** — portable, no install needed:
+**AppImage** — portable across Ubuntu 24.04-era desktops and newer, no install needed:
 ```bash
 chmod +x Limux-0.1.14-x86_64.AppImage
 ./Limux-0.1.14-x86_64.AppImage
 ```
+
+Release AppImages are built and checked on the Ubuntu 24.04 `GLIBC_2.39`
+floor. Limux still uses the host GTK4, libadwaita, and WebKitGTK runtime
+libraries, so older distributions may need the `.deb`, tarball, or a source
+build with matching system packages instead.
 
 **Tarball** — manual install:
 ```bash

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -70,7 +70,7 @@ assert_glibc_compatibility() {
 
     if version_gt "$required_glibc" "$MAX_GLIBC_VERSION"; then
         echo "ERROR: ${label} requires GLIBC_${required_glibc}, which exceeds the supported release baseline GLIBC_${MAX_GLIBC_VERSION}."
-        echo "Build release artifacts inside Ubuntu 24.04 or another environment pinned to GLIBC_${MAX_GLIBC_VERSION} or older."
+        echo "Build release artifacts inside an environment pinned to GLIBC_${MAX_GLIBC_VERSION}."
         echo "Override the baseline intentionally with LIMUX_MAX_GLIBC=<version> if you are targeting a newer distro on purpose."
         exit 1
     fi


### PR DESCRIPTION
## Why
- Address issue #49 follow-up by making the AppImage release floor explicit instead of implying universal portability.
- Fail Linux release packaging if the GitHub runner drifts away from the Ubuntu 24.04 GLIBC_2.39 baseline.

## How
- Adds a release workflow guard that asserts the expected glibc floor before package creation.
- Updates package diagnostics to reference the configured glibc baseline.
- Documents that AppImages still depend on host GTK4/libadwaita/WebKitGTK runtime libraries.

## Tests
- bash -n scripts/package.sh: pass
- yq '.' .github/workflows/release-linux.yml: pass
- git diff --check -- .github/workflows/release-linux.yml scripts/package.sh README.md: pass
- Independent review agent: no findings