### PR TITLE
feat: add Pi agent hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Checked-in JSON hook templates live in [`hooks/`](hooks/). They mirror
 a generated extension under `~/.pi/agent/extensions/`; OpenCode is omitted
 from default setup until its hook integration is ready.
 
+After installing Pi hooks, restart any already-running Pi session so it loads
+the generated extension. Set `LIMUX_PI_HOOKS_DISABLED=1` to disable the Pi
+extension without uninstalling it.
+
 Coding agents working on **limux itself** should read [`AGENTS.md`](AGENTS.md)
 and [`CLAUDE.md`](CLAUDE.md) in the repo root — those cover the build
 loop, crate map, and the `feat/cmux-parity` roadmap tracked in

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Repository maintainability rules live in [`docs/maintainability.md`](docs/mainta
 
 ## Agent integrations
 
-Limux ships first-class hooks for coding agents (Codex, Claude Code, and
-Gemini CLI). Every terminal limux spawns auto-exports
+Limux ships first-class hooks for coding agents (Codex, Claude Code, Gemini
+CLI, and Pi). Every terminal limux spawns auto-exports
 `LIMUX_WORKSPACE_ID` / `LIMUX_SURFACE_ID` / `LIMUX_PANE_ID` /
 `LIMUX_TAB_ID` / `LIMUX_SOCKET`, so the CLI auto-targets the right place
 with no flags needed from inside the agent's own terminal.
@@ -128,6 +128,7 @@ limux hooks setup
 # Drop-in hook handlers translate hook JSON on stdin into notify/session state
 echo '{"event":"stop"}' | limux claude-hook --event stop
 echo '{"event":"finished"}' | limux gemini-hook --event finished
+echo '{"event":"stop"}' | limux pi-hook --event stop
 
 # Spin up a multi-agent collaboration team — one workspace per agent,
 # launches each agent's CLI, and writes AGENTS.md describing the
@@ -155,9 +156,10 @@ limux send --workspace "$LIMUX_WORKSPACE_ID" --surface "<peer-surface-id>" \
 See the auto-generated `AGENTS.md` (written into the shared cwd) for
 the full protocol spec, peer table, and editable Policies section.
 
-Checked-in hook templates live in [`hooks/`](hooks/). They mirror
-`limux hooks setup` for Codex, Claude Code, and Gemini CLI; OpenCode is
-omitted until its hook integration is ready.
+Checked-in JSON hook templates live in [`hooks/`](hooks/). They mirror
+`limux hooks setup` for Codex, Claude Code, and Gemini CLI. Pi is installed as
+a generated extension under `~/.pi/agent/extensions/`; OpenCode is omitted
+from default setup until its hook integration is ready.
 
 Coding agents working on **limux itself** should read [`AGENTS.md`](AGENTS.md)
 and [`CLAUDE.md`](CLAUDE.md) in the repo root — those cover the build

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -33,6 +33,9 @@ Regenerate it with:
 limux hooks pi install
 ```
 
+Restart any already-running Pi session after installing so Pi loads the
+extension. New Pi sessions will load it automatically.
+
 Each command calls `limux --json hooks <agent> <event>` and is guarded by a
 per-agent disable variable:
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,8 +1,8 @@
 # Limux Agent Hooks
 
 These templates wire supported coding-agent hook systems into Limux session
-restore tracking. They are intentionally limited to Codex, Claude Code, and
-Gemini CLI until the OpenCode hook path is ready.
+restore tracking. Default setup covers Codex, Claude Code, Gemini CLI, and Pi.
+OpenCode remains omitted from default setup until its hook path is ready.
 
 The preferred install path is the CLI installer:
 
@@ -17,13 +17,21 @@ That writes the equivalent configuration into each agent's user config:
 | Codex | `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json` |
 | Claude Code | `$CLAUDE_CONFIG_DIR/settings.json` or `~/.claude/settings.json` |
 | Gemini CLI | `~/.gemini/settings.json` |
+| Pi | `~/.pi/agent/extensions/limux-hooks.ts` |
 
 Use the files in this directory as canonical examples when reviewing or
-manually repairing an agent config:
+manually repairing JSON-based agent configs:
 
 - `codex-hooks.json`
 - `claude-settings.json`
 - `gemini-settings.json`
+
+Pi uses a generated TypeScript extension instead of a checked-in JSON template.
+Regenerate it with:
+
+```bash
+limux hooks pi install
+```
 
 Each command calls `limux --json hooks <agent> <event>` and is guarded by a
 per-agent disable variable:
@@ -32,4 +40,5 @@ per-agent disable variable:
 LIMUX_CODEX_HOOKS_DISABLED=1
 LIMUX_CLAUDE_HOOKS_DISABLED=1
 LIMUX_GEMINI_HOOKS_DISABLED=1
+LIMUX_PI_HOOKS_DISABLED=1
 ```

--- a/rust/limux-cli/src/agent_hooks.rs
+++ b/rust/limux-cli/src/agent_hooks.rs
@@ -14,6 +14,7 @@ pub(crate) enum AgentKind {
     Codex,
     OpenCode,
     Gemini,
+    Pi,
 }
 
 impl AgentKind {
@@ -23,6 +24,7 @@ impl AgentKind {
             "codex" => Some(Self::Codex),
             "opencode" | "open-code" => Some(Self::OpenCode),
             "gemini" => Some(Self::Gemini),
+            "pi" | "pi-coding-agent" | "pi-coding" => Some(Self::Pi),
             _ => None,
         }
     }
@@ -33,6 +35,7 @@ impl AgentKind {
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
             Self::Gemini => "gemini",
+            Self::Pi => "pi",
         }
     }
 
