### PR TITLE
chore: bump version to 0.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "limux-cli"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "limux-control"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "limux-core"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "limux-protocol",
@@ -779,14 +779,14 @@ dependencies = [
 
 [[package]]
 name = "limux-ghostty-sys"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "limux-host-linux"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "dirs",
  "gdk4-wayland",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "limux-protocol"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["limux contributors"]
 edition = "2021"
 license = "MIT"
-version = "0.1.21"
+version = "0.1.22"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

Prepare Limux 0.1.22 release from current main, including recently merged stability fixes.

## Changes

- bump workspace package version to 0.1.22
- refresh Limux crate versions in Cargo.lock

## Testing

- `./scripts/check.sh`
- verified Cargo resolves Limux workspace crates as 0.1.22

## Did this cause any problems?

Revert version bump before publishing v0.1.22.