### PR TITLE
NixOS build support: shell.nix, flake, glad linking fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.deb
 *.AppImage
 save-sesh-plan.md
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,7 @@ dependencies = [
 name = "limux-host-linux"
 version = "0.1.21"
 dependencies = [
+ "cc",
  "dirs",
  "gdk4-wayland",
  "gtk4",

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "Limux — GPU-accelerated terminal workspace manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShell {
+            name = "limux-dev";
+            nativeBuildInputs = with pkgs; [
+              cargo rustc pkg-config zig_0_15 ncurses rustPlatform.bindgenHook
+            ];
+            buildInputs = with pkgs; [
+              gtk4 libadwaita libepoxy webkitgtk_6_0 gtk4-layer-shell
+              fontconfig freetype harfbuzz
+            ];
+            PKG_CONFIG_PATH = "${pkgs.gtk4-layer-shell.dev}/lib/pkgconfig";
+            shellHook = ''
+              export RUSTFLAGS="-C link-arg=-Wl,-rpath,${pkgs.libepoxy}/lib $RUSTFLAGS"
+              echo "Limux dev shell. Steps: git submodule update --init --recursive"
+              echo "  cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline && cd .."
+              echo "  cargo build --release"
+              echo "  LD_LIBRARY_PATH=${pkgs.libepoxy}/lib ./target/release/limux"
+            '';
+          };
+        });
+
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          limux = pkgs.rustPlatform.buildRustPackage {
+            pname = "limux";
+            version = "0.1.21";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config rustPlatform.bindgenHook zig_0_15 ncurses makeWrapper
+            ];
+            buildInputs = with pkgs; [
+              gtk4 libadwaita libepoxy webkitgtk_6_0 gtk4-layer-shell
+              fontconfig freetype harfbuzz
+            ];
+
+            PKG_CONFIG_PATH = "${pkgs.gtk4-layer-shell.dev}/lib/pkgconfig";
+
+            preBuild = ''
+              cat > .cargo/config.toml <<'CARGOEOF'
+              [target.x86_64-unknown-linux-gnu]
+              rustflags = ["-C", "link-arg=-Wl,-rpath,$out/lib"]
+              [target.aarch64-unknown-linux-gnu]
+              rustflags = ["-C", "link-arg=-Wl,-rpath,$out/lib"]
+              CARGOEOF
+              pushd ghostty
+                zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline
+              popd
+              # Build glad.o for libghostty's GL loader dependency
+              cc -c ghostty/vendor/glad/src/gl.c -I ghostty/vendor/glad/include \
+                -O2 -o $TMPDIR/glad.o
+              export RUSTFLAGS="-C link-arg=$TMPDIR/glad.o $RUSTFLAGS"
+            '';
+
+            # RUSTFLAGS set in preBuild after glad.o is compiled
+
+            postInstall = ''
+              mkdir -p $out/lib $out/share/limux/ghostty $out/share/terminfo
+              cp ghostty/zig-out/lib/libghostty.so $out/lib/
+              if [ -d ghostty/zig-out/share/ghostty ]; then
+                cp -r ghostty/zig-out/share/ghostty/. $out/share/limux/ghostty/
+              fi
+              for tdir in ghostty/zig-out/share/terminfo; do
+                if [ -d "$tdir" ]; then
+                  for f in "$tdir"/g/ghostty "$tdir"/x/xterm-ghostty; do
+                    [ -f "$f" ] || continue
+                    d=$(dirname "$f"); b=$(basename "$f")
+                    mkdir -p "$out/share/terminfo/$(basename "$d")"
+                    cp "$f" "$out/share/terminfo/$(basename "$d")/$b"
+                  done
+                  break
+                fi
+              done
+              wrapProgram $out/bin/limux \
+                --prefix LD_LIBRARY_PATH : $out/lib \
+                --prefix XDG_DATA_DIRS : $out/share
+            '';
+          };
+          default = self.packages.${system}.limux;
+        });
+    };
+}

--- a/rust/limux-host-linux/Cargo.toml
+++ b/rust/limux-host-linux/Cargo.toml
@@ -27,5 +27,8 @@ serde_json = "1"
 dirs = "6"
 shell-quote = { version = "0.7.2", default-features = false, features = ["bash"] }
 