@@ -42,6 +45,7 @@ impl AgentKind {
             Self::Codex => "Codex",
             Self::OpenCode => "OpenCode",
             Self::Gemini => "Gemini",
+            Self::Pi => "Pi",
         }
     }
 
@@ -51,6 +55,7 @@ impl AgentKind {
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
             Self::Gemini => "gemini",
+            Self::Pi => "pi",
         }
     }
 }
@@ -278,6 +283,11 @@ pub(crate) fn build_resume_command(
             parts.push(session_id);
             parts.extend(preserved_tail);
         }
+        AgentKind::Pi => {
+            parts.push("--session".to_string());
+            parts.push(session_id);
+            parts.extend(preserved_tail);
+        }
     }
 
     let command = parts
@@ -368,6 +378,12 @@ fn is_resume_selector(kind: AgentKind, arg: &str) -> bool {
         AgentKind::Claude | AgentKind::Gemini => {
             arg == "--resume" || arg.starts_with("--resume=") || arg == "--continue"
         }
+        AgentKind::Pi => {
+            arg == "--session"
+                || arg.starts_with("--session=")
+                || arg == "--continue"
+                || arg == "-c"
+        }
     }
 }
 
@@ -448,6 +464,8 @@ fn selected_environment() -> BTreeMap<String, String> {
         "CLAUDE_CONFIG_DIR",
         "OPENCODE_CONFIG_DIR",
         "GEMINI_CONFIG_DIR",
+        "PI_CODING_AGENT_DIR",
+        "PI_CODING_AGENT_SESSION_DIR",
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_MODEL",
         "ANTHROPIC_SMALL_FAST_MODEL",

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -198,8 +198,13 @@ fn parse_global_args() -> Result<GlobalOptions> {
 }
 
 fn print_help() {
-    println!(
+    print!(
+        "{}",
         "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+            .replace(
+                "hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name>",
+                "hooks setup [codex|claude|gemini|pi] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook | pi-hook --event <name>",
+            )
     );
 }
 
@@ -843,7 +848,7 @@ async fn run_notify(client: &mut Client, args: &[String]) -> Result<Value> {
 }
 
 // ---------------------------------------------------------------------------
-// Agent hooks (claude-hook / opencode-hook / gemini-hook)
+// Agent hooks (claude-hook / opencode-hook / gemini-hook / pi-hook)
 // ---------------------------------------------------------------------------
 //
 // These subcommands read a JSON hook event from stdin and translate it into
@@ -910,53 +915,7 @@ async fn run_agent_hook(
     // Build a human-friendly title + body depending on event + agent.
     let agent_label = agent.label();
     persist_agent_hook_session(agent, args, &payload, &event)?;
-    let (title, body) = match event.as_str() {
-        "Notification" => (
-            format!("{agent_label} needs you"),
-            hook_str(&payload, &["message", "notification"])
-                .unwrap_or("waiting for input")
-                .to_owned(),
-        ),
-        "Stop" | "SubagentStop" => (
-            format!("{agent_label} finished"),
-            hook_str(&payload, &["message", "reason"])
-                .unwrap_or("task complete")
-                .to_owned(),
-        ),
-        "SessionStart" => (
-            format!("{agent_label} session started"),
-            hook_str(&payload, &["cwd", "source"])
-                .unwrap_or("")
-                .to_owned(),
-        ),
-        "SessionEnd" => (
-            format!("{agent_label} session ended"),
-            hook_str(&payload, &["reason"]).unwrap_or("").to_owned(),
-        ),
-        "PreToolUse" | "PostToolUse" => (
-            format!(
-                "{agent_label}: {}",
-                hook_str(&payload, &["tool_name"]).unwrap_or("tool")
-            ),
-            hook_str(&payload, &["tool_input", "summary"])
-                .unwrap_or("")
-                .to_owned(),
-        ),
-        "UserPromptSubmit" => (
-            format!("{agent_label}: new prompt"),
-            hook_str(&payload, &["prompt"])
-                .unwrap_or("")
-                .chars()
-                .take(120)
-                .collect(),
-        ),
-        other => (
-            format!("{agent_label}: {other}"),
-            hook_str(&payload, &["message", "summary"])
-                .unwrap_or("")
-                .to_owned(),
-        ),
-    };
+    let (title, body) = agent_hook_notification_content(agent_label, &event, &payload);
 
     let subtitle = hook_str(&payload, &["session_id"])
         .map(|s| {
@@ -987,6 +946,68 @@ async fn run_agent_hook(
     .await;
 
     Ok(agent_hook_output(&event, &payload))
+}
+
+fn agent_hook_notification_content(
+    agent_label: &str,
+    event: &str,
+    payload: &Value,
+) -> (String, String) {
+    match canonical_agent_hook_display_event(event) {
+        AgentHookDisplayEvent::Notification => (
+            format!("{agent_label} needs you"),
+            hook_str(payload, &["message", "notification"])
+                .unwrap_or("waiting for input")
+                .to_owned(),
+        ),
+        AgentHookDisplayEvent::Stop => (
+            "Process needs attention".to_string(),
+            hook_str(payload, &["message", "reason"])
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("{agent_label} finished")),
+        ),
+        AgentHookDisplayEvent::SessionStart => (
+            format!("{agent_label} session started"),
+            hook_str(payload, &["cwd", "source"])
+                .unwrap_or("")
+                .to_owned(),
+        ),
+        AgentHookDisplayEvent::SessionEnd => (
+            format!("{agent_label} session ended"),
+            hook_str(payload, &["reason"]).unwrap_or("").to_owned(),
+        ),
+        AgentHookDisplayEvent::ToolUse => (
+            format!(
+                "{agent_label}: {}",
+                hook_str(payload, &["tool_name"]).unwrap_or("tool")
+            ),
+            hook_str(payload, &["tool_input", "summary"])
+                .unwrap_or("")
+                .to_owned(),
+        ),
+        AgentHookDisplayEvent::UserPromptSubmit => (
+            format!("{agent_label}: new prompt"),
+            hook_str(payload, &["prompt"])
+                .unwrap_or("")
+                .chars()
+                .take(120)
+                .collect(),
+        ),
+        AgentHookDisplayEvent::Other => {
+            let event_label = event.trim();
+            let event_label = if event_label.is_empty() {
+                "event"
+            } else {
+                event_label
+            };
+            (
+                format!("{agent_label}: {event_label}"),
+                hook_str(payload, &["message", "summary"])
+                    .unwrap_or("")
+                    .to_owned(),
+            )
+        }
+    }
 }
 
 fn agent_hook_output(event: &str, payload: &Value) -> Value {
@@ -1022,6 +1043,34 @@ fn canonical_hook_event_name(event: &str) -> Option<&'static str> {
         "SessionEnd" | "session-end" => None,
         "Cleanup" | "cleanup" | "restore-exit" => None,
         _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AgentHookDisplayEvent {
+    Notification,
+    Stop,
+    SessionStart,
+    SessionEnd,
+    ToolUse,
+    UserPromptSubmit,
+    Other,
+}
+
+fn canonical_agent_hook_display_event(event: &str) -> AgentHookDisplayEvent {
+    match event.trim() {
+        "Notification" | "notification" => AgentHookDisplayEvent::Notification,
+        "Stop" | "stop" | "SubagentStop" | "subagent-stop" | "subagent_stop" => {
+            AgentHookDisplayEvent::Stop
+        }
+        "SessionStart" | "session-start" | "session_start" => AgentHookDisplayEvent::SessionStart,
+        "SessionEnd" | "session-end" | "session_end" => AgentHookDisplayEvent::SessionEnd,
+        "PreToolUse" | "pre-tool-use" | "pre_tool_use" | "PostToolUse" | "post-tool-use"
+        | "post_tool_use" => AgentHookDisplayEvent::ToolUse,
+        "UserPromptSubmit" | "prompt-submit" | "user-prompt-submit" | "user_prompt_submit" => {
+            AgentHookDisplayEvent::UserPromptSubmit
+        }
+        _ => AgentHookDisplayEvent::Other,
     }
 }
 
@@ -1338,7 +1387,7 @@ async fn run_hooks_command(
 ) -> Result<CommandOutput> {
     let Some(first) = args.first().map(String::as_str) else {
         bail!(
-            "Usage: limux hooks setup [agent]|uninstall [agent]|<agent> install|uninstall|<event>"
+            "Usage: limux hooks setup [codex|claude|gemini|pi]|uninstall [agent]|<agent> install|uninstall|<event>"
         );
     };
 
@@ -1450,6 +1499,7 @@ fn default_hook_targets() -> Vec<agent_hooks::AgentKind> {
         agent_hooks::AgentKind::Codex,
         agent_hooks::AgentKind::Claude,
         agent_hooks::AgentKind::Gemini,
+        agent_hooks::AgentKind::Pi,
     ]
 }
 
@@ -1486,6 +1536,7 @@ fn install_hook_target(agent: agent_hooks::AgentKind) -> Result<()> {
                 ("SessionEnd", "session-end"),
             ],
         ),
+        agent_hooks::AgentKind::Pi => install_pi_extension(),
     }
 }
 
@@ -1502,6 +1553,7 @@ fn uninstall_hook_target(agent: agent_hooks::AgentKind) -> Result<()> {
             opencode_config_unregister_plugin()
         }
         agent_hooks::AgentKind::Gemini => uninstall_json_hooks(&gemini_settings_path(), agent),
+        agent_hooks::AgentKind::Pi => uninstall_pi_extension(),
     }
 }
 
