### PR TITLE
fix: stabilize tab rename editing

### DIFF
--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -15,6 +15,17 @@ pub type ghostty_app_t = *mut c_void;
 pub type ghostty_config_t = *mut c_void;
 pub type ghostty_surface_t = *mut c_void;
 
+extern "C" {
+    fn gladLoaderLoadGLContext(context: *mut c_void) -> c_int;
+    fn gladLoaderUnloadGLContext(context: *mut c_void);
+}
+
+// Keep cc-built glad objects in final links; libghostty.so references them.
+#[used]
+static GLAD_LOAD_LINK_ANCHOR: unsafe extern "C" fn(*mut c_void) -> c_int = gladLoaderLoadGLContext;
+#[used]
+static GLAD_UNLOAD_LINK_ANCHOR: unsafe extern "C" fn(*mut c_void) = gladLoaderUnloadGLContext;
+
 // -------------------------------------------------------------------
 // Enums
 // -------------------------------------------------------------------

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1941,7 +1941,13 @@ fn build_tab_button_from_label(
         let content_stack = internals.content_stack.clone();
         let tab_state = internals.tab_state.clone();
         let callbacks = internals.callbacks.clone();
-        click.connect_pressed(move |_, _, _, _| {
+        let tab_button = tab_btn.clone();
+        click.connect_pressed(move |gesture, _, _, _| {
+            if let Some(entry) = find_tab_rename_entry(&tab_button) {
+                focus_tab_rename_entry(&entry);
+                gesture.set_state(gtk::EventSequenceState::Denied);
+                return;
+            }
             activate_tab(&tab_strip, &content_stack, &tab_state, &tab_id);
             (callbacks.on_state_changed)();
         });
@@ -1962,8 +1968,14 @@ fn build_tab_button_from_label(
             pin_icon: pin_icon.clone(),
         };
         let tab_button = tab_btn.clone();
-        right_click.connect_pressed(move |_, _, _, _| {
+        right_click.connect_pressed(move |gesture, _, _, _| {
+            if let Some(entry) = find_tab_rename_entry(&tab_button) {
+                focus_tab_rename_entry(&entry);
+                gesture.set_state(gtk::EventSequenceState::Denied);
+                return;
+            }
             show_tab_context_menu(&tab_button, &tab_id, &context);
+            gesture.set_state(gtk::EventSequenceState::Claimed);
         });
     }
     tab_btn.add_controller(right_click);
@@ -1973,7 +1985,14 @@ fn build_tab_button_from_label(
     {
         let tab_id = tab_id.to_string();
         let pane_id = internals.pane_id;
-        drag_source.connect_prepare(move |_src, _x, _y| {
+        drag_source.connect_prepare(move |src, _x, _y| {
+            if src
+                .widget()
+                .and_then(|widget| find_tab_rename_entry(&widget))
+                .is_some()
+            {
+                return None;
+            }
             let payload = glib::Value::from(&TabDragPayload::new(pane_id, &tab_id).encode());
             Some(gtk::gdk::ContentProvider::for_value(&payload))
         });
@@ -2055,7 +2074,13 @@ fn show_tab_context_menu(tab_btn: &gtk::Box, tab_id: &str, context: &TabContextM
         let callbacks = context.callbacks.clone();
         rename_btn.connect_clicked(move |_| {
             menu_ref.popdown();
-            show_rename_dialog(&lbl, &state, &tid, &callbacks);
+            let lbl = lbl.clone();
+            let state = state.clone();
+            let tid = tid.clone();
+            let callbacks = callbacks.clone();
+            glib::idle_add_local_once(move || {
+                show_rename_dialog(&lbl, &state, &tid, &callbacks);
+            });
         });
     }
 
@@ -2133,6 +2158,35 @@ fn show_tab_context_menu(tab_btn: &gtk::Box, tab_id: &str, context: &TabContextM
     menu.popup();
 }
 
+fn find_tab_rename_entry<W: glib::object::IsA<gtk::Widget>>(root: &W) -> Option<gtk::Entry> {
+    fn find_entry(widget: &gtk::Widget) -> Option<gtk::Entry> {
+        if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
+            if entry.has_css_class(TAB_RENAME_ENTRY_CSS_CLASS) {
+                return Some(entry.clone());
+            }
+        }
+
+        let mut child = widget.first_child();
+        while let Some(current) = child {
+            if let Some(entry) = find_entry(&current) {
+                return Some(entry);
+            }
+            child = current.next_sibling();
+        }
+
+        None
+    }
+
+    find_entry(root.as_ref())
+}
+
+fn focus_tab_rename_entry(entry: &gtk::Entry) {
+    if !entry.has_focus() {
+        entry.grab_focus();
+        entry.select_region(0, -1);
+    }
+}
+
 fn show_rename_dialog(
     label: &gtk::Label,
     tab_state: &Rc<RefCell<TabState>>,
@@ -2147,6 +2201,15 @@ fn show_rename_dialog(
         return;
     };
 
+    if let Some(entry) = find_tab_rename_entry(&parent) {
+        parent.set_can_target(true);
+        focus_tab_rename_entry(&entry);
+        return;
+    }
+
+    let parent_was_targetable = parent.can_target();
+    parent.set_can_target(true);
+
     let entry = gtk::Entry::builder()
         .text(&current_name)
         .width_chars(15)
@@ -2158,8 +2221,7 @@ fn show_rename_dialog(
     label.set_visible(false);
     // Insert entry before the close button
     parent.insert_child_after(&entry, Some(label));
-    entry.grab_focus();
-    entry.select_region(0, -1);
+    focus_tab_rename_entry(&entry);
 
     // On activate (Enter) or focus-out, commit rename
     let lbl = label.clone();
@@ -2191,6 +2253,7 @@ fn show_rename_dialog(
             }
             lbl.set_visible(true);
             parent.remove(entry);
+            parent.set_can_target(parent_was_targetable);
             (callbacks.on_state_changed)();
         }
     };


### PR DESCRIPTION
## Summary

Fixes tab inline rename getting stuck or stacking duplicate editors after repeated right-click Rename actions.

## Changes

- Reuse and refocus an existing tab rename entry instead of inserting another one.
- Make the tab label wrapper targetable while editing so the entry can keep pointer/focus events.
- Defer opening the rename editor until the context-menu popover has released its grab.
- Suppress tab drag/activation gestures while the rename entry is active.
- Anchor glad loader symbols so host builds link cleanly against `libghostty.so`.

## Repro Steps

1. Open Limux with at least one terminal tab.
2. Right-click a tab and choose Rename.
3. Right-click the same tab while rename is active and choose Rename again.
4. Before this fix, multiple inline editors could stack and focus/cursor handling could get stuck.
5. After this fix, the existing editor is reused and remains editable.

## Testing

- `./scripts/check.sh`
- `cargo build -p limux-host-linux`
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh` attempted locally; host builds and launches, but the smoke flow stops before agent stages because Ghostty surface creation fails under Xvfb with `limux: failed to create ghostty surface`.

## Did this cause any problems?

Rollback/revert this commit and redeploy the service.
