### PR TITLE
feat: track unread notifications per tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Gemini CLI). Every terminal limux spawns auto-exports
 with no flags needed from inside the agent's own terminal.
 
 ```bash
-# Fire a libadwaita toast + sidebar unread badge from any agent
+# Fire a libadwaita toast + tab/workspace unread badges from any agent
 limux notify --subtitle "needs review" --body "blocked on auth choice" "Input needed"
 
 # Install Limux session-restore hooks for supported agents

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -199,7 +199,7 @@ fn parse_global_args() -> Result<GlobalOptions> {
 
 fn print_help() {
     println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
     );
 }
 
@@ -802,16 +802,27 @@ async fn run_send_key(client: &mut Client, args: &[String]) -> Result<Value> {
 /// `limux notify` — post a notification into the sidebar + toast overlay.
 ///
 /// Usage:
-///   limux notify [--workspace <id|ref>] [--subtitle <text>] [--body <text>] <title>
+///   limux notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>
 ///   limux notify --title "..." --subtitle "..." --body "..."
 ///
 /// Mirrors the `cmux notify` shape (title / subtitle / body). Title is
 /// required; subtitle and body are optional. Falls back to the current
 /// workspace via LIMUX_WORKSPACE_ID when --workspace isn't given.
+fn notification_surface_target(
+    args: &[String],
+    mut env_value: impl FnMut(&str) -> Option<String>,
+) -> Option<String> {
+    parse_opt(args, "--surface")
+        .or_else(|| env_value("LIMUX_TAB_ID"))
+        .or_else(|| env_value("LIMUX_SURFACE_ID"))
+        .filter(|value| !value.is_empty())
+}
+
 async fn run_notify(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
         .filter(|s| !s.is_empty());
+    let surface = notification_surface_target(args, |key| env::var(key).ok());
 
     // Title can be provided either via --title or as the trailing positional
     // (matching `limux send`'s ergonomics).
@@ -831,6 +842,9 @@ async fn run_notify(client: &mut Client, args: &[String]) -> Result<Value> {
     }
     if !body.is_empty() {
         params.insert("body".to_string(), Value::String(body));
+    }
+    if let Some(surface) = surface {
+        params.insert("surface_id".to_string(), Value::String(surface));
     }
 
     call_in_workspace_scope(
@@ -968,6 +982,7 @@ async fn run_agent_hook(
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
         .filter(|s| !s.is_empty());
+    let surface = notification_surface_target(args, |key| env::var(key).ok());
 
     let mut params = Map::new();
     params.insert("title".to_string(), Value::String(title));
@@ -976,6 +991,9 @@ async fn run_agent_hook(
     }
     if !body.is_empty() {
         params.insert("body".to_string(), Value::String(body));
+    }
+    if let Some(surface) = surface {
+        params.insert("surface_id".to_string(), Value::String(surface));
     }
 
     let _ = call_in_workspace_scope(
@@ -3698,6 +3716,24 @@ mod cli_arg_tests {
         ]);
 
         assert_eq!(trailing_title(&args).as_deref(), Some("Input needed"));
+    }
+
+    #[test]
+    fn notification_target_prefers_explicit_surface_then_stable_tab_id() {
+        let env_value = |key: &str| match key {
+            "LIMUX_TAB_ID" => Some("tab-stable".to_string()),
+            "LIMUX_SURFACE_ID" => Some("1:tab-stable".to_string()),
+            _ => None,
+        };
+
+        assert_eq!(
+            notification_surface_target(&args(&["--surface", "2:explicit"]), env_value),
+            Some("2:explicit".to_string())
+        );
+        assert_eq!(
+            notification_surface_target(&[], env_value),
+            Some("tab-stable".to_string())
+        );
     }
 
     #[test]

--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -168,10 +168,10 @@ pub enum ControlCommand {
         reply: mpsc::Sender<BridgeResult>,
     },
     /// Post a desktop-style notification into the sidebar + toast overlay.
-    /// `target` chooses the workspace to flag as unread; if not provided,
-    /// the currently-active workspace is used.
+    /// `target` chooses the workspace; `surface_hint` identifies the tab when available.
     CreateNotification {
         target: WorkspaceTarget,
+        surface_hint: Option<String>,
         title: String,
         subtitle: String,
         body: String,
@@ -664,6 +664,7 @@ fn handle_method(
             (
                 ControlCommand::CreateNotification {
                     target,
+                    surface_hint: optional_string(params, &["surface_id", "tab_id"]),
                     title,
                     subtitle,
                     body,
@@ -1016,5 +1017,30 @@ mod tests {
 
         assert_eq!(response.error, None);
         assert_eq!(response.result.expect("result")["text"], "ready");
+    }
+
+    #[test]
+    fn notification_route_preserves_surface_target() {
+        let response = dispatch_request(
+            r#"{"id":1,"method":"notification.create","params":{"workspace_id":"codex","surface_id":"surface:9:tab","title":"Done"}}"#,
+            &|command| match command {
+                ControlCommand::CreateNotification {
+                    target,
+                    surface_hint,
+                    title,
+                    reply,
+                    ..
+                } => {
+                    assert_eq!(target, WorkspaceTarget::Name("codex".to_string()));
+                    assert_eq!(surface_hint, Some("surface:9:tab".to_string()));
+                    assert_eq!(title, "Done");
+                    let _ = reply.send(Ok(json!({ "ok": true })));
+                }
+                other => panic!("unexpected command: {other:?}"),
+            },
+        );
+
+        assert_eq!(response.error, None);
+        assert_eq!(response.result.expect("result")["ok"], true);
     }
 }

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -174,6 +174,19 @@ pub fn find_pane_widget_by_id(pane_id: u32) -> Option<gtk::Widget> {
     lookup_pane_internals(pane_id).map(|internals| internals.pane_outer.clone().upcast())
 }
 
+pub fn retire_pane(pane_widget: &gtk::Widget) {
+    let Some(outer) = pane_widget.downcast_ref::<gtk::Box>() else {
+        return;
+    };
+    let internals = unsafe { outer.steal_data::<Rc<PaneInternals>>("limux-pane-internals") };
+    if let Some(internals) = internals {
+        for entry in &internals.tab_state.borrow().tabs {
+            entry.prepare_for_removal();
+        }
+        unregister_pane(internals.pane_id);
+    }
+}
+
 pub fn set_workspace_dragging_all(active: bool) {
     PANE_REGISTRY.with(|registry| {
         for weak in registry.borrow().values() {
@@ -196,6 +209,7 @@ type PanePathCallback = dyn Fn(&str);
 type PaneDesktopNotificationCallback = dyn Fn(&str, &str, bool, u32, &str);
 type PaneEmptyCallback = dyn Fn(&gtk::Widget, PaneEmptyReason);
 type PaneOpenBrowserHereCallback = dyn Fn(&gtk::Widget);
+type PaneVisibilityCallback = dyn Fn(&gtk::Widget) -> bool;
 type PaneShortcutStateCallback = dyn Fn() -> Rc<ResolvedShortcutConfig>;
 type PaneShortcutCaptureCallback =
     dyn Fn(ShortcutId, Option<NormalizedShortcut>) -> Result<ResolvedShortcutConfig, String>;
@@ -208,6 +222,7 @@ type PaneConfigChangedCallback = dyn Fn(&AppConfig, &AppConfig);
 type PaneWorkspaceLookupCallback = dyn Fn(&gtk::Widget) -> Option<String>;
 
 pub struct PaneCallbacks {
+    pub workspace_id: String,
     pub on_split: Box<PaneSplitCallback>,
     pub on_close_pane: Box<PaneWidgetCallback>,
     pub on_bell: Box<PaneBellCallback>,
@@ -219,6 +234,8 @@ pub struct PaneCallbacks {
     pub on_pwd_changed: Box<PanePathCallback>,
     pub on_empty: Box<PaneEmptyCallback>,
     pub on_state_changed: Box<PaneSignalCallback>,
+    pub on_unread_changed: Box<PaneSignalCallback>,
+    pub is_pane_visible: Box<PaneVisibilityCallback>,
     pub on_split_with_tab: Box<PaneSplitWithTabCallback>,
     pub current_config: Box<PaneConfigCallback>,
     pub on_config_changed: Rc<PaneConfigChangedCallback>,
@@ -385,6 +402,11 @@ pub const PANE_CSS: &str = r#"
     background: alpha(@window_fg_color, 0.08);
 }
 .limux-pin-icon {
+    font-size: 9px;
+    margin-right: 2px;
+}
+.limux-tab-unread-dot {
+    color: @accent_bg_color;
     font-size: 9px;
     margin-right: 2px;
 }
@@ -663,6 +685,12 @@ pub fn cycle_tab_in_pane(pane_widget: &gtk::Widget, delta: i32) {
         &internals.tab_state,
         &new_id,
     );
+    clear_tab_unread_if_visible(
+        &internals.tab_state,
+        &new_id,
+        &internals.pane_outer.clone().upcast(),
+        &internals.callbacks,
+    );
     (internals.callbacks.on_state_changed)();
 }
 
@@ -688,6 +716,12 @@ pub fn focus_active_tab_in_pane(pane_widget: &gtk::Widget) -> bool {
         &internals.content_stack,
         &internals.tab_state,
         &tab_id,
+    );
+    clear_tab_unread_if_visible(
+        &internals.tab_state,
+        &tab_id,
+        &internals.pane_outer.clone().upcast(),
+        &internals.callbacks,
     );
     true
 }
@@ -762,7 +796,40 @@ pub fn activate_tab_in_pane(pane_widget: &gtk::Widget, tab_id: &str) -> bool {
         &internals.tab_state,
         tab_id,
     );
+    clear_tab_unread_if_visible(
+        &internals.tab_state,
+        tab_id,
+        &internals.pane_outer.clone().upcast(),
+        &internals.callbacks,
+    );
     true
+}
+
+fn set_tab_unread(entry: &mut TabEntry, unread: bool) -> bool {
+    if entry.unread == unread {
+        return false;
+    }
+    entry.unread = unread;
+    entry.unread_dot.set_visible(unread);
+    true
+}
+
+fn clear_tab_unread(tab_state: &Rc<RefCell<TabState>>, tab_id: &str) -> bool {
+    tab_state
+        .borrow_mut()
+        .find_tab_mut(tab_id)
+        .is_some_and(|entry| set_tab_unread(entry, false))
+}
+
+fn clear_tab_unread_if_visible(
+    tab_state: &Rc<RefCell<TabState>>,
+    tab_id: &str,
+    pane_widget: &gtk::Widget,
+    callbacks: &Rc<PaneCallbacks>,
+) {
+    if (callbacks.is_pane_visible)(pane_widget) && clear_tab_unread(tab_state, tab_id) {
+        (callbacks.on_unread_changed)();
+    }
 }
 
 fn normalize_surface_hint(raw: &str) -> &str {
@@ -887,9 +954,11 @@ struct TabEntry {
     id: String,
     tab_button: gtk::Box,
     title_label: gtk::Label,
+    unread_dot: gtk::Label,
     content: gtk::Widget,
     custom_name: Option<String>,
     pinned: bool,
+    unread: bool,
     kind: TabKind,
 }
 
@@ -1318,7 +1387,7 @@ fn add_terminal_tab_inner(
         .as_ref()
         .and_then(|value| value.id.map(|id| id.to_string()))
         .unwrap_or_else(next_tab_id);
-    let (tab_btn, title_label) = build_tab_button("Terminal", &tab_id, internals);
+    let (tab_btn, title_label, unread_dot) = build_tab_button("Terminal", &tab_id, internals);
 
     let term_cwd = Rc::new(RefCell::new(
         options
@@ -1398,11 +1467,13 @@ fn add_terminal_tab_inner(
             id: tab_id.clone(),
             tab_button: tab_btn,
             title_label: title_label.clone(),
+            unread_dot,
             content: widget,
             custom_name: options
                 .as_ref()
                 .and_then(|value| value.custom_name.map(|name| name.to_string())),
             pinned: options.as_ref().map(|value| value.pinned).unwrap_or(false),
+            unread: false,
             kind: TabKind::Terminal {
                 state: TerminalTabState {
                     cwd: term_cwd.clone(),
@@ -1465,7 +1536,7 @@ fn add_browser_tab_inner(internals: &Rc<PaneInternals>, options: Option<BrowserT
         internals.callbacks.clone(),
     );
 
-    let (tab_btn, title_label) = build_tab_button(&title, &tab_id, internals);
+    let (tab_btn, title_label, unread_dot) = build_tab_button(&title, &tab_id, internals);
 
     internals.content_stack.add_named(&widget, Some(&tab_id));
 
@@ -1475,11 +1546,13 @@ fn add_browser_tab_inner(internals: &Rc<PaneInternals>, options: Option<BrowserT
             id: tab_id.clone(),
             tab_button: tab_btn,
             title_label: title_label.clone(),
+            unread_dot,
             content: widget,
             custom_name: options
                 .as_ref()
                 .and_then(|value| value.custom_name.map(|name| name.to_string())),
             pinned: options.as_ref().map(|value| value.pinned).unwrap_or(false),
+            unread: false,
             kind: TabKind::Browser {
                 state: BrowserTabState {
                     uri: saved_uri.clone(),
@@ -1532,7 +1605,7 @@ fn add_keybind_editor_tab_inner(internals: &Rc<PaneInternals>, input: KeybindsTa
         .and_then(|value| value.id.map(|id| id.to_string()))
         .unwrap_or_else(next_tab_id);
 
-    let (tab_btn, title_label) = build_tab_button("Keybinds", &tab_id, internals);
+    let (tab_btn, title_label, unread_dot) = build_tab_button("Keybinds", &tab_id, internals);
 
     let widget = keybind_editor::build_keybind_editor(&input.shortcuts, input.on_capture);
     internals.content_stack.add_named(&widget, Some(&tab_id));
@@ -1543,6 +1616,7 @@ fn add_keybind_editor_tab_inner(internals: &Rc<PaneInternals>, input: KeybindsTa
             id: tab_id.clone(),
             tab_button: tab_btn,
             title_label: title_label.clone(),
+            unread_dot,
             content: widget,
             custom_name: input
                 .options
@@ -1553,6 +1627,7 @@ fn add_keybind_editor_tab_inner(internals: &Rc<PaneInternals>, input: KeybindsTa
                 .as_ref()
                 .map(|value| value.pinned)
                 .unwrap_or(false),
+            unread: false,
             kind: TabKind::Keybinds,
         });
     }
@@ -1800,6 +1875,98 @@ fn pane_internals_for_root(root: &gtk::Widget) -> Vec<Rc<PaneInternals>> {
     panes
 }
 
+fn pane_internals_for_workspace(workspace_id: &str) -> Vec<Rc<PaneInternals>> {
+    let mut panes = PANE_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .values()
+            .filter_map(|weak| weak.upgrade())
+            .filter(|internals| internals.callbacks.workspace_id == workspace_id)
+            .collect::<Vec<_>>()
+    });
+    panes.sort_by_key(|internals| internals.pane_id);
+    panes
+}
+
+pub enum TabTargetResolution {
+    NotFound,
+    Unique(u32, String),
+    Ambiguous,
+}
+
+pub fn tab_target_for_workspace(workspace_id: &str, surface_hint: &str) -> TabTargetResolution {
+    let mut target = None;
+    for internals in pane_internals_for_workspace(workspace_id) {
+        let pane_id = internals.pane_id;
+        let tab_state = internals.tab_state.borrow();
+        for entry in &tab_state.tabs {
+            let surface_id = composite_surface_id(pane_id, &entry.id);
+            if surface_hint_matches(&surface_id, &entry.id, surface_hint) {
+                if target.is_some() {
+                    return TabTargetResolution::Ambiguous;
+                }
+                target = Some((pane_id, entry.id.clone()));
+            }
+        }
+    }
+    match target {
+        Some((pane_id, tab_id)) => TabTargetResolution::Unique(pane_id, tab_id),
+        None => TabTargetResolution::NotFound,
+    }
+}
+
+pub fn mark_tab_unread_in_workspace(
+    workspace_id: &str,
+    pane_id: u32,
+    tab_id: &str,
+) -> Option<bool> {
+    let internals = pane_internals_for_workspace(workspace_id)
+        .into_iter()
+        .find(|internals| internals.pane_id == pane_id)?;
+    let mut tab_state = internals.tab_state.borrow_mut();
+    let entry = tab_state.find_tab_mut(tab_id)?;
+    Some(set_tab_unread(entry, true))
+}
+
+pub fn tab_is_visible_in_workspace(
+    workspace_id: &str,
+    root: &gtk::Widget,
+    pane_id: u32,
+    tab_id: &str,
+) -> bool {
+    pane_internals_for_workspace(workspace_id)
+        .into_iter()
+        .find(|internals| internals.pane_id == pane_id)
+        .is_some_and(|internals| {
+            internals.pane_outer.is_ancestor(root)
+                && internals.tab_state.borrow().active_tab.as_deref() == Some(tab_id)
+        })
+}
+
+pub fn clear_active_tab_unread_in_root(root: &gtk::Widget) -> bool {
+    let mut changed = false;
+    for internals in pane_internals_for_root(root) {
+        let active_tab = internals.tab_state.borrow().active_tab.clone();
+        if let Some(tab_id) = active_tab {
+            changed |= clear_tab_unread(&internals.tab_state, &tab_id);
+        }
+    }
+    changed
+}
+
+pub fn workspace_has_unread_tabs(workspace_id: &str) -> bool {
+    pane_internals_for_workspace(workspace_id)
+        .into_iter()
+        .any(|internals| {
+            internals
+                .tab_state
+                .borrow()
+                .tabs
+                .iter()
+                .any(|entry| entry.unread)
+        })
+}
+
 pub fn pane_summaries_for_root(root: &gtk::Widget) -> Vec<PaneSummary> {
     pane_internals_for_root(root)
         .into_iter()
@@ -2024,17 +2191,17 @@ fn build_tab_button(
     title: &str,
     tab_id: &str,
     internals: &Rc<PaneInternals>,
-) -> (gtk::Box, gtk::Label) {
+) -> (gtk::Box, gtk::Label, gtk::Label) {
     let label = new_tab_title_label(title);
-    let tab_button = build_tab_button_from_label(&label, tab_id, internals);
-    (tab_button, label)
+    let (tab_button, unread_dot) = build_tab_button_from_label(&label, tab_id, internals);
+    (tab_button, label, unread_dot)
 }
 
 fn build_tab_button_from_label(
     label: &gtk::Label,
     tab_id: &str,
     internals: &Rc<PaneInternals>,
-) -> gtk::Box {
+) -> (gtk::Box, gtk::Label) {
     if let Some(parent) = label
         .parent()
         .and_then(|parent| parent.downcast::<gtk::Box>().ok())
@@ -2047,6 +2214,11 @@ fn build_tab_button_from_label(
     pin_icon.set_visible(false);
     pin_icon.set_can_target(false);
 
+    let unread_dot = gtk::Label::new(Some("\u{25CF}"));
+    unread_dot.add_css_class("limux-tab-unread-dot");
+    unread_dot.set_visible(false);
+    unread_dot.set_can_target(false);
+
     let close_btn = gtk::Button::builder()
         .icon_name("window-close-symbolic")
         .has_frame(false)
@@ -2056,6 +2228,7 @@ fn build_tab_button_from_label(
     let inner_box = gtk::Box::new(gtk::Orientation::Horizontal, 2);
     inner_box.set_can_target(false);
     inner_box.append(&pin_icon);
+    inner_box.append(&unread_dot);
     inner_box.append(label);
 
     let tab_btn = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -2071,6 +2244,7 @@ fn build_tab_button_from_label(
         let content_stack = internals.content_stack.clone();
         let tab_state = internals.tab_state.clone();
         let callbacks = internals.callbacks.clone();
+        let pane_widget = internals.pane_outer.downgrade();
         let tab_button = tab_btn.clone();
         click.connect_pressed(move |gesture, _, _, _| {
             if handle_tab_interaction_while_renaming(&tab_button, &tab_state) {
@@ -2078,6 +2252,14 @@ fn build_tab_button_from_label(
                 return;
             }
             activate_tab(&tab_strip, &content_stack, &tab_state, &tab_id);
+            if let Some(pane_widget) = pane_widget.upgrade() {
+                clear_tab_unread_if_visible(
+                    &tab_state,
+                    &tab_id,
+                    pane_widget.upcast_ref(),
+                    &callbacks,
+                );
+            }
             (callbacks.on_state_changed)();
         });
     }
@@ -2178,7 +2360,7 @@ fn build_tab_button_from_label(
         });
     }
 
-    tab_btn
+    (tab_btn, unread_dot)
 }
 
 fn show_tab_context_menu(tab_btn: &gtk::Box, tab_id: &str, context: &TabContextMenuContext) {
@@ -2652,10 +2834,14 @@ fn rebind_moved_tab_entry(entry: &mut TabEntry, target: &Rc<PaneInternals>) {
             &state.cwd,
         ));
     }
-    entry.tab_button = build_tab_button_from_label(&entry.title_label, &entry.id, target);
+    let (tab_button, unread_dot) =
+        build_tab_button_from_label(&entry.title_label, &entry.id, target);
+    entry.tab_button = tab_button;
+    entry.unread_dot = unread_dot;
     if entry.pinned {
         apply_pin_visuals(&entry.tab_button, true);
     }
+    entry.unread_dot.set_visible(entry.unread);
 }
 
 fn reorder_tab_to_index(
@@ -2709,6 +2895,7 @@ fn transfer_tab_between_panes(
             next_active_after_tab_removal(&all_ids, source_state.active_tab.as_deref(), source_idx);
         (source_state.tabs.remove(source_idx), next_active)
     };
+    let moved_was_unread = entry.unread;
 
     if let Some(window) = entry
         .content
@@ -2738,6 +2925,10 @@ fn transfer_tab_between_panes(
     }
     rebuild_tab_strip(&target.tab_strip, &target.tab_state);
 
+    if moved_was_unread {
+        (source.callbacks.on_unread_changed)();
+    }
+
     let source_empty = source.tab_state.borrow().tabs.is_empty();
     if source_empty {
         (source.callbacks.on_empty)(
@@ -2751,6 +2942,12 @@ fn transfer_tab_between_panes(
             &source.tab_state,
             &next_active,
         );
+        clear_tab_unread_if_visible(
+            &source.tab_state,
+            &next_active,
+            &source.pane_outer.clone().upcast(),
+            &source.callbacks,
+        );
     }
 
     activate_tab(
@@ -2759,6 +2956,17 @@ fn transfer_tab_between_panes(
         &target.tab_state,
         &moved_tab_id,
     );
+    let target_widget = target.pane_outer.clone().upcast();
+    if (target.callbacks.is_pane_visible)(&target_widget) {
+        clear_tab_unread_if_visible(
+            &target.tab_state,
+            &moved_tab_id,
+            &target_widget,
+            &target.callbacks,
+        );
+    } else if moved_was_unread {
+        (target.callbacks.on_unread_changed)();
+    }
     (target.callbacks.on_state_changed)();
     true
 }
@@ -3010,6 +3218,7 @@ fn remove_tab(
         return;
     };
     let entry = ts.tabs.remove(idx);
+    let removed_was_unread = entry.unread;
 
     entry.prepare_for_removal();
     tab_strip.remove(&entry.tab_button);
@@ -3017,6 +3226,9 @@ fn remove_tab(
 
     if ts.tabs.is_empty() {
         drop(ts);
+        if removed_was_unread {
+            (callbacks.on_unread_changed)();
+        }
         (callbacks.on_empty)(&pane_outer.clone().upcast(), empty_reason);
         return;
     }
@@ -3029,6 +3241,10 @@ fn remove_tab(
 
     if was_active {
         activate_tab(tab_strip, content_stack, tab_state, &new_id);
+        clear_tab_unread_if_visible(tab_state, &new_id, &pane_outer.clone().upcast(), callbacks);
+    }
+    if removed_was_unread {
+        (callbacks.on_unread_changed)();
     }
     (callbacks.on_state_changed)();
 }

--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -207,6 +207,21 @@ impl SplitTreeContainer {
         }
     }
 
+    pub(crate) fn reveal_pane(self: &Rc<Self>, target: &gtk::Widget) -> bool {
+        let should_restore = self
+            .zoomed_pane
+            .borrow()
+            .as_ref()
+            .is_some_and(|zoomed| zoomed != target);
+        if !should_restore {
+            return false;
+        }
+        self.zoomed_pane.borrow_mut().take();
+        *self.last_focused.borrow_mut() = Some(target.clone());
+        self.trigger_rebuild();
+        true
+    }
+
     fn zoom_pane(self: &Rc<Self>, target: &gtk::Widget) {
         self.save_focus();
         *self.zoomed_pane.borrow_mut() = Some(target.clone());

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -50,7 +50,7 @@ struct Workspace {
     notify_dot: gtk::Label,
     /// Notification message label in the sidebar row.
     notify_label: gtk::Label,
-    /// Whether this workspace has unread notifications.
+    /// Unread state for notifications without a tab target.
     unread: bool,
     /// Whether this workspace is favorited/pinned to top.
     favorite: bool,
@@ -1586,6 +1586,22 @@ pub fn build_window(app: &adw::Application) {
 
     {
         let state = state.clone();
+        window.connect_is_active_notify(move |window| {
+            if !window.is_active() {
+                return;
+            }
+            let workspace_id = state
+                .borrow()
+                .active_workspace()
+                .map(|workspace| workspace.id.clone());
+            if let Some(workspace_id) = workspace_id {
+                clear_visible_tab_unread(&state, &workspace_id);
+            }
+        });
+    }
+
+    {
+        let state = state.clone();
         let system_prefers_dark = system_prefers_dark.clone();
         style_manager.connect_dark_notify(move |style_manager| {
             sync_ghostty_color_scheme_for_config(
@@ -2721,8 +2737,26 @@ fn activate_desktop_notification_target(
 }
 
 fn focus_desktop_notification_target(state: &State, target: &DesktopNotificationTarget) -> bool {
+    let workspace = {
+        let s = state.borrow();
+        s.workspaces
+            .iter()
+            .find(|workspace| workspace.id == target.workspace_id)
+            .map(|workspace| (workspace.root.clone(), workspace.split_container.clone()))
+    };
+
     if let Some(pane_id) = target.pane_id {
         if let Some(pane_widget) = pane::find_pane_widget_by_id(pane_id) {
+            if let Some((root, container)) = workspace.as_ref() {
+                if !pane_widget.is_ancestor(root) {
+                    if let Some(tab_id) = target.tab_id.as_deref() {
+                        pane::activate_tab_in_pane(&pane_widget, tab_id);
+                    }
+                    if container.reveal_pane(&pane_widget) {
+                        return true;
+                    }
+                }
+            }
             if let Some(tab_id) = target.tab_id.as_deref() {
                 if pane::activate_tab_in_pane(&pane_widget, tab_id) {
                     return true;
@@ -2735,15 +2769,7 @@ fn focus_desktop_notification_target(state: &State, target: &DesktopNotification
         }
     }
 
-    let root = {
-        let s = state.borrow();
-        s.workspaces
-            .iter()
-            .find(|workspace| workspace.id == target.workspace_id)
-            .map(|workspace| workspace.root.clone())
-    };
-
-    if let Some(root) = root {
+    if let Some((root, _)) = workspace {
         focus_workspace_entrypoint(&root);
         return true;
     }
@@ -4466,6 +4492,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
         }
         ControlCommand::CreateNotification {
             target,
+            surface_hint,
             title,
             subtitle,
             body,
@@ -4478,14 +4505,28 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 workspace_index_for_target(&app_state, &target)
             };
 
-            let Some(index) = resolved else {
+            let Some(preferred_index) = resolved else {
                 let _ = reply.send(Err(crate::control_bridge::BridgeError::not_found(
                     "workspace not found",
                 )));
                 return;
             };
 
-            let ws_id = state.borrow().workspaces[index].id.clone();
+            let (index, tab_target) = surface_hint
+                .as_deref()
+                .map(|surface| resolve_notification_tab_target(state, preferred_index, surface))
+                .unwrap_or((preferred_index, None));
+
+            let (ws_id, root, workspace_is_active, window_active) = {
+                let s = state.borrow();
+                let workspace = &s.workspaces[index];
+                (
+                    workspace.id.clone(),
+                    workspace.root.clone(),
+                    index == s.active_idx,
+                    s.window.is_active(),
+                )
+            };
 
             // Build the sidebar message: title becomes the bold prefix,
             // subtitle + body are joined with " — " for the body text.
@@ -4496,13 +4537,18 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 (false, false) => format!("{subtitle} — {body}"),
             };
             let message = workspace_notification_message(&title, &combined_body);
+            let source_focused = tab_target.as_ref().is_some_and(|(pane_id, tab_id)| {
+                window_active
+                    && workspace_is_active
+                    && pane::tab_is_visible_in_workspace(&ws_id, &root, *pane_id, tab_id)
+            });
             let target = DesktopNotificationTarget {
                 workspace_id: ws_id.clone(),
-                pane_id: None,
-                tab_id: None,
+                pane_id: tab_target.as_ref().map(|(pane_id, _)| *pane_id),
+                tab_id: tab_target.map(|(_, tab_id)| tab_id),
             };
             if let Some(request) =
-                mark_workspace_unread_with_message(state, &ws_id, &message, false, target)
+                mark_workspace_unread_with_message(state, &ws_id, &message, source_focused, target)
             {
                 show_desktop_notification(state, request);
             }
@@ -4597,12 +4643,16 @@ pub(crate) fn create_pane_for_workspace(
     let state_for_keybinds = state.clone();
     let state_for_pwd = state.clone();
     let state_for_empty = state.clone();
+    let state_for_unread = state.clone();
+    let state_for_visibility = state.clone();
     let ws_id_split = ws_id.to_string();
     let ws_id_close = ws_id.to_string();
     let ws_id_bell = ws_id.to_string();
     let ws_id_desktop_notification = ws_id.to_string();
     let ws_id_pwd = ws_id.to_string();
     let ws_id_empty = ws_id.to_string();
+    let ws_id_unread = ws_id.to_string();
+    let ws_id_visibility = ws_id.to_string();
     let state_for_split_with_tab = state.clone();
     let state_for_config = state.clone();
     let state_for_config_changed = state.clone();
@@ -4610,6 +4660,7 @@ pub(crate) fn create_pane_for_workspace(
     let ws_id_for_env = ws_id.to_string();
 
     let callbacks = Rc::new(PaneCallbacks {
+        workspace_id: ws_id.to_string(),
         on_split: Box::new(move |pane_widget, orientation| {
             split_pane(
                 &state_for_split,
@@ -4703,6 +4754,16 @@ pub(crate) fn create_pane_for_workspace(
         on_state_changed: Box::new({
             let state = state.clone();
             move || request_session_save(&state)
+        }),
+        on_unread_changed: Box::new(move || {
+            sync_workspace_unread(&state_for_unread, &ws_id_unread);
+        }),
+        is_pane_visible: Box::new(move |pane_widget| {
+            let s = state_for_visibility.borrow();
+            s.window.is_active()
+                && s.active_workspace().is_some_and(|workspace| {
+                    workspace.id == ws_id_visibility && pane_widget.is_ancestor(&workspace.root)
+                })
         }),
         on_split_with_tab: Box::new(
             move |source_pane, target_pane, orientation, tab_id, new_pane_first| {
@@ -4830,46 +4891,34 @@ fn close_workspace_by_id_internal(
 }
 
 fn switch_workspace(state: &State, idx: usize) {
-    let (stack, stack_name, unread_handles, focus_root) = {
-        let mut s = state.borrow_mut();
-        if idx >= s.workspaces.len() || idx == s.active_idx {
+    let active_workspace_id = {
+        let s = state.borrow();
+        if idx >= s.workspaces.len() {
             return;
         }
+        (idx == s.active_idx).then(|| s.workspaces[idx].id.clone())
+    };
+    if let Some(workspace_id) = active_workspace_id {
+        clear_visible_tab_unread(state, &workspace_id);
+        return;
+    }
+
+    let (stack, stack_name, focus_root, workspace_id) = {
+        let mut s = state.borrow_mut();
         s.active_idx = idx;
         let stack = s.stack.clone();
         let stack_name = format!("ws-{}", s.workspaces[idx].id);
         let focus_root = s.workspaces[idx].root.clone();
+        let workspace_id = s.workspaces[idx].id.clone();
 
-        let unread_handles = if s.workspaces[idx].unread {
-            let ws = &mut s.workspaces[idx];
-            ws.unread = false;
-            Some((
-                ws.notify_dot.clone(),
-                ws.notify_label.clone(),
-                ws.sidebar_row.clone(),
-            ))
-        } else {
-            None
-        };
-
-        (stack, stack_name, unread_handles, focus_root)
+        (stack, stack_name, focus_root, workspace_id)
     };
 
     stack.set_visible_child_name(&stack_name);
+    clear_visible_tab_unread(state, &workspace_id);
     glib::idle_add_local_once(move || {
         focus_workspace_entrypoint(&focus_root);
     });
-
-    if let Some((notify_dot, notify_label, sidebar_row)) = unread_handles {
-        notify_dot.remove_css_class("limux-notify-dot");
-        notify_dot.add_css_class("limux-notify-dot-hidden");
-        notify_label.remove_css_class("limux-notify-msg-unread");
-        notify_label.add_css_class("limux-notify-msg");
-        notify_label.set_visible(false);
-        if let Some(row_box) = sidebar_row.child() {
-            row_box.remove_css_class("limux-sidebar-row-unread");
-        }
-    }
 
     request_session_save(state);
 }
@@ -5153,7 +5202,11 @@ fn remove_pane_internal(state: &State, ws_id: &str, pane_widget: &gtk::Widget, p
     }
 
     // Mutate the data model and trigger async widget tree rebuild
-    container.remove(pane_widget);
+    if !container.remove(pane_widget) {
+        return;
+    }
+    pane::retire_pane(pane_widget);
+    sync_workspace_unread(state, ws_id);
 
     if persist {
         request_session_save(state);
@@ -5754,6 +5807,119 @@ fn should_emit_desktop_notification(
     desktop_notifications_enabled && (!window_active || !workspace_is_active || !source_focused)
 }
 
+fn resolve_notification_tab_target(
+    state: &State,
+    preferred_index: usize,
+    surface_hint: &str,
+) -> (usize, Option<(u32, String)>) {
+    let workspace_ids = state
+        .borrow()
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.id.clone())
+        .collect::<Vec<_>>();
+
+    match pane::tab_target_for_workspace(&workspace_ids[preferred_index], surface_hint) {
+        pane::TabTargetResolution::Unique(pane_id, tab_id) => {
+            return (preferred_index, Some((pane_id, tab_id)));
+        }
+        pane::TabTargetResolution::Ambiguous => return (preferred_index, None),
+        pane::TabTargetResolution::NotFound => {}
+    }
+
+    let mut target = None;
+    for (index, workspace_id) in workspace_ids.iter().enumerate() {
+        if index == preferred_index {
+            continue;
+        }
+        match pane::tab_target_for_workspace(workspace_id, surface_hint) {
+            pane::TabTargetResolution::Unique(pane_id, tab_id) if target.is_none() => {
+                target = Some((index, pane_id, tab_id));
+            }
+            pane::TabTargetResolution::Unique(_, _) | pane::TabTargetResolution::Ambiguous => {
+                return (preferred_index, None);
+            }
+            pane::TabTargetResolution::NotFound => {}
+        }
+    }
+
+    target
+        .map(|(index, pane_id, tab_id)| (index, Some((pane_id, tab_id))))
+        .unwrap_or((preferred_index, None))
+}
+
+fn has_unread(workspace_unread: bool, tab_unread: bool) -> bool {
+    workspace_unread || tab_unread
+}
+
+fn set_workspace_unread_visual(workspace: &Workspace, unread: bool) {
+    if unread {
+        workspace
+            .notify_dot
+            .remove_css_class("limux-notify-dot-hidden");
+        workspace.notify_dot.add_css_class("limux-notify-dot");
+        workspace.notify_label.remove_css_class("limux-notify-msg");
+        workspace
+            .notify_label
+            .add_css_class("limux-notify-msg-unread");
+        workspace
+            .notify_label
+            .set_visible(!workspace.notify_label.label().is_empty());
+        if let Some(row_box) = workspace.sidebar_row.child() {
+            row_box.add_css_class("limux-sidebar-row-unread");
+        }
+    } else {
+        workspace.notify_dot.remove_css_class("limux-notify-dot");
+        workspace
+            .notify_dot
+            .add_css_class("limux-notify-dot-hidden");
+        workspace
+            .notify_label
+            .remove_css_class("limux-notify-msg-unread");
+        workspace.notify_label.add_css_class("limux-notify-msg");
+        workspace.notify_label.set_visible(false);
+        workspace.notify_label.set_label("");
+        if let Some(row_box) = workspace.sidebar_row.child() {
+            row_box.remove_css_class("limux-sidebar-row-unread");
+        }
+    }
+}
+
+fn sync_workspace_unread(state: &State, ws_id: &str) {
+    let workspace_unread = {
+        let s = state.borrow();
+        let Some(workspace) = s.workspaces.iter().find(|workspace| workspace.id == ws_id) else {
+            return;
+        };
+        workspace.unread
+    };
+    let tab_unread = pane::workspace_has_unread_tabs(ws_id);
+    let s = state.borrow();
+    if let Some(workspace) = s.workspaces.iter().find(|workspace| workspace.id == ws_id) {
+        set_workspace_unread_visual(workspace, has_unread(workspace_unread, tab_unread));
+    }
+}
+
+fn clear_visible_tab_unread(state: &State, ws_id: &str) {
+    let root = {
+        let mut s = state.borrow_mut();
+        if !s.window.is_active() {
+            return;
+        }
+        let Some(workspace) = s
+            .workspaces
+            .iter_mut()
+            .find(|workspace| workspace.id == ws_id)
+        else {
+            return;
+        };
+        workspace.unread = false;
+        workspace.root.clone()
+    };
+    pane::clear_active_tab_unread_in_root(&root);
+    sync_workspace_unread(state, ws_id);
+}
+
 fn mark_workspace_unread(
     state: &State,
     ws_id: &str,
@@ -5787,48 +5953,62 @@ fn mark_workspace_unread_with_message(
     source_focused: bool,
     target: DesktopNotificationTarget,
 ) -> Option<DesktopNotificationRequest> {
-    let mut s = state.borrow_mut();
-    let active_idx = s.active_idx;
-    let window_active = s.window.is_active();
-    let notifications = s.config.borrow().notifications;
-    if let Some((idx, ws)) = s
-        .workspaces
-        .iter_mut()
-        .enumerate()
-        .find(|(_, w)| w.id == ws_id)
-    {
-        let workspace_is_active = idx == active_idx;
-        let desktop_request = should_emit_desktop_notification(
-            notifications.enabled,
-            window_active,
-            workspace_is_active,
-            source_focused,
+    let (workspace_idx, active_idx, workspace_name, window_active, notifications) = {
+        let s = state.borrow();
+        let workspace_idx = s
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.id == ws_id)?;
+        let workspace = &s.workspaces[workspace_idx];
+        let notifications = s.config.borrow().notifications;
+        (
+            workspace_idx,
+            s.active_idx,
+            workspace.name.clone(),
+            s.window.is_active(),
+            notifications,
         )
-        .then(|| DesktopNotificationRequest {
-            summary: ws.name.clone(),
-            body: message.to_string(),
-            sound: notifications.sound,
-            target: target.clone(),
-        });
+    };
+    let workspace_is_active = workspace_idx == active_idx;
+    let desktop_request = should_emit_desktop_notification(
+        notifications.enabled,
+        window_active,
+        workspace_is_active,
+        source_focused,
+    )
+    .then(|| DesktopNotificationRequest {
+        summary: workspace_name,
+        body: message.to_string(),
+        sound: notifications.sound,
+        target: target.clone(),
+    });
 
-        if idx != active_idx {
-            ws.unread = true;
-            ws.notify_dot.remove_css_class("limux-notify-dot-hidden");
-            ws.notify_dot.add_css_class("limux-notify-dot");
-            ws.notify_label.set_label(message);
-            ws.notify_label.remove_css_class("limux-notify-msg");
-            ws.notify_label.add_css_class("limux-notify-msg-unread");
-            ws.notify_label.set_visible(true);
-            // Add glow pulse to the sidebar row box
-            if let Some(row_box) = ws.sidebar_row.child() {
-                row_box.add_css_class("limux-sidebar-row-unread");
+    let source_is_unread = !window_active || !workspace_is_active || !source_focused;
+    if source_is_unread {
+        let tab_target = target.pane_id.zip(target.tab_id.as_deref());
+        let tab_was_targeted = tab_target
+            .and_then(|(pane_id, tab_id)| {
+                pane::mark_tab_unread_in_workspace(ws_id, pane_id, tab_id)
+            })
+            .is_some();
+        let mark_workspace_level = !tab_was_targeted;
+
+        if tab_was_targeted || mark_workspace_level {
+            let mut s = state.borrow_mut();
+            if let Some(workspace) = s
+                .workspaces
+                .iter_mut()
+                .find(|workspace| workspace.id == ws_id)
+            {
+                workspace.unread |= mark_workspace_level;
+                workspace.notify_label.set_label(message);
             }
+            drop(s);
+            sync_workspace_unread(state, ws_id);
         }
-
-        return desktop_request;
     }
 
-    None
+    desktop_request
 }
 
 fn desktop_notification_hints(
@@ -5928,9 +6108,9 @@ mod tests {
         desktop_notification_activation_token_from_signal,
         desktop_notification_closed_id_from_signal, desktop_notification_id_from_response,
         directional_neighbor_score, favorites_prefix_len, font_size_after_delta,
-        ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, next_active_workspace_index,
-        pane_create_split_placement, queue_session_save_request, resolve_pane_create_source_id,
-        resolved_system_prefers_dark, sanitize_background_opacity,
+        ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
+        next_active_workspace_index, pane_create_split_placement, queue_session_save_request,
+        resolve_pane_create_source_id, resolved_system_prefers_dark, sanitize_background_opacity,
         shortcut_allowed_while_browser_find_active, shortcut_blocked_by_editable,
         shortcut_command_from_key_event, shortcut_dispatch_propagation,
         should_emit_desktop_notification, tab_drag_workspace_seed, use_opaque_window_background,
@@ -6397,6 +6577,13 @@ mod tests {
             false, false, false, false
         ));
         assert!(!should_emit_desktop_notification(true, true, true, true));
+    }
+
+    #[test]
+    fn workspace_badge_stays_unread_while_any_tab_is_unread() {
+        assert!(has_unread(false, true));
+        assert!(has_unread(true, false));
+        assert!(!has_unread(false, false));
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does

- Adds an unread blue dot to each tab that receives a bell or agent notification.
- Keeps the workspace unread indicator visible while any tab in that workspace remains unread.
- Clears unread state only when the relevant tab is visible, including workspace switches, window activation, split panes, and zoomed panes.
- Routes `limux notify` and agent hooks through the stable tab ID, so notifications still find tabs moved between panes or workspaces.
- Recomputes aggregate unread state when tabs move or close, and rejects ambiguous tab targets instead of silently dropping notifications.

## Why

Unread state was stored only on the workspace and cleared as soon as the workspace was selected. A notification in a background tab therefore disappeared before the user viewed that tab.

## Validation

- `RUSTFLAGS='-C link-arg=-Wl,-u,gladLoaderLoadGLContext -C link-arg=-Wl,-u,gladLoaderUnloadGLContext' ./scripts/check.sh`
- 29 CLI tests, 212 GTK host tests, workspace tests, clippy with warnings denied, formatting, doc tests, and packaging smoke all pass.
- Added regressions for notification surface routing, stable tab-ID precedence, and workspace aggregation.

<img width="617" height="195" alt="image" src="https://github.com/user-attachments/assets/ded9fee9-e2a6-4e8a-af3b-0c93d0707df0" />