@@ -1558,7 +1610,9 @@ fn install_json_hooks(
 fn hook_timeout(agent: agent_hooks::AgentKind) -> u64 {
     match agent {
         agent_hooks::AgentKind::Claude => 5,
-        agent_hooks::AgentKind::Codex | agent_hooks::AgentKind::Gemini => 5000,
+        agent_hooks::AgentKind::Codex
+        | agent_hooks::AgentKind::Gemini
+        | agent_hooks::AgentKind::Pi => 5000,
         agent_hooks::AgentKind::OpenCode => 0,
     }
 }
@@ -1672,7 +1726,105 @@ fn hook_marker(agent: agent_hooks::AgentKind) -> &'static str {
         agent_hooks::AgentKind::Codex => "hooks codex",
         agent_hooks::AgentKind::OpenCode => "hooks opencode",
         agent_hooks::AgentKind::Gemini => "hooks gemini",
+        agent_hooks::AgentKind::Pi => "hooks pi",
     }
+}
+
+fn pi_extension_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".pi/agent/extensions/limux-hooks.ts")
+}
+
+fn install_pi_extension() -> Result<()> {
+    let path = pi_extension_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(&path, pi_extension_source()).context("failed to write Pi extension")
+}
+
+fn uninstall_pi_extension() -> Result<()> {
+    let path = pi_extension_path();
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("failed to remove {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn pi_extension_source() -> &'static str {
+    r#"// Installed by `limux hooks pi install`. Do not edit manually.
+import { spawnSync } from "node:child_process";
+
+type ExtensionAPI = {
+  on(event: string, handler: (...args: any[]) => unknown): void;
+};
+
+type ExtensionContext = {
+  cwd?: unknown;
+  sessionManager?: {
+    getSessionFile?: () => unknown;
+  };
+};
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function transcriptPath(ctx: ExtensionContext): string | undefined {
+  try {
+    return optionalString(ctx.sessionManager?.getSessionFile?.());
+  } catch {
+    return undefined;
+  }
+}
+
+function send(
+  eventName: string,
+  ctx: ExtensionContext | undefined,
+  extra: Record<string, unknown> = {},
+) {
+  if (process.env.LIMUX_PI_HOOKS_DISABLED === "1") return;
+
+  try {
+    const safeCtx = ctx ?? {};
+    const payload = {
+      transcript_path: transcriptPath(safeCtx),
+      cwd: optionalString(safeCtx.cwd) ?? process.cwd(),
+      pid: process.pid,
+      hook_event_name: eventName,
+      ...extra,
+    };
+    spawnSync("limux", ["--json", "hooks", "pi", eventName], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+  } catch {
+    // Hooks must never break pi.
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", (event: any, ctx: ExtensionContext | undefined) => {
+    send("session-start", ctx, { reason: event?.reason });
+  });
+
+  pi.on("before_agent_start", (event: any, ctx: ExtensionContext | undefined) => {
+    send("prompt-submit", ctx, { prompt: event?.prompt });
+  });
+
+  pi.on("agent_end", (_event: any, ctx: ExtensionContext | undefined) => {
+    send("stop", ctx);
+  });
+
+  pi.on("session_shutdown", (event: any, ctx: ExtensionContext | undefined) => {
+    send("session-end", ctx, { reason: event?.reason });
+  });
+}
+"#
 }
 
 fn read_json_object(path: &Path) -> Result<Map<String, Value>> {
@@ -3425,11 +3577,12 @@ async fn execute_command(client: &mut Client, opts: &GlobalOptions) -> Result<Co
                 CommandOutput::Text("OK".to_string())
             }
         }
