### PR TITLE
fix: avoid double-borrow panic on rapid Ctrl+Tab tab switching

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2961,28 +2961,37 @@ fn activate_tab(
     tab_state: &Rc<RefCell<TabState>>,
     tab_id: &str,
 ) {
-    let mut ts = tab_state.borrow_mut();
-    ts.active_tab = Some(tab_id.to_string());
+    let (focus_target, has_content_child) = {
+        let mut ts = tab_state.borrow_mut();
+        ts.active_tab = Some(tab_id.to_string());
 
-    // Update visual state on all tabs
-    for entry in &ts.tabs {
-        if entry.id == tab_id {
-            entry.tab_button.add_css_class("limux-tab-active");
-        } else {
-            entry.tab_button.remove_css_class("limux-tab-active");
+        // Update visual state on all tabs
+        for entry in &ts.tabs {
+            if entry.id == tab_id {
+                entry.tab_button.add_css_class("limux-tab-active");
+            } else {
+                entry.tab_button.remove_css_class("limux-tab-active");
+            }
         }
-    }
 
-    if content_stack.child_by_name(tab_id).is_some() {
+        let focus_target = ts
+            .tabs
+            .iter()
+            .find(|entry| entry.id == tab_id)
+            .map(TabFocusTarget::from_entry);
+
+        (focus_target, content_stack.child_by_name(tab_id).is_some())
+        // `ts` (the RefCell borrow_mut guard) is dropped here, before we touch
+        // content_stack. set_visible_child_name() synchronously fires GTK
+        // unmap/map signals (hover-out on the old surface, etc.), and those
+        // handlers can re-enter tab_state.borrow() (e.g. tab_rename_active).
+        // Holding the mutable borrow across that call caused a double-borrow
+        // panic on rapid repeated tab switches (Ctrl+Tab x2-4 fast).
+    };
+
+    if has_content_child {
         content_stack.set_visible_child_name(tab_id);
     }
-
-    let focus_target = ts
-        .tabs
-        .iter()
-        .find(|entry| entry.id == tab_id)
-        .map(TabFocusTarget::from_entry);
-    drop(ts);
 
     if let Some(target) = focus_target {
         // Mouse-initiated tab switches can leave focus on the click target if we


### PR DESCRIPTION
## Summary

Fixes a crash caused by a double-borrow panic on `TabState`'s `RefCell` when rapidly switching tabs with Ctrl+Tab.

## Root cause

`activate_tab()` in `pane.rs` held `tab_state.borrow_mut()` across the call to `content_stack.set_visible_child_name(tab_id)`. That GTK call synchronously fires an unmap/map signal cascade on the old and new tab content — including hover/crossing signals on the terminal surface, whose callback calls `tab_rename_active(&tab_state)`, which needs `tab_state.borrow()`.

A single tab switch usually completes (and drops the borrow) before the next signal fires, so it goes unnoticed. But pressing Ctrl+Tab rapidly (2-4x in quick succession) can start a second `activate_tab()` call while the first switch's unmap cascade is still resolving, causing the reentrant `.borrow()` to panic while the outer `.borrow_mut()` is still held — and since this happens inside a GTK/glib signal callback (FFI boundary), the panic can't unwind and the process aborts (SIGABRT).

## Fix

Narrowed the `borrow_mut()` scope so it's dropped before `content_stack.set_visible_child_name()` is called, removing the reentrancy window.

## Testing

- Reproduced the crash consistently on the release build from AUR (`limux-bin`) before applying the fix — rapid Ctrl+Tab (2-4 presses) crashed every time
- Applied the fix, built [v0.1.22](https://github.com/ferdinankurnian/limux/releases/tag/v0.1.22) via this repo's `Build Linux Release Packages` workflow, downloaded and ran the resulting build locally — rapid Ctrl+Tab no longer crashes
- `Rust Quality` workflow (build, clippy, fmt) passes on the fix commit

Fixes #111