### PR TITLE
fix: handle embedded terminal mouse cursor actions

### DIFF
--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -77,6 +77,7 @@ pub const GHOSTTY_ACTION_DESKTOP_NOTIFICATION: c_int = 31;
 pub const GHOSTTY_ACTION_SET_TITLE: c_int = 32;
 pub const GHOSTTY_ACTION_PWD: c_int = 34;
 pub const GHOSTTY_ACTION_MOUSE_SHAPE: c_int = 35;
+pub const GHOSTTY_ACTION_MOUSE_VISIBILITY: c_int = 36;
 pub const GHOSTTY_ACTION_MOUSE_OVER_LINK: c_int = 37;
 pub const GHOSTTY_ACTION_COLOR_CHANGE: c_int = 45;
 pub const GHOSTTY_ACTION_RELOAD_CONFIG: c_int = 46;
@@ -85,6 +86,48 @@ pub const GHOSTTY_ACTION_CLOSE_WINDOW: c_int = 48;
 pub const GHOSTTY_ACTION_RING_BELL: c_int = 49;
 pub const GHOSTTY_ACTION_OPEN_URL: c_int = 53;
 pub const GHOSTTY_ACTION_SHOW_CHILD_EXITED: c_int = 54;
+
+pub type ghostty_action_mouse_shape_e = c_int;
+
+pub const GHOSTTY_MOUSE_SHAPE_DEFAULT: ghostty_action_mouse_shape_e = 0;
+pub const GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU: ghostty_action_mouse_shape_e = 1;
+pub const GHOSTTY_MOUSE_SHAPE_HELP: ghostty_action_mouse_shape_e = 2;
+pub const GHOSTTY_MOUSE_SHAPE_POINTER: ghostty_action_mouse_shape_e = 3;
+pub const GHOSTTY_MOUSE_SHAPE_PROGRESS: ghostty_action_mouse_shape_e = 4;
+pub const GHOSTTY_MOUSE_SHAPE_WAIT: ghostty_action_mouse_shape_e = 5;
+pub const GHOSTTY_MOUSE_SHAPE_CELL: ghostty_action_mouse_shape_e = 6;
+pub const GHOSTTY_MOUSE_SHAPE_CROSSHAIR: ghostty_action_mouse_shape_e = 7;
+pub const GHOSTTY_MOUSE_SHAPE_TEXT: ghostty_action_mouse_shape_e = 8;
+pub const GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT: ghostty_action_mouse_shape_e = 9;
+pub const GHOSTTY_MOUSE_SHAPE_ALIAS: ghostty_action_mouse_shape_e = 10;
+pub const GHOSTTY_MOUSE_SHAPE_COPY: ghostty_action_mouse_shape_e = 11;
+pub const GHOSTTY_MOUSE_SHAPE_MOVE: ghostty_action_mouse_shape_e = 12;
+pub const GHOSTTY_MOUSE_SHAPE_NO_DROP: ghostty_action_mouse_shape_e = 13;
+pub const GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED: ghostty_action_mouse_shape_e = 14;
+pub const GHOSTTY_MOUSE_SHAPE_GRAB: ghostty_action_mouse_shape_e = 15;
+pub const GHOSTTY_MOUSE_SHAPE_GRABBING: ghostty_action_mouse_shape_e = 16;
+pub const GHOSTTY_MOUSE_SHAPE_ALL_SCROLL: ghostty_action_mouse_shape_e = 17;
+pub const GHOSTTY_MOUSE_SHAPE_COL_RESIZE: ghostty_action_mouse_shape_e = 18;
+pub const GHOSTTY_MOUSE_SHAPE_ROW_RESIZE: ghostty_action_mouse_shape_e = 19;
+pub const GHOSTTY_MOUSE_SHAPE_N_RESIZE: ghostty_action_mouse_shape_e = 20;
+pub const GHOSTTY_MOUSE_SHAPE_E_RESIZE: ghostty_action_mouse_shape_e = 21;
+pub const GHOSTTY_MOUSE_SHAPE_S_RESIZE: ghostty_action_mouse_shape_e = 22;
+pub const GHOSTTY_MOUSE_SHAPE_W_RESIZE: ghostty_action_mouse_shape_e = 23;
+pub const GHOSTTY_MOUSE_SHAPE_NE_RESIZE: ghostty_action_mouse_shape_e = 24;
+pub const GHOSTTY_MOUSE_SHAPE_NW_RESIZE: ghostty_action_mouse_shape_e = 25;
+pub const GHOSTTY_MOUSE_SHAPE_SE_RESIZE: ghostty_action_mouse_shape_e = 26;
+pub const GHOSTTY_MOUSE_SHAPE_SW_RESIZE: ghostty_action_mouse_shape_e = 27;
+pub const GHOSTTY_MOUSE_SHAPE_EW_RESIZE: ghostty_action_mouse_shape_e = 28;
+pub const GHOSTTY_MOUSE_SHAPE_NS_RESIZE: ghostty_action_mouse_shape_e = 29;
+pub const GHOSTTY_MOUSE_SHAPE_NESW_RESIZE: ghostty_action_mouse_shape_e = 30;
+pub const GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE: ghostty_action_mouse_shape_e = 31;
+pub const GHOSTTY_MOUSE_SHAPE_ZOOM_IN: ghostty_action_mouse_shape_e = 32;
+pub const GHOSTTY_MOUSE_SHAPE_ZOOM_OUT: ghostty_action_mouse_shape_e = 33;
+
+pub type ghostty_action_mouse_visibility_e = c_int;
+
+pub const GHOSTTY_MOUSE_VISIBLE: ghostty_action_mouse_visibility_e = 0;
+pub const GHOSTTY_MOUSE_HIDDEN: ghostty_action_mouse_visibility_e = 1;
 
 // Key codes (W3C UIEvents, subset)
 pub const GHOSTTY_KEY_UNIDENTIFIED: c_int = 0;