-        "claude-hook" | "opencode-hook" | "gemini-hook" => {
+        "claude-hook" | "opencode-hook" | "gemini-hook" | "pi-hook" => {
             let agent = match command {
                 "claude-hook" => agent_hooks::AgentKind::Claude,
                 "opencode-hook" => agent_hooks::AgentKind::OpenCode,
                 "gemini-hook" => agent_hooks::AgentKind::Gemini,
+                "pi-hook" => agent_hooks::AgentKind::Pi,
                 _ => unreachable!(),
             };
             let payload = run_agent_hook(client, agent, args).await?;
@@ -3756,6 +3909,7 @@ mod cli_arg_tests {
                 agent_hooks::AgentKind::Codex,
                 agent_hooks::AgentKind::Claude,
                 agent_hooks::AgentKind::Gemini,
+                agent_hooks::AgentKind::Pi,
             ]
         );
         assert!(!default_hook_targets().contains(&agent_hooks::AgentKind::OpenCode));
@@ -3783,6 +3937,16 @@ mod cli_arg_tests {
     }
 
     #[test]
+    fn pi_extension_uses_best_effort_session_file() {
+        let source = pi_extension_source();
+
+        assert!(source.contains("getSessionFile"));
+        assert!(source.contains("hooks\", \"pi\""));
+        assert!(!source.contains("getSessionId"));
+        assert!(!source.contains("@earendil-works/pi-coding-agent"));
+    }
+
+    #[test]
     fn stop_hook_output_matches_codex_schema_shape() {
         let output = agent_hook_output("stop", &json!({ "session_id": "session-a" }));
 
@@ -3792,6 +3956,21 @@ mod cli_arg_tests {
                 "continue": true,
                 "suppressOutput": false
             })
+        );
+    }
+
+    #[test]
+    fn lowercase_stop_hook_builds_attention_notification() {
+        assert_eq!(
+            canonical_agent_hook_display_event("stop"),
+            AgentHookDisplayEvent::Stop
+        );
+        assert_eq!(
+            agent_hook_notification_content("Codex", "stop", &json!({})),
+            (
+                "Process needs attention".to_string(),
+                "Codex finished".to_string()
+            )
         );
     }
 

