### PR TITLE
fix: prevent SIGABRT crash on split and fix send-key Return on bash prompts

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1084,8 +1084,11 @@ fn make_terminal_callbacks(
             if has_custom || title.is_empty() {
                 return;
             }
-            let display = if title.len() > 22 {
-                format!("{}…", &title[..21])
+            // title.len()은 바이트 수 — 멀티바이트 문자 중간에서 자르면 패닉이 발생한다.
+            // char_indices로 21번째 문자 경계를 찾아 안전하게 자른다.
+            let display = if title.chars().count() > 22 {
+                let cut = title.char_indices().nth(21).map(|(i, _)| i).unwrap_or(title.len());
+                format!("{}…", &title[..cut])
             } else {
                 title.to_string()
             };

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -234,7 +234,7 @@ impl TerminalHandle {
             return false;
         };
 
-        let press = translate_key_event(
+        let mut press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
@@ -250,6 +250,19 @@ impl TerminalHandle {
             0,
             modifier,
         );
+
+        // key_event_text() filters control characters (including \r for Return), so
+        // send_key via API always has text=null. Ghostty uses the text field to write
+        // to the PTY; without it, Return never reaches bash. Provide \r explicitly
+        // for Return/Enter so send-key works on plain shell prompts too.
+        let cr_text;
+        if matches!(
+            keyval,
+            gtk::gdk::Key::Return | gtk::gdk::Key::KP_Enter | gtk::gdk::Key::ISO_Enter
+        ) {
+            cr_text = CString::new("\r").unwrap();
+            press.text = cr_text.as_ptr();
+        }
 
         unsafe {
             ghostty_surface_key(surface, press);
@@ -413,6 +426,11 @@ fn request_terminal_focus(gl_area: &gtk::GLArea, had_focus: &Cell<bool>) {
 }
 
 fn refresh_surface_display(surface: ghostty_surface_t, gl_area: &gtk::GLArea) {
+    // split rebuild이 타이머 콜백보다 먼저 GLArea를 unrealize하면 ghostty_surface_refresh가
+    // GL 컨텍스트 없이 호출되어 SIGABRT가 발생한다. realized 상태일 때만 진행.
+    if !gl_area.is_realized() {
+        return;
+    }
     let alloc = gl_area.allocation();
     let w = alloc.width() as u32;
     let h = alloc.height() as u32;


### PR DESCRIPTION
## Summary

- **SIGABRT crash on rapid pane splits** — `refresh_surface_display()` called `ghostty_surface_refresh()` unconditionally, even when the `GLArea` had been unrealized by `trigger_rebuild()`. Deferred timer callbacks (scheduled 16 ms / 80 ms after a rebuild) could fire after the widget tree was torn down, hitting an unrealized GL context and causing a fatal abort. Fixed with an `is_realized()` guard.

- **`send-key Return` silently ignored on plain bash prompts** — `key_event_text()` filters control characters, so the `text` field in `ghostty_input_key_s` was always `null` when `send_key()` was called via the control socket. Ghostty relies on this field to write the character to the PTY, so `Return` never reached the shell. Fixed by explicitly setting `text = "\r"` for `Return`/`Enter`/`KP_Enter` key events inside `send_key()`.

- **UTF-8 char-boundary panic in `on_title_changed`** — `&title[..21]` used byte indexing; multibyte characters (Korean, emoji) from application terminal titles caused `slice_error_fail` panics when the slice landed inside a multi-byte sequence. Fixed with `char_indices().nth(21)` to find a safe char boundary.

## Test plan

- [ ] Open limux and rapidly split a pane 3–4 times in quick succession — no SIGABRT
- [ ] From the control socket, run `limux send-key --surface <ref> Return` on a bare bash prompt — command is submitted
- [ ] Open a pane running a program that sets a Korean or emoji terminal title (e.g. `claude`) — no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVFDJJwHACrcRJCJ8EgAxz