### PR TITLE
feat: add workspace path visibility setting

### DIFF
--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -53,11 +53,23 @@ pub struct AppConfig {
     pub font_size: Option<f32>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AppearanceConfig {
     pub color_scheme: ColorScheme,
     pub ghostty_color_scheme: ColorScheme,
     pub ui_scale: UiScale,
+    pub show_workspace_path: bool,
+}
+
+impl Default for AppearanceConfig {
+    fn default() -> Self {
+        Self {
+            color_scheme: ColorScheme::default(),
+            ghostty_color_scheme: ColorScheme::default(),
+            ui_scale: UiScale::default(),
+            show_workspace_path: true,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -289,6 +301,11 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .and_then(UiScale::new)
         .unwrap_or_default();
 
+    let show_workspace_path = appearance
+        .and_then(|appearance| appearance.get("show_workspace_path"))
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
     let notifications = root.get("notifications").and_then(Value::as_object);
     let notification_defaults = NotificationConfig::default();
     let notifications_enabled = notifications
@@ -322,6 +339,7 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
             color_scheme,
             ghostty_color_scheme,
             ui_scale,
+            show_workspace_path,
         },
         notifications: NotificationConfig {
             enabled: notifications_enabled,
@@ -354,6 +372,10 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
     appearance.insert(
         "ghostty_color_scheme".to_string(),
         json!(config.appearance.ghostty_color_scheme.as_str()),
+    );
+    appearance.insert(
+        "show_workspace_path".to_string(),
+        json!(config.appearance.show_workspace_path),
     );
     if !config.appearance.ui_scale.is_default() {
         appearance.insert(
@@ -488,7 +510,8 @@ fn ensure_default_config_file(path: &Path) -> std::io::Result<()> {
     let default_root = json!({
         "appearance": {
             "color_scheme": "dark",
-            "ghostty_color_scheme": "dark"
+            "ghostty_color_scheme": "dark",
+            "show_workspace_path": true
         },
         "focus": {
             "hover_terminal_focus": false
@@ -571,6 +594,10 @@ mod tests {
         assert_eq!(
             parsed["appearance"]["ghostty_color_scheme"],
             Value::String("dark".to_string())
+        );
+        assert_eq!(
+            parsed["appearance"]["show_workspace_path"],
+            Value::Bool(true)
         );
         assert_eq!(parsed["notifications"]["enabled"], Value::Bool(true));
         assert_eq!(
@@ -721,6 +748,28 @@ mod tests {
     }
 
     #[test]
+    fn load_from_path_reads_workspace_path_visibility() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+        fs::write(
+            &path,
+            r#"{
+  "appearance": {
+    "show_workspace_path": false
+  }
+}
+"#,
+        )
+        .expect("write config");
+
+        let loaded = load_from_path(&path);
+
+        assert!(loaded.warnings.is_empty());
+        assert!(!loaded.config.appearance.show_workspace_path);
+    }
+
+    #[test]
     fn save_writes_gtk_and_ghostty_color_schemes() {
         let dir = TempDir::new().expect("temp dir");
         let path = settings_path_in(dir.path());
@@ -758,6 +807,24 @@ mod tests {
         let raw = fs::read_to_string(&path).expect("read config");
         let parsed: Value = serde_json::from_str(&raw).expect("parse config");
         assert_eq!(parsed["appearance"]["ui_scale"], json!(1.5));
+    }
+
+    #[test]
+    fn save_to_path_writes_workspace_path_visibility() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+
+        let mut config = AppConfig::default();
+        config.appearance.show_workspace_path = false;
+        save_to_path(&path, &config).expect("save workspace path visibility");
+
+        let raw = fs::read_to_string(&path).expect("read config");
+        let parsed: Value = serde_json::from_str(&raw).expect("parse config");
+        assert_eq!(
+            parsed["appearance"]["show_workspace_path"],
+            Value::Bool(false)
+        );
     }
 
     #[test]

--- a/rust/limux-host-linux/src/settings_editor.rs
+++ b/rust/limux-host-linux/src/settings_editor.rs
@@ -143,7 +143,11 @@ pub fn present_settings_dialog(parent: &impl IsA<gtk::Widget>, input: SettingsEd
     window.present();
 }
 
-fn apply_config_change<F, G>(config: &Rc<RefCell<AppConfig>>, on_changed: &F, update: G)
+fn apply_config_change<F, G>(
+    config: &Rc<RefCell<AppConfig>>,
+    on_changed: &F,
+    update: G,
+) -> AppConfig
 where
     F: Fn(&AppConfig, &AppConfig) + ?Sized,
     G: FnOnce(&mut AppConfig),
@@ -156,6 +160,7 @@ where
         (previous, updated)
     };
     on_changed(&previous, &updated);
+    config.borrow().clone()
 }
 
 fn build_settings_window_content(window: &adw::Window, input: SettingsEditorInput) -> gtk::Widget {
@@ -368,11 +373,22 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
     {
         let config = input.config.clone();
         let on_changed = input.on_config_changed.clone();
+        let syncing = Rc::new(Cell::new(false));
         workspace_path_switch.connect_active_notify(move |switch| {
+            if syncing.get() {
+                return;
+            }
             let show_workspace_path = switch.is_active();
-            apply_config_change(&config, &*on_changed, move |c| {
+            let effective = apply_config_change(&config, &*on_changed, move |c| {
                 c.appearance.show_workspace_path = show_workspace_path;
-            });
+            })
+            .appearance
+            .show_workspace_path;
+            if switch.is_active() != effective {
+                syncing.set(true);
+                switch.set_active(effective);
+                syncing.set(false);
+            }
         });
     }
     {
@@ -503,20 +519,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn apply_config_change_allows_reentrant_config_sync() {
+    fn apply_config_change_returns_reentrant_config_state() {
         let config = Rc::new(RefCell::new(AppConfig::default()));
 
-        apply_config_change(
+        let effective = apply_config_change(
             &config,
-            &|_previous, updated| {
-                config.borrow_mut().clone_from(updated);
+            &|previous, _updated| {
+                config.borrow_mut().clone_from(previous);
             },
             |current| {
                 current.focus.hover_terminal_focus = true;
             },
         );
 
-        assert!(config.borrow().focus.hover_terminal_focus);
+        assert!(!effective.focus.hover_terminal_focus);
+        assert!(!config.borrow().focus.hover_terminal_focus);
     }
 
     #[test]

--- a/rust/limux-host-linux/src/settings_editor.rs
+++ b/rust/limux-host-linux/src/settings_editor.rs
@@ -267,6 +267,19 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
     hover_row.set_activatable_widget(Some(&hover_switch));
     group.add(&hover_row);
 
+    let workspace_path_row = adw::ActionRow::builder()
+        .title("Show workspace path")
+        .subtitle("Display workspace folder below its name")
+        .build();
+    workspace_path_row.set_title_lines(1);
+    workspace_path_row.set_subtitle_lines(2);
+    let workspace_path_switch = gtk::Switch::new();
+    workspace_path_switch.set_active(input.config.borrow().appearance.show_workspace_path);
+    workspace_path_switch.set_valign(gtk::Align::Center);
+    workspace_path_row.add_suffix(&workspace_path_switch);
+    workspace_path_row.set_activatable_widget(Some(&workspace_path_switch));
+    group.add(&workspace_path_row);
+
     let auto_copy_row = adw::ActionRow::builder()
         .title("Copy selection automatically")
         .subtitle("Copy selected terminal text to the regular clipboard")
@@ -349,6 +362,16 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
             let hover_terminal_focus = switch.is_active();
             apply_config_change(&config, &*on_changed, move |c| {
                 c.focus.hover_terminal_focus = hover_terminal_focus;
+            });
+        });
+    }
+    {
+        let config = input.config.clone();
+        let on_changed = input.on_config_changed.clone();
+        workspace_path_switch.connect_active_notify(move |switch| {
+            let show_workspace_path = switch.is_active();
+            apply_config_change(&config, &*on_changed, move |c| {
+                c.appearance.show_workspace_path = show_workspace_path;
             });
         });
     }

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -59,7 +59,6 @@ struct Workspace {
     /// The folder path this workspace was opened with.
     folder_path: Option<String>,
     /// Path label shown below workspace name in sidebar.
-    #[allow(dead_code)]
     path_label: gtk::Label,
 }
 
@@ -2882,6 +2881,7 @@ fn activate_last_workspace_shortcut(state: &State) {
 fn build_sidebar_row(
     name: &str,
     folder_path: Option<&str>,
+    show_workspace_path: bool,
 ) -> (
     gtk::ListBoxRow,
     gtk::Label,
@@ -2923,10 +2923,8 @@ fn build_sidebar_row(
     if let Some(p) = folder_path {
         path_label.set_label(&abbreviate_path(p));
         path_label.set_tooltip_text(Some(p));
-        path_label.set_visible(true);
-    } else {
-        path_label.set_visible(false);
     }
+    path_label.set_visible(workspace_path_visible(folder_path, show_workspace_path));
 
     let notify_label = gtk::Label::builder()
         .xalign(0.0)
@@ -2956,6 +2954,20 @@ fn build_sidebar_row(
         notify_label,
         path_label,
     )
+}
+
+fn workspace_path_visible(folder_path: Option<&str>, show_workspace_path: bool) -> bool {
+    show_workspace_path && folder_path.is_some()
+}
+
+fn sync_workspace_path_visibility(state: &State, show_workspace_path: bool) {
+    let app_state = state.borrow();
+    for workspace in &app_state.workspaces {
+        workspace.path_label.set_visible(workspace_path_visible(
+            workspace.folder_path.as_deref(),
+            show_workspace_path,
+        ));
+    }
 }
 
 /// Abbreviate a path by replacing the home directory with ~.
@@ -3478,8 +3490,14 @@ fn create_workspace_for_tab(state: &State, payload: &str) -> bool {
     let split_container = SplitTreeContainer::new(state, pane.clone().upcast());
     let root = split_container.widget().clone();
 
+    let show_workspace_path = state
+        .borrow()
+        .config
+        .borrow()
+        .appearance
+        .show_workspace_path;
     let (row, name_label, favorite_button, notify_dot, notify_label, path_label) =
-        build_sidebar_row(&seed.name, seed.folder_path.as_deref());
+        build_sidebar_row(&seed.name, seed.folder_path.as_deref(), show_workspace_path);
     let row_clone = row.clone();
     {
         let mut app_state = state.borrow_mut();
@@ -4593,8 +4611,18 @@ fn add_workspace_from_state(state: &State, workspace: &WorkspaceState) {
         build_workspace_root(state, &shortcuts, &id, working_dir, &workspace.layout);
     stack.add_named(&root, Some(&stack_name));
 
+    let show_workspace_path = state
+        .borrow()
+        .config
+        .borrow()
+        .appearance
+        .show_workspace_path;
     let (row, name_label, favorite_button, notify_dot, notify_label, path_label) =
-        build_sidebar_row(&workspace.name, workspace.folder_path.as_deref());
+        build_sidebar_row(
+            &workspace.name,
+            workspace.folder_path.as_deref(),
+            show_workspace_path,
+        );
     sidebar_list.append(&row);
     install_workspace_row_interactions(state, &id, &row, &favorite_button);
 
@@ -4794,6 +4822,13 @@ pub(crate) fn create_pane_for_workspace(
                 if updated.appearance.ui_scale != previous.appearance.ui_scale {
                     reload_app_css(&state_for_config_changed, updated);
                 }
+                if updated.appearance.show_workspace_path != previous.appearance.show_workspace_path
+                {
+                    sync_workspace_path_visibility(
+                        &state_for_config_changed,
+                        updated.appearance.show_workspace_path,
+                    );
+                }
                 if let Err(err) = app_config::save(updated) {
                     state_for_config_changed
                         .borrow()
@@ -4803,6 +4838,14 @@ pub(crate) fn create_pane_for_workspace(
                     apply_appearance(&style_manager, system_prefers_dark, &previous.appearance);
                     if updated.appearance.ui_scale != previous.appearance.ui_scale {
                         reload_app_css(&state_for_config_changed, previous);
+                    }
+                    if updated.appearance.show_workspace_path
+                        != previous.appearance.show_workspace_path
+                    {
+                        sync_workspace_path_visibility(
+                            &state_for_config_changed,
+                            previous.appearance.show_workspace_path,
+                        );
                     }
 
                     let detail = format!("Failed to save Limux settings: {err}");
@@ -6134,8 +6177,8 @@ mod tests {
         shortcut_command_from_key_event, shortcut_dispatch_propagation,
         should_emit_desktop_notification, tab_drag_workspace_seed, use_opaque_window_background,
         validate_workspace_folder_input_with_dirs, workspace_drop_layout_path,
-        workspace_folder_path_from_input, workspace_notification_message, Direction,
-        EditableCaptureContext, NeighborScore, PaneBounds, PaneCreateDirection,
+        workspace_folder_path_from_input, workspace_notification_message, workspace_path_visible,
+        Direction, EditableCaptureContext, NeighborScore, PaneBounds, PaneCreateDirection,
         PaneCreateTargetError, PortalColorSchemePreference, SessionSaveAccess, SessionSaveRequest,
         WorkspaceSeedSource, BASE_CSS, HOST_ENTRY_CSS_CLASS, WORKSPACE_RENAME_ENTRY_CSS_CLASS,
         WORKSPACE_RENAME_ENTRY_CSS_CLASSES,
@@ -7000,6 +7043,13 @@ mod tests {
         assert_eq!(seed.name, "Browser");
         assert_eq!(seed.cwd.as_deref(), Some("/workspace-folder"));
         assert_eq!(seed.folder_path.as_deref(), Some("/workspace-folder"));
+    }
+
+    #[test]
+    fn workspace_path_visibility_requires_path_and_enabled_setting() {
+        assert!(workspace_path_visible(Some("/workspace"), true));
+        assert!(!workspace_path_visible(Some("/workspace"), false));
+        assert!(!workspace_path_visible(None, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Workspace rows always display their folder path, which makes each sidebar row taller and limits how many workspaces fit without scrolling.

Add a default-on **Show workspace path** switch under General settings. Disabling it hides path subtext immediately for existing rows and keeps new or restored rows compact.

## Changes

- persist `appearance.show_workspace_path` with a backward-compatible default of `true`
- update workspace path labels live when setting changes
- apply setting to newly created and restored workspace rows
- restore previous visibility and switch state if saving settings fails
- cover defaults, persistence, and visibility behavior with focused tests

## Testing

- `cargo test -p limux-host-linux workspace_path`
- `./scripts/check.sh` with freshly built Ghostty on `LD_LIBRARY_PATH`
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`
- 299 Rust tests passed
- 14 package-script checks passed
- live GTK/Ghostty smoke passed
- workspace-wide clippy passed with warnings denied

## Did this cause any problems?

No known regressions. Reverting commit restores always-visible workspace paths.