### PR TITLE
ci: harden release process

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract version
         id: version

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: "Version to build (without v prefix)"
-        required: false
+        required: true
 
 permissions:
   contents: write
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -31,6 +31,9 @@ jobs:
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Validate release version
+        run: ./scripts/validate-release-version.sh "${{ steps.version.outputs.version }}"
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2
@@ -100,7 +103,7 @@ jobs:
 
       - name: Upload packages to release
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: |
@@ -109,7 +112,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload packages as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: limux-linux-packages-${{ steps.version.outputs.version }}
           path: dist/*

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: "Version to build (without v prefix)"
-        required: false
+        required: true
 
 permissions:
   contents: write
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -35,6 +35,9 @@ jobs:
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Validate release version
+        run: ./scripts/validate-release-version.sh "${{ steps.version.outputs.version }}"
 
       - name: Install stable Rust
         run: |
@@ -95,7 +98,7 @@ jobs:
 
       - name: Upload RPM to release
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: ${{ steps.rpm.outputs.rpm_path }}
@@ -103,7 +106,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload RPM as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: limux-rpm-${{ steps.version.outputs.version }}
           path: ${{ steps.rpm.outputs.rpm_path }}

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Download the latest release from [GitHub Releases](https://github.com/am-will/li
 
 **Debian/Ubuntu (.deb)** — recommended:
 ```bash
-sudo dpkg -i ./limux_0.1.20_amd64.deb
+sudo dpkg -i ./limux_*_amd64.deb
 ```
 
 **AppImage** — portable across Ubuntu 24.04-era desktops and newer, no install needed:
 ```bash
-chmod +x Limux-0.1.20-x86_64.AppImage
-./Limux-0.1.20-x86_64.AppImage
+chmod +x Limux-*-x86_64.AppImage
+./Limux-*-x86_64.AppImage
 ```
 
 Release AppImages are built and checked on the Ubuntu 24.04 `GLIBC_2.39`
@@ -114,6 +114,7 @@ Run the canonical local quality gate before committing:
 ```
 
 Repository maintainability rules live in [`docs/maintainability.md`](docs/maintainability.md).
+Release procedure lives in [`docs/releasing.md`](docs/releasing.md).
 
 ## Agent integrations
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,47 @@
+# Releasing Limux
+
+Releases are cut from a version-bumped, green `main` commit. Publishing a
+GitHub release triggers Linux package, RPM, and AUR automation.
+
+## Cut a release
+
+1. Bump `workspace.package.version` in `Cargo.toml` and refresh `Cargo.lock`:
+
+   ```bash
+   cargo check -p limux-protocol
+   ./scripts/check.sh
+   ```
+
+2. Merge the version bump through a pull request and wait for the `main`
+   `Rust Quality` run to pass.
+
+3. Publish the release at that exact merge commit:
+
+   ```bash
+   version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+   sha=$(gh api repos/am-will/limux/commits/main --jq .sha)
+   gh release create "v$version" \
+     --repo am-will/limux \
+     --target "$sha" \
+     --title "Limux v$version" \
+     --generate-notes
+   ```
+
+4. Wait for `Build Linux Release Packages` and `Build RPM Package`. A
+   successful tagged Linux build triggers `Publish to AUR`.
+
+5. Verify release contains tarball, Debian package, AppImage, and RPM. Confirm
+   AUR `limux-bin` reports matching version.
+
+## Rebuild release assets
+
+Both package workflows support manual dispatch. Select release tag as workflow
+ref and provide matching version:
+
+```bash
+gh workflow run release-linux.yml --ref v0.1.22 -f version=0.1.22
+gh workflow run release-rpm.yml --ref v0.1.22 -f version=0.1.22
+```
+
+`scripts/validate-release-version.sh` rejects malformed versions and mismatches
+between workflow input, package version, and checked-out Cargo workspace.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -8,4 +8,5 @@ cd "$ROOT_DIR"
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+./scripts/tests/test-release-version.sh
 ./scripts/tests/test-package-svg-loader.sh

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Read version from workspace Cargo.toml (single source of truth)
 VERSION="${1:-$(grep '^version' "$ROOT_DIR/Cargo.toml" | head -1 | sed 's/.*"\(.*\)"/\1/')}"
+"$ROOT_DIR/scripts/validate-release-version.sh" "$VERSION" >/dev/null
 ARCH="$(uname -m)"
 DEB_ARCH="amd64"
 [ "$ARCH" = "aarch64" ] && DEB_ARCH="arm64"

--- a/scripts/tests/test-release-version.sh
+++ b/scripts/tests/test-release-version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate-release-version.sh"
+WORKSPACE_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -1)"
+
+actual="$($VALIDATOR "$WORKSPACE_VERSION")"
+[ "$actual" = "$WORKSPACE_VERSION" ]
+
+for invalid in "" "v$WORKSPACE_VERSION" "0.1" "next"; do
+    if "$VALIDATOR" "$invalid" >/dev/null 2>&1; then
+        echo "FAIL: accepted invalid release version: ${invalid:-<empty>}" >&2
+        exit 1
+    fi
+done
+
+mismatch="999.999.999"
+if "$VALIDATOR" "$mismatch" >/dev/null 2>&1; then
+    echo "FAIL: accepted version that differs from Cargo.toml: $mismatch" >&2
+    exit 1
+fi
+
+echo "release version validation: OK"

--- a/scripts/validate-release-version.sh
+++ b/scripts/validate-release-version.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REQUESTED_VERSION="${1:-}"
+WORKSPACE_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -1)"
+
+if [[ ! "$REQUESTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: release version must use x.y.z without a v prefix: ${REQUESTED_VERSION:-<empty>}" >&2
+    exit 1
+fi
+
+if [ "$REQUESTED_VERSION" != "$WORKSPACE_VERSION" ]; then
+    echo "ERROR: release version $REQUESTED_VERSION does not match Cargo workspace version $WORKSPACE_VERSION" >&2
+    exit 1
+fi
+
+printf '%s\n' "$REQUESTED_VERSION"


### PR DESCRIPTION
## Summary

Remove release ambiguity found while cutting v0.1.22 and make future releases reproducible from version-bumped main.

## Changes

- document version bump, exact-SHA release, asset verification, and rebuild flow
- reject malformed or Cargo-mismatched package versions before builds
- require manual workflow version input
- update GitHub Actions to current Node 24-compatible majors where available
- keep install examples version-independent

## Testing

- `./scripts/check.sh`
- ShellCheck on new release validation scripts
- parsed all workflow YAML with `yq`
- verified matching, malformed, prefixed, empty, and mismatched versions

## Did this cause any problems?

Revert this commit. Existing v0.1.22 artifacts are unaffected.