@@ -327,6 +370,8 @@ pub union ghostty_action_u {
     pub set_title: ghostty_action_set_title_s,
     pub pwd: ghostty_action_pwd_s,
     pub open_url: ghostty_action_open_url_s,
+    pub mouse_shape: ghostty_action_mouse_shape_e,
+    pub mouse_visibility: ghostty_action_mouse_visibility_e,
     pub mouse_over_link: ghostty_action_mouse_over_link_s,
     pub child_exited: ghostty_surface_message_childexited_s,
     _padding: [u8; 24],

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -11,7 +11,7 @@ use std::os::unix::ffi::OsStringExt;
 use std::ptr;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use limux_ghostty_sys::*;
@@ -60,6 +60,7 @@ const LINK_PREVIEW_CURSOR_Y_GAP: i32 = 14;
 
 /// Per-surface state, stored in a global registry keyed by surface pointer.
 struct SurfaceEntry {
+    identity: SurfaceIdentity,
     gl_area: gtk::GLArea,
     toast_overlay: gtk::Overlay,
     scrollbar: gtk::Scrollbar,
@@ -136,8 +137,80 @@ enum MouseCursorUpdate {
     Visibility(ghostty_action_mouse_visibility_e),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SurfaceIdentity {
+    surface_key: usize,
+    generation: u64,
+}
+
+#[derive(Default)]
+struct SurfaceIdentityRegistry {
+    next_generation: u64,
+    active_generations: HashMap<usize, u64>,
+}
+
+impl SurfaceIdentityRegistry {
+    fn register(&mut self, surface_key: usize) -> SurfaceIdentity {
+        self.next_generation = self.next_generation.wrapping_add(1);
+        let identity = SurfaceIdentity {
+            surface_key,
+            generation: self.next_generation,
+        };
+        self.active_generations
+            .insert(surface_key, identity.generation);
+        identity
+    }
+
+    fn current(&self, surface_key: usize) -> Option<SurfaceIdentity> {
+        self.active_generations
+            .get(&surface_key)
+            .copied()
+            .map(|generation| SurfaceIdentity {
+                surface_key,
+                generation,
+            })
+    }
+
+    fn is_current(&self, identity: SurfaceIdentity) -> bool {
+        self.current(identity.surface_key) == Some(identity)
+    }
+
+    fn unregister(&mut self, identity: SurfaceIdentity) {
+        if self.is_current(identity) {
+            self.active_generations.remove(&identity.surface_key);
+        }
+    }
+}
+
 thread_local! {
     static SURFACE_MAP: RefCell<HashMap<usize, SurfaceEntry>> = RefCell::new(HashMap::new());
+}
+
+static SURFACE_IDENTITIES: OnceLock<Mutex<SurfaceIdentityRegistry>> = OnceLock::new();
+
+fn surface_identity_registry() -> &'static Mutex<SurfaceIdentityRegistry> {
+    SURFACE_IDENTITIES.get_or_init(|| Mutex::new(SurfaceIdentityRegistry::default()))
+}
+
+fn register_surface_identity(surface_key: usize) -> SurfaceIdentity {
+    surface_identity_registry()
+        .lock()
+        .expect("surface identity registry poisoned")
+        .register(surface_key)
+}
+
+fn current_surface_identity(surface_key: usize) -> Option<SurfaceIdentity> {
+    surface_identity_registry()
+        .lock()
+        .expect("surface identity registry poisoned")
+        .current(surface_key)
+}
+
+fn unregister_surface_identity(identity: SurfaceIdentity) {
+    surface_identity_registry()
+        .lock()
+        .expect("surface identity registry poisoned")
+        .unregister(identity);
 }
 
 #[derive(Clone)]
@@ -629,12 +702,15 @@ fn set_gtk_mouse_cursor(widget: &impl IsA<gtk::Widget>, state: MouseCursorState)
     widget.set_cursor_from_name(Some(state.gtk_cursor_name()));
 }
 
-fn apply_mouse_cursor_update(surface_key: usize, update: MouseCursorUpdate) {
+fn apply_mouse_cursor_update(identity: SurfaceIdentity, update: MouseCursorUpdate) {
     SURFACE_MAP.with(|map| {
         let map = map.borrow();
-        let Some(entry) = map.get(&surface_key) else {
+        let Some(entry) = map.get(&identity.surface_key) else {
             return;
         };
+        if entry.identity != identity {
+            return;
+        }
         let state = match update {
             MouseCursorUpdate::Shape(shape) => entry.mouse_cursor.get().update_shape(shape),
             MouseCursorUpdate::Visibility(visibility) => {
@@ -647,12 +723,16 @@ fn apply_mouse_cursor_update(surface_key: usize, update: MouseCursorUpdate) {
 }
 
 fn dispatch_mouse_cursor_update(surface_key: usize, update: MouseCursorUpdate) {
+    let Some(identity) = current_surface_identity(surface_key) else {
+        return;
+    };
+
     if glib::MainContext::default().is_owner() {
-        apply_mouse_cursor_update(surface_key, update);
+        apply_mouse_cursor_update(identity, update);
     } else {
-        // Capture only copied payload data. GTK access and stale-surface lookup
-        // happen later on the main context.
-        glib::idle_add_once(move || apply_mouse_cursor_update(surface_key, update));
+        // Capture copied payload and surface generation. GTK access happens
+        // later, only if this pointer still identifies the same surface.
+        glib::idle_add_once(move || apply_mouse_cursor_update(identity, update));
     }
 }
 
@@ -1487,6 +1567,8 @@ pub fn create_terminal(
                 eprintln!("limux: failed to create ghostty surface");
                 return;
             }
+            let surface_key = surface as usize;
+            let surface_identity = register_surface_identity(surface_key);
             unsafe {
                 (*clipboard_context).surface.set(surface);
                 ghostty_surface_set_color_scheme(surface, current_ghostty_color_scheme());
@@ -1514,11 +1596,11 @@ pub fn create_terminal(
                 refresh_surface_display(surface, gl_area);
             }
 
-            let surface_key = surface as usize;
             SURFACE_MAP.with(|map| {
                 map.borrow_mut().insert(
                     surface_key,
                     SurfaceEntry {
+                        identity: surface_identity,
                         gl_area: gl.clone(),
                         toast_overlay: overlay_for_map.clone(),
                         scrollbar: scrollbar_for_map.clone(),
@@ -1938,6 +2020,7 @@ pub fn create_terminal(
                 let surface_key = surface as usize;
                 SURFACE_MAP.with(|map| {
                     if let Some(entry) = map.borrow_mut().remove(&surface_key) {
+                        unregister_surface_identity(entry.identity);
                         unsafe {
                             drop(Box::from_raw(entry.clipboard_context));
                         }
@@ -2577,6 +2660,22 @@ mod tests {
         let state = state.update_visibility(c_int::MAX);
         assert!(state.visible);
         assert_eq!(state.gtk_cursor_name(), "wait");
+    }
+
+    #[test]
+    fn surface_generation_rejects_queued_cursor_update_after_address_reuse() {
+        let mut registry = SurfaceIdentityRegistry::default();
+        let surface_key = 0x1234;
+        let original = registry.register(surface_key);
+        let queued_update = registry.current(surface_key).unwrap();
+
+        registry.unregister(original);
+        let replacement = registry.register(surface_key);
+
+        assert_eq!(queued_update.surface_key, replacement.surface_key);
+        assert_ne!(queued_update.generation, replacement.generation);
+        assert!(!registry.is_current(queued_update));
+        assert!(registry.is_current(replacement));
     }
 
     #[test]

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -79,6 +79,7 @@ struct SurfaceEntry {
     link_popover: gtk::Popover,
     link_label: gtk::Label,
     cursor_pos: Rc<Cell<(f64, f64)>>,
+    mouse_cursor: Cell<MouseCursorState>,
 }
 
 struct ClipboardContext {
@@ -91,6 +92,48 @@ struct ClipboardWritePolicy {
     write_clipboard: bool,
     write_primary: bool,
     show_toast: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MouseCursorState {
+    shape: ghostty_action_mouse_shape_e,
+    visible: bool,
+}
+
+impl Default for MouseCursorState {
+    fn default() -> Self {
+        Self {
+            shape: GHOSTTY_MOUSE_SHAPE_TEXT,
+            visible: true,
+        }
+    }
+}
+
+impl MouseCursorState {
+    fn update_shape(self, shape: ghostty_action_mouse_shape_e) -> Self {
+        Self { shape, ..self }
+    }
+
+    fn update_visibility(self, visibility: ghostty_action_mouse_visibility_e) -> Self {
+        Self {
+            visible: visibility != GHOSTTY_MOUSE_HIDDEN,
+            ..self
+        }
+    }
+
+    fn gtk_cursor_name(self) -> &'static str {
+        if self.visible {
+            gtk_cursor_name_for_ghostty_shape(self.shape)
+        } else {
+            "none"
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MouseCursorUpdate {
+    Shape(ghostty_action_mouse_shape_e),
+    Visibility(ghostty_action_mouse_visibility_e),
 }
 
 thread_local! {
@@ -542,6 +585,77 @@ fn current_ghostty_color_scheme() -> c_int {
     CURRENT_COLOR_SCHEME.load(Ordering::Relaxed)
 }
 
+fn gtk_cursor_name_for_ghostty_shape(shape: ghostty_action_mouse_shape_e) -> &'static str {
+    match shape {
+        GHOSTTY_MOUSE_SHAPE_DEFAULT => "default",
+        GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU => "context-menu",
+        GHOSTTY_MOUSE_SHAPE_HELP => "help",
+        GHOSTTY_MOUSE_SHAPE_POINTER => "pointer",
+        GHOSTTY_MOUSE_SHAPE_PROGRESS => "progress",
+        GHOSTTY_MOUSE_SHAPE_WAIT => "wait",
+        GHOSTTY_MOUSE_SHAPE_CELL => "cell",
+        GHOSTTY_MOUSE_SHAPE_CROSSHAIR => "crosshair",
+        GHOSTTY_MOUSE_SHAPE_TEXT => "text",
+        GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT => "vertical-text",
+        GHOSTTY_MOUSE_SHAPE_ALIAS => "alias",
+        GHOSTTY_MOUSE_SHAPE_COPY => "copy",
+        GHOSTTY_MOUSE_SHAPE_MOVE => "move",
+        GHOSTTY_MOUSE_SHAPE_NO_DROP => "no-drop",
+        GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED => "not-allowed",
+        GHOSTTY_MOUSE_SHAPE_GRAB => "grab",
+        GHOSTTY_MOUSE_SHAPE_GRABBING => "grabbing",
+        GHOSTTY_MOUSE_SHAPE_ALL_SCROLL => "all-scroll",
+        GHOSTTY_MOUSE_SHAPE_COL_RESIZE => "col-resize",
+        GHOSTTY_MOUSE_SHAPE_ROW_RESIZE => "row-resize",
+        GHOSTTY_MOUSE_SHAPE_N_RESIZE => "n-resize",
+        GHOSTTY_MOUSE_SHAPE_E_RESIZE => "e-resize",
+        GHOSTTY_MOUSE_SHAPE_S_RESIZE => "s-resize",
+        GHOSTTY_MOUSE_SHAPE_W_RESIZE => "w-resize",
+        GHOSTTY_MOUSE_SHAPE_NE_RESIZE => "ne-resize",
+        GHOSTTY_MOUSE_SHAPE_NW_RESIZE => "nw-resize",
+        GHOSTTY_MOUSE_SHAPE_SE_RESIZE => "se-resize",
+        GHOSTTY_MOUSE_SHAPE_SW_RESIZE => "sw-resize",
+        GHOSTTY_MOUSE_SHAPE_EW_RESIZE => "ew-resize",
+        GHOSTTY_MOUSE_SHAPE_NS_RESIZE => "ns-resize",
+        GHOSTTY_MOUSE_SHAPE_NESW_RESIZE => "nesw-resize",
+        GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE => "nwse-resize",
+        GHOSTTY_MOUSE_SHAPE_ZOOM_IN => "zoom-in",
+        GHOSTTY_MOUSE_SHAPE_ZOOM_OUT => "zoom-out",
+        _ => "default",
+    }
+}
+
+fn set_gtk_mouse_cursor(widget: &impl IsA<gtk::Widget>, state: MouseCursorState) {
+    widget.set_cursor_from_name(Some(state.gtk_cursor_name()));
+}
+
+fn apply_mouse_cursor_update(surface_key: usize, update: MouseCursorUpdate) {
+    SURFACE_MAP.with(|map| {
+        let map = map.borrow();
+        let Some(entry) = map.get(&surface_key) else {
+            return;
+        };
+        let state = match update {
+            MouseCursorUpdate::Shape(shape) => entry.mouse_cursor.get().update_shape(shape),
+            MouseCursorUpdate::Visibility(visibility) => {
+                entry.mouse_cursor.get().update_visibility(visibility)
+            }
+        };
+        entry.mouse_cursor.set(state);
+        set_gtk_mouse_cursor(&entry.gl_area, state);
+    });
+}
+
+fn dispatch_mouse_cursor_update(surface_key: usize, update: MouseCursorUpdate) {
+    if glib::MainContext::default().is_owner() {
+        apply_mouse_cursor_update(surface_key, update);
+    } else {
+        // Capture only copied payload data. GTK access and stale-surface lookup
+        // happen later on the main context.
+        glib::idle_add_once(move || apply_mouse_cursor_update(surface_key, update));
+    }
+}
+
 pub fn sync_color_scheme(dark: bool) {
     let scheme = ghostty_color_scheme_for_dark_mode(dark);
     CURRENT_COLOR_SCHEME.store(scheme, Ordering::Relaxed);
@@ -698,6 +812,25 @@ unsafe extern "C" fn ghostty_action_cb(
                         }
                     });
                 }
+            }
+            true
+        }
+        GHOSTTY_ACTION_MOUSE_SHAPE => {
+            if target.tag == GHOSTTY_TARGET_SURFACE {
+                let surface_key = unsafe { target.target.surface } as usize;
+                let shape = unsafe { action.action.mouse_shape };
+                dispatch_mouse_cursor_update(surface_key, MouseCursorUpdate::Shape(shape));
+            }
+            true
+        }
+        GHOSTTY_ACTION_MOUSE_VISIBILITY => {
+            if target.tag == GHOSTTY_TARGET_SURFACE {
+                let surface_key = unsafe { target.target.surface } as usize;
+                let visibility = unsafe { action.action.mouse_visibility };
+                dispatch_mouse_cursor_update(
+                    surface_key,
+                    MouseCursorUpdate::Visibility(visibility),
+                );
             }
             true
         }
@@ -1143,6 +1276,7 @@ pub fn create_terminal(
     gl_area.set_auto_render(true);
     gl_area.set_focusable(true);
     gl_area.set_can_focus(true);
+    set_gtk_mouse_cursor(&gl_area, MouseCursorState::default());
     let wd = working_directory.map(|s| s.to_string());
     let saved_font_size = options.saved_font_size;
     let startup_command = options.startup_command;
@@ -1437,6 +1571,7 @@ pub fn create_terminal(
                         link_popover: link_popover_for_map.clone(),
                         link_label: link_label_for_map.clone(),
                         cursor_pos: cursor_pos_for_map.clone(),
+                        mouse_cursor: Cell::new(MouseCursorState::default()),
                     },
                 );
             });
@@ -2380,6 +2515,68 @@ mod tests {
             ghostty_color_scheme_for_dark_mode(false),
             GHOSTTY_COLOR_SCHEME_LIGHT
         );
+    }
+
+    #[test]
+    fn maps_ghostty_mouse_shapes_to_gtk_cursor_names() {
+        let cases = [
+            (GHOSTTY_MOUSE_SHAPE_DEFAULT, "default"),
+            (GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU, "context-menu"),
+            (GHOSTTY_MOUSE_SHAPE_HELP, "help"),
+            (GHOSTTY_MOUSE_SHAPE_POINTER, "pointer"),
+            (GHOSTTY_MOUSE_SHAPE_PROGRESS, "progress"),
+            (GHOSTTY_MOUSE_SHAPE_WAIT, "wait"),
+            (GHOSTTY_MOUSE_SHAPE_CELL, "cell"),
+            (GHOSTTY_MOUSE_SHAPE_CROSSHAIR, "crosshair"),
+            (GHOSTTY_MOUSE_SHAPE_TEXT, "text"),
+            (GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT, "vertical-text"),
+            (GHOSTTY_MOUSE_SHAPE_ALIAS, "alias"),
+            (GHOSTTY_MOUSE_SHAPE_COPY, "copy"),
+            (GHOSTTY_MOUSE_SHAPE_MOVE, "move"),
+            (GHOSTTY_MOUSE_SHAPE_NO_DROP, "no-drop"),
+            (GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED, "not-allowed"),
+            (GHOSTTY_MOUSE_SHAPE_GRAB, "grab"),
+            (GHOSTTY_MOUSE_SHAPE_GRABBING, "grabbing"),
+            (GHOSTTY_MOUSE_SHAPE_ALL_SCROLL, "all-scroll"),
+            (GHOSTTY_MOUSE_SHAPE_COL_RESIZE, "col-resize"),
+            (GHOSTTY_MOUSE_SHAPE_ROW_RESIZE, "row-resize"),
+            (GHOSTTY_MOUSE_SHAPE_N_RESIZE, "n-resize"),
+            (GHOSTTY_MOUSE_SHAPE_E_RESIZE, "e-resize"),
+            (GHOSTTY_MOUSE_SHAPE_S_RESIZE, "s-resize"),
+            (GHOSTTY_MOUSE_SHAPE_W_RESIZE, "w-resize"),
+            (GHOSTTY_MOUSE_SHAPE_NE_RESIZE, "ne-resize"),
+            (GHOSTTY_MOUSE_SHAPE_NW_RESIZE, "nw-resize"),
+            (GHOSTTY_MOUSE_SHAPE_SE_RESIZE, "se-resize"),
+            (GHOSTTY_MOUSE_SHAPE_SW_RESIZE, "sw-resize"),
+            (GHOSTTY_MOUSE_SHAPE_EW_RESIZE, "ew-resize"),
+            (GHOSTTY_MOUSE_SHAPE_NS_RESIZE, "ns-resize"),
+            (GHOSTTY_MOUSE_SHAPE_NESW_RESIZE, "nesw-resize"),
+            (GHOSTTY_MOUSE_SHAPE_NWSE_RESIZE, "nwse-resize"),
+            (GHOSTTY_MOUSE_SHAPE_ZOOM_IN, "zoom-in"),
+            (GHOSTTY_MOUSE_SHAPE_ZOOM_OUT, "zoom-out"),
+        ];
+
+        for (shape, expected) in cases {
+            assert_eq!(gtk_cursor_name_for_ghostty_shape(shape), expected);
+        }
+        assert_eq!(gtk_cursor_name_for_ghostty_shape(c_int::MAX), "default");
+    }
+
+    #[test]
+    fn mouse_visibility_restores_latest_shape_and_treats_unknown_as_visible() {
+        let state = MouseCursorState::default()
+            .update_shape(GHOSTTY_MOUSE_SHAPE_POINTER)
+            .update_visibility(GHOSTTY_MOUSE_HIDDEN);
+        assert_eq!(state.gtk_cursor_name(), "none");
+
+        let state = state
+            .update_shape(GHOSTTY_MOUSE_SHAPE_WAIT)
+            .update_visibility(GHOSTTY_MOUSE_VISIBLE);
+        assert_eq!(state.gtk_cursor_name(), "wait");
+
+        let state = state.update_visibility(c_int::MAX);
+        assert!(state.visible);
+        assert_eq!(state.gtk_cursor_name(), "wait");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Handle Ghostty mouse cursor actions in embedded terminal surfaces so pointer shape and visibility are controlled by Limux instead of being ignored.

## Changes

- bind Ghostty mouse-shape and mouse-visibility action payloads in `limux-ghostty-sys`
- map every Ghostty cursor shape to matching GTK cursor name
- initialize terminal surfaces with visible text cursor
- preserve latest shape while hidden and restore it when Ghostty makes cursor visible
- marshal cursor updates onto GTK main context
- assign each surface generation identity so queued updates cannot target reused addresses
- unregister identity before surface free
- add mapping, visibility, and address-reuse regression tests

Addresses #107.

## Testing

```bash
export LD_LIBRARY_PATH="$PWD/ghostty/zig-out/lib:${LD_LIBRARY_PATH:-}"
./scripts/check.sh
LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh
```

Results:

- 302 Rust tests passed
- 14 packaging checks passed
- live GTK/Ghostty smoke passed
- independent final FFI, threading, lifecycle, and address-reuse review: APPROVE

Affected AMD Strix Halo hardware still needs reporter validation.

## Did this cause any problems?

No known regressions. Revert this PR to restore previous cursor behavior.