+[build-dependencies]
+cc = "1.2"
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/rust/limux-host-linux/build.rs
+++ b/rust/limux-host-linux/build.rs
@@ -1,0 +1,34 @@
+use std::path::PathBuf;
+
+fn main() {
+    // Compile glad (GL loader) which libghostty.so depends on at link time.
+    // This must be done from a bin crate's build.rs because we need
+    // rustc-link-arg (which doesn't propagate from library build scripts).
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ghostty_root = manifest_dir.join("../../ghostty");
+    let glad_src = ghostty_root.join("vendor/glad/src/gl.c");
+    let glad_include = ghostty_root.join("vendor/glad/include");
+    if glad_src.exists() {
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+        let cc = cc::Build::new();
+        let compiler = cc.get_compiler();
+        let glad_o = out_dir.join("glad.o");
+        let mut cmd = std::process::Command::new(compiler.path());
+        cmd.args(compiler.args());
+        cmd.arg("-c")
+            .arg(glad_src.to_str().unwrap())
+            .arg("-I")
+            .arg(glad_include.to_str().unwrap())
+            .arg("-O2")
+            .arg("-o")
+            .arg(glad_o.to_str().unwrap());
+        let status = cmd.status().expect("failed to compile glad.c");
+        assert!(status.success(), "glad.c compilation failed");
+
+        // Pass the .o directly to the linker (after -lghostty),
+        // resolving the glad symbols libghostty.so needs.
+        println!("cargo:rustc-link-arg={}", glad_o.display());
+    }
+
+    println!("cargo:rerun-if-changed={}", glad_src.display());
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,47 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+
+mkShell {
+  name = "limux-dev";
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    pkg-config
+    wrapGAppsHook4
+    zig_0_15       # to build libghostty.so
+  ];
+
+  buildInputs = [
+    # Rust GTK/WebKit crate dependencies (found via pkg-config)
+    gtk4 libadwaita webkitgtk_6_0 libsoup_3
+    cairo pango harfbuzz gdk-pixbuf graphene
+    glib libepoxy vulkan-loader wayland
+
+    # libghostty GL deps
+    libGL
+    libxkbcommon fontconfig
+  ];
+
+  # pkg-config needs .dev outputs — use lib.getDev for those that have it,
+  # bare package for single-output ones
+  PKG_CONFIG_PATH = lib.makeSearchPath "lib/pkgconfig" [
+    (lib.getDev gtk4) (lib.getDev libadwaita) (lib.getDev webkitgtk_6_0) (lib.getDev libsoup_3)
+    (lib.getDev cairo) (lib.getDev pango) (lib.getDev harfbuzz) (lib.getDev gdk-pixbuf)
+    (lib.getDev graphene) (lib.getDev glib) (lib.getDev libepoxy) (lib.getDev vulkan-loader)
+    (lib.getDev wayland) (lib.getDev libxkbcommon) (lib.getDev fontconfig) libGL
+  ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    gtk4 libadwaita webkitgtk_6_0 libsoup_3 cairo pango harfbuzz gdk-pixbuf
+    graphene glib libepoxy vulkan-loader wayland libxkbcommon fontconfig libGL
+  ];
+
+  WEBKIT_EXEC_PATH = "${webkitgtk_6_0}/libexec/webkitgtk-6.0";
+
+  shellHook = ''
+    echo "limux dev shell — nix-shell"
+    echo "  cargo build  ← run this"
+  '';
+}


### PR DESCRIPTION
## Summary

Makes Limux buildable on NixOS.

## Changes

- **`shell.nix`** — drop-in nix-shell with all deps (GTK4, libadwaita, webkitgtk, zig, pkg-config, etc.)
- **`flake.nix`** — existing flake updated: glad.o compiled in preBuild, version bumped
- **`rust/limux-host-linux/build.rs`** — compiles `vendor/glad/src/gl.c` into `glad.o` and passes it via `cargo:rustc-link-arg=`. Resolves `gladLoader*` symbols that `libghostty.so` needs at link time (they get dropped by `--as-needed` when placed in the static block)
- **`rust/limux-host-linux/Cargo.toml`** — added `cc` build-dependency

## Build

```sh
nix-shell          # or: nix develop
cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast
cargo build
```

Or with flake:
```sh
nix build .#limux
```