### PR TITLE
fix: suspend hover focus during tab rename

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2163,7 +2163,7 @@ fn show_rename_dialog(
     entry.grab_focus();
     entry.select_region(0, -1);
 
-    // On activate (Enter) or focus-out, commit rename
+    // On activate (Enter) or blur, commit rename.
     let lbl = label.clone();
     let state = tab_state.clone();
     let tid = tab_id.to_string();
@@ -2208,15 +2208,18 @@ fn show_rename_dialog(
     }
     {
         let do_rename = do_rename.clone();
-        let focus_controller = gtk::EventControllerFocus::new();
-        focus_controller.connect_leave(move |ctrl| {
-            if let Some(widget) = ctrl.widget() {
-                if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
-                    do_rename(entry);
-                }
+        entry.connect_notify_local(Some("has-focus"), move |entry, _| {
+            if entry.has_focus() {
+                return;
             }
+            let do_rename = do_rename.clone();
+            let entry = entry.clone();
+            glib::idle_add_local_once(move || {
+                if !entry.has_focus() {
+                    do_rename(&entry);
+                }
+            });
         });
-        entry.add_controller(focus_controller);
     }
 }
 

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2054,8 +2054,9 @@ fn show_tab_context_menu(tab_btn: &gtk::Box, tab_id: &str, context: &TabContextM
         let menu_ref = menu.clone();
         let callbacks = context.callbacks.clone();
         rename_btn.connect_clicked(move |_| {
+            let hover_focus_guard = terminal::suspend_hover_focus();
             menu_ref.popdown();
-            show_rename_dialog(&lbl, &state, &tid, &callbacks);
+            show_rename_dialog(&lbl, &state, &tid, &callbacks, hover_focus_guard);
         });
     }
 
@@ -2138,6 +2139,7 @@ fn show_rename_dialog(
     tab_state: &Rc<RefCell<TabState>>,
     tab_id: &str,
     callbacks: &Rc<PaneCallbacks>,
+    hover_focus_guard: terminal::HoverFocusGuard,
 ) {
     let current_name = label.label().to_string();
 
@@ -2168,6 +2170,7 @@ fn show_rename_dialog(
     let parent_for_cleanup = parent.clone();
 
     let commit = Rc::new(std::cell::Cell::new(false));
+    let hover_focus_guard = Rc::new(RefCell::new(Some(hover_focus_guard)));
 
     let do_rename = {
         let commit = commit.clone();
@@ -2176,6 +2179,7 @@ fn show_rename_dialog(
         let tid = tid.clone();
         let parent = parent_for_cleanup.clone();
         let callbacks = callbacks.clone();
+        let hover_focus_guard = hover_focus_guard.clone();
         move |entry: &gtk::Entry| {
             if commit.get() {
                 return;
@@ -2191,6 +2195,7 @@ fn show_rename_dialog(
             }
             lbl.set_visible(true);
             parent.remove(entry);
+            hover_focus_guard.borrow_mut().take();
             (callbacks.on_state_changed)();
         }
     };

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -52,6 +52,19 @@ pub struct TerminalIdentity {
     pub surface_id: String,
 }
 
+pub(crate) struct HoverFocusGuard;
+
+impl Drop for HoverFocusGuard {
+    fn drop(&mut self) {
+        HOVER_FOCUS_SUPPRESS_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
+pub(crate) fn suspend_hover_focus() -> HoverFocusGuard {
+    HOVER_FOCUS_SUPPRESS_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+    HoverFocusGuard
+}
+
 /// Per-surface state, stored in a global registry keyed by surface pointer.
 struct SurfaceEntry {
     gl_area: gtk::GLArea,
@@ -160,6 +173,7 @@ impl TerminalImeState {
 }
 
 thread_local! {
+    static HOVER_FOCUS_SUPPRESS_DEPTH: Cell<usize> = const { Cell::new(0) };
     static SURFACE_MAP: RefCell<HashMap<usize, SurfaceEntry>> = RefCell::new(HashMap::new());
 }
 
@@ -1684,7 +1698,7 @@ pub fn create_terminal(
         let had_focus = had_focus.clone();
         let motion = gtk::EventControllerMotion::new();
         motion.connect_enter(move |ctrl, x, y| {
-            if (hover_focus)() {
+            if HOVER_FOCUS_SUPPRESS_DEPTH.with(|depth| depth.get() == 0) && (hover_focus)() {
                 // Match common Hyprland/Omarchy-style focus-follows-mouse behavior:
                 // as soon as the pointer enters a terminal, focus it so typing works
                 // immediately without an extra click.


### PR DESCRIPTION
Hi. First off, nice project. I like it and I use this everyday now.

I noticed that when "Hover terminal focus" toggle is enabled I could not rename tabs without accidentally focusing on  terminal. So I couldn't type inside the tab rename text field (which is bug 1), nor could I focus back at it (which is bug 2). This change attempts to fix both.

## Bug 1
The way I implemented is to try a skip the hover focus code path by checking if any tab (~~one or more .. so had to use a counter~~ ¹) is in "rename" state. I don't know if this was the cleanest fix, and I know zero rust (did c++ before but not rust), and codex did helped me through.

¹ after my fix of bug 2 it can only be 1 tab in rename state at a time .. so this was a bit too defensive .. but changing it from counter to boolean doesn't reduce LoC either, so 🤷‍♂️ going to keep it the way it is

## Bug 2
On checking code for this bug, I realized the code was meant to exit rename state on focus exit. But it remained in a partial exited state as you can see in this video:
https://github.com/user-attachments/assets/80348bf2-113c-4b76-ac53-8a21c512ef89

My understanding is that one cant just mutate tab state within `connect_leave` event as GTK focus transitioning hasn't fully finished yet, and that's why this bug happens. You have to wait a bit. So my idea is 1. dont even rely on that event, rather watch for `has-focus` becoming false as that feels more stable state and 2. then add a GTK idle state callback to exit from the "rename" state.

