### PR TITLE
fix: inject text for control-socket send_key so keys reach the PTY

### DIFF
--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -199,7 +199,7 @@ fn parse_global_args() -> Result<GlobalOptions> {
 
 fn print_help() {
     println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] [--shell-safe] <text>\n      --shell-safe wraps the text in a single-quoted `echo '#…'` so a plain\n      shell at the destination prints it instead of executing it.\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
     );
 }
 
@@ -760,27 +760,55 @@ fn render_list_text(command: &str, payload: &Value) -> String {
     }
 }
 
+fn shell_safe_wrap(text: &str) -> String {
+    let escaped = text.trim_end_matches('\n').replace('\'', "'\\''");
+    format!("echo '#{}'\n", escaped)
+}
+
 async fn run_send(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
         .filter(|s| !s.is_empty());
     let surface = parse_opt(args, "--surface").filter(|s| !s.is_empty());
+    let shell_safe = parse_flag(args, "--shell-safe");
 
     let text = trailing_title(args).ok_or_else(|| anyhow!("send requires text"))?;
+    let text = if shell_safe {
+        shell_safe_wrap(&text)
+    } else {
+        text
+    };
 
     let mut params = Map::new();
     params.insert("text".to_string(), Value::String(text));
-    if let Some(surface) = surface {
-        params.insert("surface_id".to_string(), Value::String(surface));
+    if let Some(surface) = &surface {
+        params.insert("surface_id".to_string(), Value::String(surface.clone()));
     }
 
-    call_in_workspace_scope(
+    let payload = call_in_workspace_scope(
         client,
-        workspace,
+        workspace.clone(),
         "surface.send_text",
         Value::Object(params),
     )
-    .await
+    .await?;
+
+    if shell_safe {
+        let mut key_params = Map::new();
+        key_params.insert("key".to_string(), Value::String("Enter".to_string()));
+        if let Some(surface) = surface {
+            key_params.insert("surface_id".to_string(), Value::String(surface));
+        }
+        call_in_workspace_scope(
+            client,
+            workspace,
+            "surface.send_key",
+            Value::Object(key_params),
+        )
+        .await?;
+    }
+
+    Ok(payload)
 }
 
 async fn run_send_key(client: &mut Client, args: &[String]) -> Result<Value> {
@@ -2267,6 +2295,16 @@ fn build_agents_md(
     out.push_str("Reply with the envelope reversed and `reply-to` set to the original `id`:\n\n");
     out.push_str("```bash\n");
     out.push_str("limux send --surface <orig-sender-surface-id> $'<agent-msg from=\"claude\" to=\"codex\" id=\"<new-uuid>\" reply-to=\"<orig-uuid>\" ts=\"<iso8601>\">\\n<response>...</response>\\n</agent-msg>\\n'\n");
+    out.push_str("```\n\n");
+    out.push_str(
+        "If the destination surface is a plain shell (the orchestrator's\n\
+         terminal, a scratch pane) rather than an agent CLI, add\n\
+         `--shell-safe`: limux wraps the envelope in a single-quoted\n\
+         `echo '#...'` so the shell prints it instead of executing it.\n\
+         Never send a raw envelope at a shell prompt — bash will run it.\n\n",
+    );
+    out.push_str("```bash\n");
+    out.push_str("limux send --shell-safe --surface <orch-surface-id> $'<agent-msg from=\"claude\" to=\"orchestrator\" id=\"<new-uuid>\" reply-to=\"<orig-uuid>\" ts=\"<iso8601>\">\\n<response>...</response>\\n</agent-msg>\\n'\n");
     out.push_str("```\n\n");
 
     out.push_str("## Pinging the human\n\n");
@@ -3986,6 +4024,35 @@ mod agent_team_tests {
         assert!(md.contains("LIMUX_SURFACE_ID"));
         assert!(md.contains("limux new-pane --direction right --command bash"));
         assert!(md.contains("Live GTK self-spawn currently supports terminal"));
+
+        // Shell-safe reply guidance for non-agent (plain shell) surfaces
+        assert!(md.contains("limux send --shell-safe --surface"));
+        assert!(md.contains("Never send a raw envelope at a shell prompt"));
+    }
+
+    #[test]
+    fn shell_safe_wrap_neutralizes_everything_bash_expands() {
+        let wrapped = shell_safe_wrap(
+            "<response>pong $(reboot) `id` !! \"quoted\" (specs 001-004)</response>\n",
+        );
+        assert_eq!(
+            wrapped,
+            "echo '#<response>pong $(reboot) `id` !! \"quoted\" (specs 001-004)</response>'\n"
+        );
+    }
+
+    #[test]
+    fn shell_safe_wrap_escapes_embedded_single_quotes() {
+        assert_eq!(shell_safe_wrap("jana's fix"), "echo '#jana'\\''s fix'\n");
+    }
+
+    #[test]
+    fn shell_safe_wrap_preserves_inner_newlines_and_trims_trailing() {
+        let wrapped = shell_safe_wrap("<agent-msg>\n<response>ok</response>\n</agent-msg>\n\n");
+        assert_eq!(
+            wrapped,
+            "echo '#<agent-msg>\n<response>ok</response>\n</agent-msg>'\n"
+        );
     }
 }
 

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -180,7 +180,7 @@ impl TerminalHandle {
             return false;
         };
 
-        let press = translate_key_event(
+        let mut press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
@@ -196,6 +196,14 @@ impl TerminalHandle {
             0,
             modifier,
         );
+
+        // translate_key_event leaves `text` null, but Ghostty relies on it to
+        // write characters to the PTY. Populate it for the control-socket path
+        // so `send-key Return` (and printable keys) actually reach the shell.
+        let key_text = control_socket_key_text(keyval);
+        if let Some(ref text) = key_text {
+            press.text = text.as_ptr();
+        }
 
         unsafe {
             ghostty_surface_key(surface, press);
@@ -2082,6 +2090,27 @@ fn key_event_text(keyval: gtk::gdk::Key) -> Option<CString> {
     let mut buf = [0u8; 4];
     let s = ch.encode_utf8(&mut buf);
     CString::new(s.as_bytes()).ok()
+}
+
+/// Text bytes to hand Ghostty for a synthetic key coming from the control
+/// socket. `key_event_text` drops control characters, so map the common
+/// control keys (Return, Tab, Escape, Backspace) to their PTY bytes and fall
+/// back to the printable-character text otherwise.
+fn control_socket_key_text(keyval: gtk::gdk::Key) -> Option<CString> {
+    use gtk::gdk::Key;
+    if keyval == Key::Return || keyval == Key::KP_Enter {
+        return CString::new("\r").ok();
+    }
+    if keyval == Key::Tab {
+        return CString::new("\t").ok();
+    }
+    if keyval == Key::Escape {
+        return CString::new("\x1b").ok();
+    }
+    if keyval == Key::BackSpace {
+        return CString::new("\x7f").ok();
+    }
+    key_event_text(keyval)
 }
 
 fn keyval_unicode_unshifted(


### PR DESCRIPTION
## Summary

`send-key` over the control socket is silently ignored — no key (not even a
printable character, and critically not `Return`) reaches the shell. This makes
socket-driven automation unusable on Linux: you can build layouts and `send`
text into a pane, but you can never *submit* a command.

## Root cause

`TerminalHandle::send_key` builds its `ghostty_input_key_s` via
`translate_key_event`, which hard-codes:

```rust
ghostty_input_key_s {
    ...
    text: ptr::null(),
    ...
}
```

Ghostty relies on the `text` field to write the character to the PTY. Because
`send_key` never populates it, `ghostty_surface_key` receives a key event with
no text and nothing is written to the shell. `key_event_text` can't help here
either — it deliberately returns `None` for control characters, so `Return`
(`\r`) would be dropped even if it were consulted.

Repro on `main`:

```bash
limux send     --surface <ref> "echo hi"   # text appears at the prompt
limux send-key --surface <ref> Return       # returns OK, but nothing executes
limux read-screen --surface <ref>           # command still sitting at the prompt, unexecuted
```

## Fix

Populate `press.text` in `send_key` from a small helper that maps the common
control keys to their PTY bytes (`Return`/`KP_Enter` → `\r`, `Tab` → `\t`,
`Escape` → `\x1b`, `BackSpace` → `\x7f`) and falls back to `key_event_text`
for printable characters. Only the control-socket path is touched; interactive
GTK key handling is unchanged.

## Test plan

- [x] `limux send-key --surface <ref> Return` on a bare bash prompt now submits
      the buffered command (verified end-to-end: the command executes and its
      output appears, followed by a fresh prompt).
- [x] Printable keys sent via the socket now reach the shell.
- [x] Interactive typing in a pane is unaffected (helper is only invoked from
      `send_key`).
- [x] `cargo build --release` is clean.

## Notes

This is the same underlying issue as the `send-key Return` portion of #108
(which was closed unmerged); this PR is scoped to just the input fix and
extends it to the other common control keys.