--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -114,6 +114,7 @@ pub enum RestorableAgentKind {
     Codex,
     OpenCode,
     Gemini,
+    Pi,
 }
 
 impl RestorableAgentKind {
@@ -132,6 +133,7 @@ impl RestorableAgentKind {
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
             Self::Gemini => "gemini",
+            Self::Pi => "pi",
         }
     }
 
@@ -141,6 +143,7 @@ impl RestorableAgentKind {
             Self::Codex => "codex",
             Self::OpenCode => "opencode",
             Self::Gemini => "gemini",
+            Self::Pi => "pi",
         }
     }
 }
@@ -493,6 +496,7 @@ impl RestorableAgentIndex {
             (RestorableAgentKind::Codex, "codex-hook-sessions.json"),
             (RestorableAgentKind::OpenCode, "opencode-hook-sessions.json"),
             (RestorableAgentKind::Gemini, "gemini-hook-sessions.json"),
+            (RestorableAgentKind::Pi, "pi-hook-sessions.json"),
         ] {
             let path = dir.join(file_name);
             let Ok(raw) = fs::read_to_string(&path) else {
@@ -720,6 +724,11 @@ fn build_resume_command(
             parts.push(session_id.clone());
             parts.extend(preserved_tail);
         }
+        RestorableAgentKind::Pi => {
+            parts.push("--session".to_string());
+            parts.push(session_id.clone());
+            parts.extend(preserved_tail);
+        }
     }
 
     let command = parts
@@ -842,6 +851,12 @@ fn is_resume_selector(kind: RestorableAgentKind, arg: &str) -> bool {
         RestorableAgentKind::OpenCode => arg == "--session" || arg.starts_with("--session="),
         RestorableAgentKind::Claude | RestorableAgentKind::Gemini => {
             arg == "--resume" || arg.starts_with("--resume=") || arg == "--continue"
+        }
+        RestorableAgentKind::Pi => {
+            arg == "--session"
+                || arg.starts_with("--session=")
+                || arg == "--continue"
+                || arg == "-c"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Pi as a supported Limux hook agent with session persistence and resume command handling
- install/uninstall a generated Pi TypeScript extension under `~/.pi/agent/extensions/limux-hooks.ts`
- document Pi hook setup, `pi-hook`, and `LIMUX_PI_HOOKS_DISABLED`

## Verification
- `RUSTUP_TOOLCHAIN=1.92 cargo test -p limux-cli cli_arg_tests -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.92 cargo check -p limux-host-linux`
- `RUSTUP_TOOLCHAIN=1.92 ./scripts/check.sh`
- `RUSTUP_TOOLCHAIN=1.92 cargo run -p limux-cli -- --help | rg -n "hooks setup|pi-hook"`