### PR TITLE
fix(control): deliver send-key to the PTY; expose select-workspace

### DIFF
--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -199,7 +199,7 @@ fn parse_global_args() -> Result<GlobalOptions> {
 
 fn print_help() {
     println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  select-workspace --workspace <id|ref>\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
     );
 }
 
@@ -2330,6 +2330,23 @@ async fn run_close_workspace(client: &mut Client, args: &[String]) -> Result<Val
         .await
 }
 
+/// `limux select-workspace --workspace <id|ref>` — bring a workspace to the front.
+///
+/// The host has always implemented `workspace.select`; it just wasn't reachable
+/// from the CLI. It needs to be, because a pane only realizes its ghostty surface
+/// once its workspace is displayed. Splits made in a background workspace stay
+/// unrealized — `surface-health` reports `healthy=false` and `send-key` fails —
+/// until something selects it. Without this verb a purely CLI-driven fleet cannot
+/// bring its own workspace forward, so it can never start.
+async fn run_select_workspace(client: &mut Client, args: &[String]) -> Result<Value> {
+    let workspace = parse_opt(args, "--workspace")
+        .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
+        .ok_or_else(|| anyhow!("select-workspace requires --workspace <id|ref>"))?;
+    client
+        .call("workspace.select", json!({ "workspace_id": workspace }))
+        .await
+}
+
 async fn run_sidebar_state(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
@@ -3447,6 +3464,14 @@ async fn execute_command(client: &mut Client, opts: &GlobalOptions) -> Result<Co
             } else {
                 let handle = handle_from_payload(&payload, "workspace_id", "workspace_ref");
                 CommandOutput::Text(format!("OK {}", handle))
+            }
+        }
+        "select-workspace" => {
+            let payload = run_select_workspace(client, args).await?;
+            if opts.json_output {
+                CommandOutput::Json(payload)
+            } else {
+                CommandOutput::Text("OK".to_string())
             }
         }
         "close-workspace" => {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -180,12 +180,20 @@ impl TerminalHandle {
             return false;
         };
 
+        // Ghostty resolves the *physical* key from the hardware keycode; it does
+        // not fall back to the keyval. Synthesizing an event with keycode 0 makes
+        // ghostty see an unidentified key and drop it silently — the caller gets a
+        // successful reply and the PTY never sees the keystroke. Map the keyval
+        // back to a real keycode through the display's keymap so control-socket
+        // keys are encoded exactly like keys typed by a human.
+        let keycode = keycode_for_keyval(self.gl_area.upcast_ref(), keyval);
+
         let press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
             keyval,
-            0,
+            keycode,
             modifier,
         );
         let release = translate_key_event(
@@ -193,7 +201,7 @@ impl TerminalHandle {
             Some(self.gl_area.upcast_ref()),
             None,
             keyval,
-            0,
+            keycode,
             modifier,
         );
 
@@ -2071,6 +2079,21 @@ fn translate_key_event(
         unshifted_codepoint: unshifted,
         composing: false,
     }
+}
+
+/// Map a keyval back to a hardware keycode via the display's keymap.
+///
+/// Real key events arrive from GTK with the keycode already filled in. Keys
+/// injected through the control socket only have a keyval (parsed from a string
+/// like `enter`), so we have to ask the keymap for the physical key that
+/// produces it. Returns 0 when the keyval isn't on the current layout, which
+/// preserves the previous behaviour rather than inventing a wrong key.
+fn keycode_for_keyval(widget: &gtk::Widget, keyval: gtk::gdk::Key) -> u32 {
+    widget
+        .display()
+        .map_keyval(keyval)
+        .and_then(|keys| keys.first().map(|key| key.keycode()))
+        .unwrap_or(0)
 }
 
 fn key_event_text(keyval: gtk::gdk::Key) -> Option<CString> {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -180,15 +180,28 @@ impl TerminalHandle {
             return false;
         };
 
-        // Ghostty resolves the *physical* key from the hardware keycode; it does
-        // not fall back to the keyval. Synthesizing an event with keycode 0 makes
-        // ghostty see an unidentified key and drop it silently — the caller gets a
-        // successful reply and the PTY never sees the keystroke. Map the keyval
-        // back to a real keycode through the display's keymap so control-socket
-        // keys are encoded exactly like keys typed by a human.
+        // A key needs BOTH halves, and supplying only one drops it silently.
+        //
+        // `keycode` — ghostty resolves the *physical* key from the hardware keycode
+        // and does not fall back to the keyval. With `keycode: 0` it sees an
+        // unidentified key and drops the event, so Enter, arrows, F-keys and
+        // ctrl-chords never reach the PTY.
+        //
+        // `text` — ghostty writes ordinary printable input from the text field, not
+        // from the keycode (see the comment on the GTK key controller below: "Ghostty
+        // uses the text field for actual character input and the keycode for
+        // bindings"). With `text` null, `send-key a` is encoded as a keypress that
+        // produces no character, so it too vanishes.
+        //
+        // The GTK path gets `text` from the input method; a socket-injected key has
+        // no IM behind it, so derive it here the same way GTK's fallback does.
+        // `key_event_text` returns None for control characters, which is what we want:
+        // Enter and ctrl-chords must be *encoded* by ghostty from the key + mods, not
+        // written as literal bytes.
         let keycode = keycode_for_keyval(self.gl_area.upcast_ref(), keyval);
+        let text = key_event_text(keyval);
 
-        let press = translate_key_event(
+        let mut press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
@@ -196,6 +209,13 @@ impl TerminalHandle {
             keycode,
             modifier,
         );
+        // The CString must outlive the ghostty call below; `text` owns it until the
+        // end of this function.
+        if let Some(text) = text.as_ref() {
+            press.text = text.as_ptr();
+        }
+
+        // Release carries no text, matching the GTK controller.
         let release = translate_key_event(
             GHOSTTY_ACTION_RELEASE,
             Some(self.gl_area.upcast_ref()),
@@ -209,6 +229,7 @@ impl TerminalHandle {
             ghostty_surface_key(surface, press);
             ghostty_surface_key(surface, release);
         }
+        drop(text);
         true
     }
 
@@ -2390,6 +2411,53 @@ mod tests {
         assert_eq!(ctrl_shift_h.as_deref(), Some("H"));
         assert_eq!(alt_shift_gt.as_deref(), Some(">"));
         assert!(key_event_text(gtk::gdk::Key::BackSpace).is_none());
+    }
+
+    /// The contract `send-key` depends on, in one place.
+    ///
+    /// A socket-injected key needs BOTH the hardware keycode and, for printable
+    /// input, the text field. Supplying only one drops the key silently:
+    ///
+    ///   * keycode only -> `send-key a` returns OK and writes nothing.
+    ///   * text only    -> Enter/arrows/ctrl-chords cannot be encoded at all.
+    ///
+    /// `key_event_text` is what decides which keys carry text, so pin its behaviour
+    /// for each of the three classes.
+    #[test]
+    fn send_key_text_is_supplied_for_printables_and_withheld_from_control_keys() {
+        // Printable: ghostty writes these from the text field.
+        for (key, expected) in [
+            (gtk::gdk::Key::a, "a"),
+            (gtk::gdk::Key::A, "A"),
+            (gtk::gdk::Key::_1, "1"),
+            (gtk::gdk::Key::space, " "),
+        ] {
+            let text = key_event_text(key).and_then(|s| s.into_string().ok());
+            assert_eq!(
+                text.as_deref(),
+                Some(expected),
+                "printable key must carry text or it is dropped"
+            );
+        }
+
+        // Control keys: text must be WITHHELD so ghostty encodes them from the
+        // key + mods. Writing "\r" as literal text instead of letting ghostty encode
+        // Return is how you break the kitty keyboard protocol.
+        for key in [
+            gtk::gdk::Key::Return,
+            gtk::gdk::Key::Tab,
+            gtk::gdk::Key::Escape,
+            gtk::gdk::Key::BackSpace,
+        ] {
+            assert!(
+                key_event_text(key).is_none(),
+                "{key:?} must be encoded by ghostty, not written as literal text"
+            );
+        }
+
+        // Non-textual keys have no unicode at all.
+        assert!(key_event_text(gtk::gdk::Key::Up).is_none());
+        assert!(key_event_text(gtk::gdk::Key::F1).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Two defects made limux undrivable from the control socket. Together they broke the four-verb loop (`send` / `send-key` / `read-screen` / `identify`) that agent orchestration depends on. Both are fixed here.

I found these while porting [`disler/learning-cmux-with-agents`](https://github.com/disler/learning-cmux-with-agents) to limux and discovering that no prompt in it could actually run.

## 1. `send-key` never reached the PTY

`Terminal::send_key` synthesized a ghostty key event with **`keycode: 0`**:

```rust
let press = translate_key_event(GHOSTTY_ACTION_PRESS, …, keyval, 0, modifier);
//                                                                ^ no keycode
```

Ghostty resolves the *physical* key from the hardware keycode and does not fall back to the keyval, and `translate_key_event` always sets `text: ptr::null()`. So every key injected over the socket arrived as an unidentified key and was dropped.

The failure was **silent** — the caller still got `OK`:

```console
$ limux send     --workspace $WS 'echo hello'
OK surface:22:terminal-0
$ limux send-key --workspace $WS enter
OK surface:22:terminal-0          # ← looks fine
$ limux read-screen --workspace $WS --lines 2
❯ echo hello                      # ← never ran
```

Text just accumulated at the prompt forever. No command sent over the control socket could execute, so no agent could be started or prompted. Reproduced on 0.1.19 and 0.1.21, focused and unfocused, across `enter` / `Enter` / `Return` / `KP_Enter` / `cr` / `newline`, and with a trailing `\n`/`\r` inside `send`.

The GTK key controller passes the real `keycode` (`connect_key_pressed`); only the socket path passed `0`.

**Fix:** map the keyval back to a hardware keycode through the display's keymap — the inverse of the existing `keyval_unicode_unshifted` — so socket keys are encoded exactly like keys typed by a human.

## 2. Panes in a background workspace never realize

A pane only realizes its ghostty surface once its workspace is *displayed*. A split made in a workspace that isn't selected stays unrealized: `surface-health` reports `healthy=false`, and `send_key` returns `false`, which the bridge surfaces as the misleading `-32602: unsupported key` (the key was fine — the surface didn't exist).

The host already implements `workspace.select`, and `limux-cli` even calls it internally — it just wasn't reachable as a command. So a CLI-driven fleet could not bring its own workspace forward and could never start.

**Fix:** expose `limux select-workspace --workspace <id|ref>`.

## Verification

End-to-end on Wayland / GTK4, with both patches applied:

```console
$ limux send --workspace $WS 'echo FIXED-$((6*7))'; limux send-key --workspace $WS enter
$ limux read-screen --workspace $WS --lines 4
❯ echo FIXED-$((6*7))
FIXED-42                                  # ← it runs
```

Full loop: create a workspace → `select-workspace` → split a 2×2 → every pane `healthy=true` → drive each pane independently with `send-key --surface` → launch an interactive REPL in one pane, prompt it over the socket, and read the answer back off the screen:

```
>>> print('THE-ANSWER-IS', 6*7)
THE-ANSWER-IS 42
```

That is the agent-TUI pattern working: `agent-team` and CLI-driven fleets become possible.

## Gate

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `cargo test --workspace` — `hook_session_id_falls_back_to_transcript_stem` fails, but it **also fails on an unmodified checkout** (and is the known failure called out in `CLAUDE.md`). Unrelated to this change.

## Notes for review

- I did **not** add a regression test: exercising `send_key` needs a live GTK display, and I couldn't see a headless harness in the tree. Happy to add one if you can point me at the right seam — I know the repo convention asks for it.
- I built against the prebuilt `libghostty.so` from the 0.1.21 release tarball (dropped into `ghostty/zig-out/lib/`) rather than building the submodule, since I didn't have zig. The change itself doesn't depend on that; a clean-room build should use the real submodule.