### PR TITLE
ci: require live GTK host smoke checks

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -45,3 +45,49 @@ jobs:
 
       - name: Run repository quality checks
         run: ./scripts/check.sh
+
+  gtk-host-smoke:
+    name: GTK host smoke
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            blueprint-compiler \
+            build-essential \
+            jq \
+            libadwaita-1-dev \
+            libepoxy-dev \
+            libgl1-mesa-dri \
+            libgtk-4-dev \
+            libwebkitgtk-6.0-dev \
+            pkg-config \
+            util-linux \
+            weston
+
+      - name: Build libghostty for embedding
+        run: |
+          cd ghostty
+          zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline
+
+      - name: Run live GTK host smoke test
+        env:
+          LIMUX_SMOKE_PROFILE: debug
+        run: ./scripts/xvfb-smoke-test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,8 @@ The CLI surface lives in `rust/limux-cli/src/main.rs`:
 - `build_agents_md` writes the generated runtime protocol file.
 
 Keep `limux agent-team --dry-run` working without a host. For live behavior,
-the Xvfb smoke script exercises the bridge, generated `AGENTS.md`, workspace
-name addressing, and by-name send path.
+the headless Weston smoke script exercises terminal surface health, input and
+screen readback, bridge routing, generated `AGENTS.md`, and session restart.
 
 ## Repository Rules
 

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -198,9 +198,49 @@ fn parse_global_args() -> Result<GlobalOptions> {
 }
 
 fn print_help() {
-    println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux --version\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  select-workspace --workspace <id|ref>\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
-    );
+    const HELP: &str = r#"limux CLI
+
+Usage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]
+       limux --version
+       limux
+
+Running `limux` with no arguments launches the GTK app.
+
+Common commands:
+  identify [--workspace <id|ref>] [--surface <id|ref>]
+  list-panels [--workspace <id|ref>]
+  list-panes [--workspace <id|ref>]
+  list-workspaces
+  surface-health [--workspace <id|ref>]
+  send [--workspace <id|ref>] [--surface <id|ref>] <text>
+  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>
+  new-workspace [--cwd <path>] [--command <text>]
+  select-workspace --workspace <id|ref>
+  close-workspace --workspace <id|ref>
+  sidebar-state --workspace <id|ref>
+  new-surface [--workspace <id|ref>]
+  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]
+      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.
+  rename-workspace [--workspace <id|ref>] <title>
+  rename-window [--workspace <id|ref>] <title>
+  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>
+  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
+  capture-pane (alias of read-screen)
+  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]
+  browser [--surface <id|ref>|<surface>] <subcommand> ...
+
+Agent integrations:
+  notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>
+  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>
+  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]
+  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]
+      Splits the active workspace into one pane per agent (caller's pane stays
+      as the orchestrator on the left, peers stack down the right), launches
+      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>
+      XML protocol so peers can talk via
+      `limux send --surface <peer-surface-id> <envelope>`."#;
+
+    println!("{HELP}\n");
 }
 
 fn should_launch_host(opts: &GlobalOptions) -> bool {

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -199,7 +199,7 @@ fn parse_global_args() -> Result<GlobalOptions> {
 
 fn print_help() {
     println!(
-        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux --version\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
+        "limux CLI\n\nUsage: limux [--socket <path>] [--json] [--id-format refs|both|uuids] <command> [args...]\n       limux --version\n       limux\n\nRunning `limux` with no arguments launches the GTK app.\n\nCommon commands:\n  identify [--workspace <id|ref>] [--surface <id|ref>]\n  list-panels [--workspace <id|ref>]\n  list-panes [--workspace <id|ref>]\n  list-workspaces\n  surface-health [--workspace <id|ref>]\n  send [--workspace <id|ref>] [--surface <id|ref>] <text>\n  send-key [--workspace <id|ref>] [--surface <id|ref>] <key>\n  new-workspace [--cwd <path>] [--command <text>]\n  select-workspace --workspace <id|ref>\n  close-workspace --workspace <id|ref>\n  sidebar-state --workspace <id|ref>\n  new-surface [--workspace <id|ref>]\n  new-pane [--workspace <id|ref>] [--pane <id|ref>] [--surface <id|ref>] [--direction <left|right|up|down>] [--type <terminal|browser>] [--command <text>] [--url <url>]\n      Live GTK self-spawn currently supports terminal panes only; browser panes remain deferred.\n  rename-workspace [--workspace <id|ref>] <title>\n  rename-window [--workspace <id|ref>] <title>\n  rename-tab [--workspace <id|ref>] [--tab <id|ref>] <title>\n  read-screen [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]\n  capture-pane (alias of read-screen)\n  tab-action --action <name> [--workspace <id|ref>] [--tab <id|ref>] [--title <text>] [--url <url>]\n  browser [--surface <id|ref>|<surface>] <subcommand> ...\n\nAgent integrations:\n  notify [--workspace <id|ref>] [--surface <id|ref>] [--subtitle <text>] [--body <text>] <title>\n  hooks setup [agent] | hooks uninstall [agent] | hooks <agent> <event>\n  claude-hook | opencode-hook | gemini-hook --event <name> [--subtitle <text>] [--body <text>] [--title <text>]\n  agent-team [--agents codex,claude[,opencode,gemini]] [--cwd <path>] [--no-launch] [--dry-run]\n      Splits the active workspace into one pane per agent (caller's pane stays\n      as the orchestrator on the left, peers stack down the right), launches\n      each CLI in its pane, and writes AGENTS.md describing the <agent-msg>\n      XML protocol so peers can talk via\n      `limux send --surface <peer-surface-id> <envelope>`.\n"
     );
 }
 
@@ -2348,6 +2348,23 @@ async fn run_close_workspace(client: &mut Client, args: &[String]) -> Result<Val
         .await
 }
 
+/// `limux select-workspace --workspace <id|ref>` — bring a workspace to the front.
+///
+/// The host has always implemented `workspace.select`; it just wasn't reachable
+/// from the CLI. It needs to be, because a pane only realizes its ghostty surface
+/// once its workspace is displayed. Splits made in a background workspace stay
+/// unrealized — `surface-health` reports `healthy=false` and `send-key` fails —
+/// until something selects it. Without this verb a purely CLI-driven fleet cannot
+/// bring its own workspace forward, so it can never start.
+async fn run_select_workspace(client: &mut Client, args: &[String]) -> Result<Value> {
+    let workspace = parse_opt(args, "--workspace")
+        .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
+        .ok_or_else(|| anyhow!("select-workspace requires --workspace <id|ref>"))?;
+    client
+        .call("workspace.select", json!({ "workspace_id": workspace }))
+        .await
+}
+
 async fn run_sidebar_state(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
@@ -3466,6 +3483,14 @@ async fn execute_command(client: &mut Client, opts: &GlobalOptions) -> Result<Co
             } else {
                 let handle = handle_from_payload(&payload, "workspace_id", "workspace_ref");
                 CommandOutput::Text(format!("OK {}", handle))
+            }
+        }
+        "select-workspace" => {
+            let payload = run_select_workspace(client, args).await?;
+            if opts.json_output {
+                CommandOutput::Json(payload)
+            } else {
+                CommandOutput::Text("OK".to_string())
             }
         }
         "close-workspace" => {

--- a/rust/limux-ghostty-sys/build.rs
+++ b/rust/limux-ghostty-sys/build.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 fn main() {
     // Find libghostty relative to the workspace root.
@@ -21,7 +21,12 @@ fn main() {
         cc::Build::new()
             .file(&glad_src)
             .include(&glad_include)
+            .cargo_metadata(false)
             .compile("glad");
+
+        let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set"));
+        println!("cargo:rustc-link-search=native={}", out_dir.display());
+        println!("cargo:rustc-link-lib=static:+whole-archive=glad");
     }
 
     // Re-run if libghostty changes

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -180,12 +180,20 @@ impl TerminalHandle {
             return false;
         };
 
+        // Ghostty resolves the *physical* key from the hardware keycode; it does
+        // not fall back to the keyval. Synthesizing an event with keycode 0 makes
+        // ghostty see an unidentified key and drop it silently — the caller gets a
+        // successful reply and the PTY never sees the keystroke. Map the keyval
+        // back to a real keycode through the display's keymap so control-socket
+        // keys are encoded exactly like keys typed by a human.
+        let keycode = keycode_for_keyval(self.gl_area.upcast_ref(), keyval);
+
         let press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
             keyval,
-            0,
+            keycode,
             modifier,
         );
         let release = translate_key_event(
@@ -193,7 +201,7 @@ impl TerminalHandle {
             Some(self.gl_area.upcast_ref()),
             None,
             keyval,
-            0,
+            keycode,
             modifier,
         );
 
@@ -2071,6 +2079,21 @@ fn translate_key_event(
         unshifted_codepoint: unshifted,
         composing: false,
     }
+}
+
+/// Map a keyval back to a hardware keycode via the display's keymap.
+///
+/// Real key events arrive from GTK with the keycode already filled in. Keys
+/// injected through the control socket only have a keyval (parsed from a string
+/// like `enter`), so we have to ask the keymap for the physical key that
+/// produces it. Returns 0 when the keyval isn't on the current layout, which
+/// preserves the previous behaviour rather than inventing a wrong key.
+fn keycode_for_keyval(widget: &gtk::Widget, keyval: gtk::gdk::Key) -> u32 {
+    widget
+        .display()
+        .map_keyval(keyval)
+        .and_then(|keys| keys.first().map(|key| key.keycode()))
+        .unwrap_or(0)
 }
 
 fn key_event_text(keyval: gtk::gdk::Key) -> Option<CString> {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -180,15 +180,28 @@ impl TerminalHandle {
             return false;
         };
 
-        // Ghostty resolves the *physical* key from the hardware keycode; it does
-        // not fall back to the keyval. Synthesizing an event with keycode 0 makes
-        // ghostty see an unidentified key and drop it silently — the caller gets a
-        // successful reply and the PTY never sees the keystroke. Map the keyval
-        // back to a real keycode through the display's keymap so control-socket
-        // keys are encoded exactly like keys typed by a human.
+        // A key needs BOTH halves, and supplying only one drops it silently.
+        //
+        // `keycode` — ghostty resolves the *physical* key from the hardware keycode
+        // and does not fall back to the keyval. With `keycode: 0` it sees an
+        // unidentified key and drops the event, so Enter, arrows, F-keys and
+        // ctrl-chords never reach the PTY.
+        //
+        // `text` — ghostty writes ordinary printable input from the text field, not
+        // from the keycode (see the comment on the GTK key controller below: "Ghostty
+        // uses the text field for actual character input and the keycode for
+        // bindings"). With `text` null, `send-key a` is encoded as a keypress that
+        // produces no character, so it too vanishes.
+        //
+        // The GTK path gets `text` from the input method; a socket-injected key has
+        // no IM behind it, so derive it here the same way GTK's fallback does.
+        // `key_event_text` returns None for control characters, which is what we want:
+        // Enter and ctrl-chords must be *encoded* by ghostty from the key + mods, not
+        // written as literal bytes.
         let keycode = keycode_for_keyval(self.gl_area.upcast_ref(), keyval);
+        let text = key_event_text(keyval);
 
-        let press = translate_key_event(
+        let mut press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
             Some(self.gl_area.upcast_ref()),
             None,
@@ -196,6 +209,13 @@ impl TerminalHandle {
             keycode,
             modifier,
         );
+        // The CString must outlive the ghostty call below; `text` owns it until the
+        // end of this function.
+        if let Some(text) = text.as_ref() {
+            press.text = text.as_ptr();
+        }
+
+        // Release carries no text, matching the GTK controller.
         let release = translate_key_event(
             GHOSTTY_ACTION_RELEASE,
             Some(self.gl_area.upcast_ref()),
@@ -209,6 +229,7 @@ impl TerminalHandle {
             ghostty_surface_key(surface, press);
             ghostty_surface_key(surface, release);
         }
+        drop(text);
         true
     }
 
@@ -2390,6 +2411,53 @@ mod tests {
         assert_eq!(ctrl_shift_h.as_deref(), Some("H"));
         assert_eq!(alt_shift_gt.as_deref(), Some(">"));
         assert!(key_event_text(gtk::gdk::Key::BackSpace).is_none());
+    }
+
+    /// The contract `send-key` depends on, in one place.
+    ///
+    /// A socket-injected key needs BOTH the hardware keycode and, for printable
+    /// input, the text field. Supplying only one drops the key silently:
+    ///
+    ///   * keycode only -> `send-key a` returns OK and writes nothing.
+    ///   * text only    -> Enter/arrows/ctrl-chords cannot be encoded at all.
+    ///
+    /// `key_event_text` is what decides which keys carry text, so pin its behaviour
+    /// for each of the three classes.
+    #[test]
+    fn send_key_text_is_supplied_for_printables_and_withheld_from_control_keys() {
+        // Printable: ghostty writes these from the text field.
+        for (key, expected) in [
+            (gtk::gdk::Key::a, "a"),
+            (gtk::gdk::Key::A, "A"),
+            (gtk::gdk::Key::_1, "1"),
+            (gtk::gdk::Key::space, " "),
+        ] {
+            let text = key_event_text(key).and_then(|s| s.into_string().ok());
+            assert_eq!(
+                text.as_deref(),
+                Some(expected),
+                "printable key must carry text or it is dropped"
+            );
+        }
+
+        // Control keys: text must be WITHHELD so ghostty encodes them from the
+        // key + mods. Writing "\r" as literal text instead of letting ghostty encode
+        // Return is how you break the kitty keyboard protocol.
+        for key in [
+            gtk::gdk::Key::Return,
+            gtk::gdk::Key::Tab,
+            gtk::gdk::Key::Escape,
+            gtk::gdk::Key::BackSpace,
+        ] {
+            assert!(
+                key_event_text(key).is_none(),
+                "{key:?} must be encoded by ghostty, not written as literal text"
+            );
+        }
+
+        // Non-textual keys have no unicode at all.
+        assert!(key_event_text(gtk::gdk::Key::Up).is_none());
+        assert!(key_event_text(gtk::gdk::Key::F1).is_none());
     }
 
     #[test]

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -199,7 +199,9 @@ impl TerminalHandle {
         // Enter and ctrl-chords must be *encoded* by ghostty from the key + mods, not
         // written as literal bytes.
         let keycode = keycode_for_keyval(self.gl_area.upcast_ref(), keyval);
-        let text = key_event_text(keyval);
+        let text_keyval =
+            translated_keyval_for_keycode(self.gl_area.upcast_ref(), keyval, keycode, modifier);
+        let text = key_event_text(text_keyval);
 
         let mut press = translate_key_event(
             GHOSTTY_ACTION_PRESS,
@@ -2115,6 +2117,34 @@ fn keycode_for_keyval(widget: &gtk::Widget, keyval: gtk::gdk::Key) -> u32 {
         .map_keyval(keyval)
         .and_then(|keys| keys.first().map(|key| key.keycode()))
         .unwrap_or(0)
+}
+
+fn translated_keyval_for_keycode(
+    widget: &gtk::Widget,
+    keyval: gtk::gdk::Key,
+    keycode: u32,
+    modifier: gtk::gdk::ModifierType,
+) -> gtk::gdk::Key {
+    if keycode == 0 {
+        return keyval;
+    }
+
+    let display = widget.display();
+    let group = display
+        .map_keyval(keyval)
+        .and_then(|mappings| {
+            mappings
+                .iter()
+                .find(|mapping| mapping.keycode() == keycode)
+                .or_else(|| mappings.first())
+                .map(|mapping| mapping.group())
+        })
+        .unwrap_or(0);
+
+    display
+        .translate_key(keycode, modifier, group)
+        .map(|(translated, _, _, _)| translated)
+        .unwrap_or(keyval)
 }
 
 fn key_event_text(keyval: gtk::gdk::Key) -> Option<CString> {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -155,8 +155,8 @@ fn send_pane_create_response_after_command(
     reply: std::sync::mpsc::Sender<Result<serde_json::Value, BridgeError>>,
 ) {
     let mut attempts = 0;
+    let mut command_sent = false;
     let mut reply = Some(reply);
-    let command = format!("{command}\n");
 
     glib::timeout_add_local(
         std::time::Duration::from_millis(PANE_CREATE_COMMAND_READY_INTERVAL_MS),
@@ -166,7 +166,10 @@ fn send_pane_create_response_after_command(
             if let Some((matched_surface_id, handle)) =
                 pane::exact_terminal_handle_for_surface(&pane_widget, &surface_id)
             {
-                if matched_surface_id == surface_id && handle.send_text(&command) {
+                if matched_surface_id == surface_id && !command_sent {
+                    command_sent = handle.send_text(&command);
+                }
+                if command_sent && handle.send_key("Enter") {
                     if let Some(reply) = reply.take() {
                         let _ = reply.send(Ok(response.clone()));
                     }

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # scripts/xvfb-smoke-test.sh - Headless end-to-end smoke test for the
-# limux agent-integrations stack. Runs a real limux GTK host under Xvfb,
+# limux agent-integrations stack. Runs a real limux GTK host under Weston,
 # exercises limux-cli against the live Unix socket, asserts expected
 # behavior, then tears down. Zero display hardware required.
+# The historical filename is retained for contributor compatibility.
 #
 # Usage:
 #   ./scripts/xvfb-smoke-test.sh                # release build
@@ -23,12 +24,14 @@ echo "demo dir:  $DEMO_DIR"
 echo "log dir:   $LOG_DIR"
 
 # --- 1. Deps --------------------------------------------------------------
-command -v xvfb-run >/dev/null || {
-  echo "FAIL: xvfb-run not installed (sudo pacman -S xorg-server-xvfb)"
+command -v weston >/dev/null || {
+  echo "FAIL: weston not installed"
   exit 2
 }
 command -v cargo >/dev/null || { echo "FAIL: cargo missing"; exit 2; }
+command -v jq >/dev/null || { echo "FAIL: jq missing"; exit 2; }
 command -v sed >/dev/null || { echo "FAIL: sed missing"; exit 2; }
+command -v setsid >/dev/null || { echo "FAIL: setsid missing"; exit 2; }
 
 # --- 2. Build -------------------------------------------------------------
 if [ "$PROFILE" = "release" ]; then
@@ -71,13 +74,14 @@ grep -q "peers=\[codex, claude, opencode, gemini\]" \
   || { echo "FAIL: stage 0 dry-run did not report expected peers"; exit 1; }
 echo "stage 0: OK"
 
-# --- 4. Launch the live host under Xvfb ----------------------------------
+# --- 4. Launch the live host under headless Weston -----------------------
 # Each smoke run gets its own socket path so we don't collide with the
 # user's real limux session.
 SOCKET="$DEMO_DIR/limux.sock"
 export LIMUX_SOCKET="$SOCKET"
 export LIMUX_SOCKET_PATH="$SOCKET"
 export LIMUX_SOCKET_MODE="runtime"
+unset LIMUX_PANE_ID LIMUX_SURFACE_ID LIMUX_TAB_ID LIMUX_WORKSPACE_ID
 export XDG_DATA_HOME="$DEMO_DIR/data"
 export XDG_STATE_HOME="$DEMO_DIR/state"
 export XDG_RUNTIME_DIR="$DEMO_DIR/runtime"
@@ -116,34 +120,127 @@ cat > "$XDG_DATA_HOME/limux/session.json" <<SMOKE_SESSION
 SMOKE_SESSION
 
 echo
-echo "== stage 1: boot limux host under xvfb-run =="
-# Under Xvfb there is no GPU, so Mesa would fall back to llvmpipe, which
-# has historically crashed on Ghostty's shader variants. Force softpipe
-# (slower but stable), and pin GL version to avoid newer-feature probes.
+echo "== stage 1: boot limux host under headless Weston =="
 export LIBGL_ALWAYS_SOFTWARE=1
-export GALLIUM_DRIVER=softpipe
+export GALLIUM_DRIVER="${GALLIUM_DRIVER:-llvmpipe}"
 export LP_NUM_THREADS=1
-export MESA_GL_VERSION_OVERRIDE="${MESA_GL_VERSION_OVERRIDE:-3.3}"
-xvfb-run -a -s "-screen 0 1280x800x24 +extension GLX +render" \
-  "$LIMUX_HOST" >"$LOG_DIR/host.stdout" 2>"$LOG_DIR/host.stderr" &
-HOST_PID=$!
-echo "host PID: $HOST_PID (socket=$SOCKET)"
+export GDK_BACKEND=wayland
+export WAYLAND_DISPLAY=wayland-limux-smoke
+HOST_PID=""
+WESTON_PID=""
+
+start_compositor() {
+  setsid weston \
+    --backend=headless-backend.so \
+    --socket="$WAYLAND_DISPLAY" \
+    --idle-time=0 \
+    --width=1280 \
+    --height=800 \
+    >"$LOG_DIR/weston.log" 2>&1 &
+  WESTON_PID=$!
+
+  for _ in $(seq 1 50); do
+    if [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
+      return 0
+    fi
+    if ! kill -0 "$WESTON_PID" 2>/dev/null; then
+      echo "FAIL: Weston died before opening its Wayland socket"
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  echo "FAIL: Weston socket never appeared"
+  return 1
+}
+
+start_host() {
+  local log_name="$1"
+  rm -f "$SOCKET"
+  setsid "$LIMUX_HOST" >"$LOG_DIR/$log_name.stdout" 2>"$LOG_DIR/$log_name.stderr" &
+  HOST_PID=$!
+  echo "host process group: $HOST_PID (socket=$SOCKET)"
+
+  for i in $(seq 1 60); do
+    if [ -S "$SOCKET" ]; then
+      echo "socket up after ${i}*500ms"
+      return 0
+    fi
+    if ! kill -0 "$HOST_PID" 2>/dev/null; then
+      echo "FAIL: host process died before opening the socket"
+      return 1
+    fi
+    sleep 0.5
+  done
+
+  echo "FAIL: socket $SOCKET never appeared"
+  return 1
+}
+
+stop_host() {
+  local pid="$HOST_PID"
+  [ -n "$pid" ] || return 0
+
+  kill -TERM -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 50); do
+    if ! kill -0 -- "-$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      HOST_PID=""
+      rm -f "$SOCKET"
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "FAIL: host process group $pid did not exit after SIGTERM"
+  return 1
+}
+
+wait_for_healthy_surfaces() {
+  local workspace="$1"
+  local output="$2"
+
+  for _ in $(seq 1 60); do
+    if "$LIMUX_CLI" --json surface-health --workspace "$workspace" >"$output" 2>/dev/null \
+      && jq -e '
+        .surfaces | length > 0 and all(.[];
+          .type == "terminal" and
+          .healthy == true and
+          .realized == true and
+          .process_exited == false and
+          (.columns // 0) > 0 and
+          (.rows // 0) > 0 and
+          (.width_px // 0) > 0 and
+          (.height_px // 0) > 0
+        )
+      ' "$output" >/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  echo "FAIL: terminal surfaces for workspace '$workspace' never became healthy"
+  cat "$output" 2>/dev/null || true
+  return 1
+}
 
 cleanup() {
   local rc=$?
   echo
   echo "-- cleanup (rc=$rc) --"
-  if kill -0 "$HOST_PID" 2>/dev/null; then
-    kill "$HOST_PID" 2>/dev/null || true
-    sleep 1
-    kill -9 "$HOST_PID" 2>/dev/null || true
+  if [ -n "$HOST_PID" ] && kill -0 -- "-$HOST_PID" 2>/dev/null; then
+    kill -KILL -- "-$HOST_PID" 2>/dev/null || true
+  fi
+  if [ -n "$WESTON_PID" ] && kill -0 -- "-$WESTON_PID" 2>/dev/null; then
+    kill -KILL -- "-$WESTON_PID" 2>/dev/null || true
   fi
   # Tail the host log on failure to aid debugging.
   if [ "$rc" -ne 0 ]; then
-    echo "-- host.stdout (tail) --"
-    tail -n 40 "$LOG_DIR/host.stdout" 2>/dev/null || true
-    echo "-- host.stderr (tail) --"
-    tail -n 40 "$LOG_DIR/host.stderr" 2>/dev/null || true
+    for log in "$LOG_DIR"/host*.stdout "$LOG_DIR"/host*.stderr "$LOG_DIR"/weston.log; do
+      [ -f "$log" ] || continue
+      echo "-- $log (tail) --"
+      tail -n 40 "$log" || true
+    done
     echo "artifacts retained at: $DEMO_DIR"
   else
     # Clean slate on success.
@@ -152,35 +249,55 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Poll for the socket (up to 30s)
-for i in $(seq 1 60); do
-  if [ -S "$SOCKET" ]; then
-    echo "socket up after ${i}*500ms"
+start_compositor
+start_host host
+
+echo
+echo "== stage 1b: terminal surface health and screen I/O =="
+wait_for_healthy_surfaces limux "$LOG_DIR/stage1-health.json"
+
+SCREEN_PROOF="limux-screen-proof-$$"
+SCREEN_COMMAND="clear; printf '%s\\n' '$SCREEN_PROOF'; printf screen-ok > '$DEMO_DIR/screen-command-proof'"
+"$LIMUX_CLI" send --workspace limux "$SCREEN_COMMAND" >"$LOG_DIR/stage1-send.txt"
+"$LIMUX_CLI" send-key --workspace limux Enter >"$LOG_DIR/stage1-send-key.txt"
+for _ in $(seq 1 50); do
+  "$LIMUX_CLI" read-screen --workspace limux >"$LOG_DIR/stage1-screen.txt" 2>/dev/null || true
+  if [ -f "$DEMO_DIR/screen-command-proof" ] \
+    && grep -Fq "$SCREEN_PROOF" "$LOG_DIR/stage1-screen.txt"; then
     break
   fi
-  if ! kill -0 "$HOST_PID" 2>/dev/null; then
-    echo "FAIL: host process died before opening the socket"
-    exit 1
-  fi
-  sleep 0.5
+  sleep 0.1
 done
-
-[ -S "$SOCKET" ] || { echo "FAIL: socket $SOCKET never appeared"; exit 1; }
+[ "$(cat "$DEMO_DIR/screen-command-proof" 2>/dev/null)" = "screen-ok" ] \
+  || { echo "FAIL: terminal command did not execute"; exit 1; }
+grep -Fq "$SCREEN_PROOF" "$LOG_DIR/stage1-screen.txt" \
+  || { echo "FAIL: terminal output was not readable through read-screen"; exit 1; }
+echo "stage 1b: OK (surface realized, terminal command executed, screen readable)"
 
 # --- 5. Stage 2: live agent-team ------------------------------------------
 echo
 echo "== stage 2: agent-team against live host (--no-launch) =="
 # --no-launch keeps the workspace commands from actually spawning codex/
-# claude binaries (which may not be installed in CI); the bridge + AGENTS.md
-# + allow_name=true path are still fully exercised.
-"$LIMUX_CLI" --id-format both agent-team \
+# claude binaries (which may not be installed in CI); pane creation and
+# AGENTS.md generation are still fully exercised.
+"$LIMUX_CLI" --json --id-format both agent-team \
   --agents codex,claude \
   --cwd "$DEMO_DIR" \
   --no-launch \
-  2>&1 | tee "$LOG_DIR/stage2.txt"
+  2>&1 | tee "$LOG_DIR/stage2.json"
 
-grep -q "peers=\[codex, claude\]" "$LOG_DIR/stage2.txt" \
-  || { echo "FAIL: live agent-team did not create peers"; exit 1; }
+jq -e '
+  .ok == true and
+  .workspace_name == "limux" and
+  (.peers | map(.agent)) == ["codex", "claude"] and
+  all(.peers[];
+    (.pane_id | type == "string" and length > 0) and
+    (.surface_id | type == "string" and length > 0)
+  )
+' "$LOG_DIR/stage2.json" >/dev/null \
+  || { echo "FAIL: live agent-team returned invalid peer metadata"; exit 1; }
+CLAUDE_SURFACE="$(jq -r '.peers[] | select(.agent == "claude") | .surface_id' "$LOG_DIR/stage2.json")"
+WORKSPACE_ID="$(jq -r '.workspace_id' "$LOG_DIR/stage2.json")"
 [ -f "$DEMO_DIR/AGENTS.md" ] \
   || { echo "FAIL: AGENTS.md not written to $DEMO_DIR"; exit 1; }
 
@@ -188,38 +305,39 @@ grep -q "peers=\[codex, claude\]" "$LOG_DIR/stage2.txt" \
 grep -q "<agent-msg"  "$DEMO_DIR/AGENTS.md" || { echo "FAIL: AGENTS.md missing <agent-msg>"; exit 1; }
 grep -q "\bcodex\b"   "$DEMO_DIR/AGENTS.md" || { echo "FAIL: AGENTS.md missing codex peer"; exit 1; }
 grep -q "\bclaude\b"  "$DEMO_DIR/AGENTS.md" || { echo "FAIL: AGENTS.md missing claude peer"; exit 1; }
-echo "stage 2: OK (AGENTS.md + 2 workspaces + allow_name bridge path)"
+echo "stage 2: OK (AGENTS.md + 2 peer panes)"
 
-# --- 6. Stage 3: list-workspaces sanity -----------------------------------
+# --- 6. Stage 3: shared-workspace pane inventory --------------------------
 echo
-echo "== stage 3: list-workspaces sees both peers =="
-"$LIMUX_CLI" list-workspaces 2>&1 | tee "$LOG_DIR/stage3.txt"
-grep -q codex  "$LOG_DIR/stage3.txt" || { echo "FAIL: list-workspaces missing codex"; exit 1; }
-grep -q claude "$LOG_DIR/stage3.txt" || { echo "FAIL: list-workspaces missing claude"; exit 1; }
-echo "stage 3: OK"
+echo "== stage 3: list-panes sees orchestrator and peers =="
+"$LIMUX_CLI" --json list-panes --workspace limux >"$LOG_DIR/stage3-panes.json"
+jq -e '(.panes | length) == 3 and all(.panes[]; .surface_count == 1)' \
+  "$LOG_DIR/stage3-panes.json" >/dev/null \
+  || { echo "FAIL: shared workspace does not contain 3 single-surface panes"; exit 1; }
+wait_for_healthy_surfaces limux "$LOG_DIR/stage3-health.json"
+echo "stage 3: OK (3 healthy terminal panes)"
 
-# --- 7. Stage 4: by-name send (the phase-5 allow_name=true unlock) --------
-# This is the single most important assertion in the whole harness —
-# it proves that `limux send --workspace <name>` resolves to the right
-# workspace via the bridge. Without allow_name=true this errors out.
+# --- 7. Stage 4: exact-surface send ---------------------------------------
 echo
-echo "== stage 4: surface.send_text by workspace name =="
+echo "== stage 4: surface.send_text to peer surface =="
 ENVELOPE=$'<agent-msg from="codex" to="claude" id="smoke-1" ts="2026-04-19T23:59:00Z"><request>smoke test ping</request></agent-msg>\n'
-if "$LIMUX_CLI" send --workspace claude "$ENVELOPE" 2>&1 | tee "$LOG_DIR/stage4.txt"; then
-  echo "stage 4: OK (by-name send accepted)"
+if "$LIMUX_CLI" send --workspace limux --surface "$CLAUDE_SURFACE" "$ENVELOPE" \
+  2>&1 | tee "$LOG_DIR/stage4.txt"; then
+  echo "stage 4: OK (exact-surface send accepted)"
 else
-  echo "FAIL: by-name send to 'claude' failed — allow_name=true may be regressed"
+  echo "FAIL: exact-surface send to claude peer failed"
   exit 1
 fi
 
-# --- 8. Stage 5: by-name notify -------------------------------------------
+# --- 8. Stage 5: surface-targeted notify ----------------------------------
 echo
-echo "== stage 5: notification.create by workspace name =="
-if "$LIMUX_CLI" notify --workspace claude --subtitle "smoke" --body "all good" "Smoke test" \
+echo "== stage 5: notification.create for peer surface =="
+if "$LIMUX_CLI" notify --workspace limux --surface "$CLAUDE_SURFACE" \
+     --subtitle "smoke" --body "all good" "Smoke test" \
      2>&1 | tee "$LOG_DIR/stage5.txt"; then
-  echo "stage 5: OK (by-name notify accepted)"
+  echo "stage 5: OK (surface-targeted notify accepted)"
 else
-  echo "FAIL: by-name notify failed — allow_name=true on notification.create may be regressed"
+  echo "FAIL: surface-targeted notify failed"
   exit 1
 fi
 
@@ -230,19 +348,25 @@ SELF_SPLIT_PROOF="$DEMO_DIR/self-split-proof"
 SELF_SPLIT_ENV="$DEMO_DIR/self-split-env"
 SELF_SPLIT_CMD="printf split-ok > '$SELF_SPLIT_PROOF'; printf '%s\n%s\n%s\n' \"\$LIMUX_WORKSPACE_ID\" \"\$LIMUX_PANE_ID\" \"\$LIMUX_SURFACE_ID\" > '$SELF_SPLIT_ENV'"
 
-"$LIMUX_CLI" --json new-pane \
-  --workspace claude \
+"$LIMUX_CLI" --json --id-format both new-pane \
+  --workspace limux \
+  --surface "$CLAUDE_SURFACE" \
   --direction right \
   --command "$SELF_SPLIT_CMD" \
   2>&1 | tee "$LOG_DIR/stage6.json"
 
-RESPONSE_WORKSPACE="$(sed -n 's/.*"workspace_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$LOG_DIR/stage6.json" | head -1)"
-RESPONSE_PANE="$(sed -n 's/.*"pane_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$LOG_DIR/stage6.json" | head -1)"
-RESPONSE_SURFACE="$(sed -n 's/.*"surface_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$LOG_DIR/stage6.json" | head -1)"
+jq -e '
+  .ok == true and
+  .surface_type == "terminal" and
+  (.workspace_id | type == "string" and length > 0) and
+  (.pane_id | type == "string" and length > 0) and
+  (.surface_id | type == "string" and length > 0)
+' "$LOG_DIR/stage6.json" >/dev/null \
+  || { echo "FAIL: pane.create returned an invalid response"; exit 1; }
 
-[ -n "$RESPONSE_WORKSPACE" ] || { echo "FAIL: pane.create response missing workspace_id"; exit 1; }
-[ -n "$RESPONSE_PANE" ] || { echo "FAIL: pane.create response missing pane_id"; exit 1; }
-[ -n "$RESPONSE_SURFACE" ] || { echo "FAIL: pane.create response missing surface_id"; exit 1; }
+RESPONSE_WORKSPACE="$(jq -r '.workspace_id' "$LOG_DIR/stage6.json")"
+RESPONSE_PANE="$(jq -r '.pane_id' "$LOG_DIR/stage6.json")"
+RESPONSE_SURFACE="$(jq -r '.surface_id' "$LOG_DIR/stage6.json")"
 
 for _ in $(seq 1 50); do
   if [ -f "$SELF_SPLIT_PROOF" ] && [ -f "$SELF_SPLIT_ENV" ]; then
@@ -276,15 +400,51 @@ echo "stage 6: OK (self-split command ran with fresh LIMUX_* env)"
 # --- 10. Stage 7: hook translators end-to-end -----------------------------
 echo
 echo "== stage 7: claude-hook event translation =="
-if echo '{"hook_event_name":"Notification","message":"hello from smoke"}' \
+echo '{"hook_event_name":"Notification","message":"hello from smoke"}' \
   | LIMUX_WORKSPACE_ID="" "$LIMUX_CLI" claude-hook 2>&1 \
-  | tee "$LOG_DIR/stage7.txt"; then
-  echo "stage 7: OK (claude-hook accepted JSON on stdin)"
-else
-  # claude-hook legitimately errors without a workspace target — that's
-  # a pass-through error, not a bridge regression. Surface the output.
-  echo "stage 7: claude-hook returned non-zero (check output)"
-fi
+  | tee "$LOG_DIR/stage7.txt"
+echo "stage 7: OK (claude-hook accepted JSON on stdin)"
+
+# --- 11. Stage 8: session persistence and clean process restart -----------
+echo
+echo "== stage 8: session persistence and host restart =="
+RESTORED_WORKSPACE="limux-restored"
+"$LIMUX_CLI" rename-workspace --workspace "$WORKSPACE_ID" "$RESTORED_WORKSPACE"
+for _ in $(seq 1 50); do
+  if jq -e --arg name "$RESTORED_WORKSPACE" \
+    '.workspaces | any(.name == $name)' \
+    "$XDG_DATA_HOME/limux/session.json" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+jq -e --arg name "$RESTORED_WORKSPACE" \
+  '.workspaces | any(.name == $name)' \
+  "$XDG_DATA_HOME/limux/session.json" >/dev/null \
+  || { echo "FAIL: renamed workspace was not persisted"; exit 1; }
+
+stop_host
+start_host host-restart
+"$LIMUX_CLI" list-workspaces >"$LOG_DIR/stage8-workspaces.txt"
+grep -Fq "$RESTORED_WORKSPACE" "$LOG_DIR/stage8-workspaces.txt" \
+  || { echo "FAIL: renamed workspace was not restored"; exit 1; }
+"$LIMUX_CLI" --json list-panes --workspace "$RESTORED_WORKSPACE" \
+  >"$LOG_DIR/stage8-panes.json"
+jq -e '(.panes | length) == 4' "$LOG_DIR/stage8-panes.json" >/dev/null \
+  || { echo "FAIL: restored workspace did not retain all panes"; exit 1; }
+wait_for_healthy_surfaces "$RESTORED_WORKSPACE" "$LOG_DIR/stage8-health.json"
+stop_host
+kill -TERM -- "-$WESTON_PID"
+for _ in $(seq 1 50); do
+  if ! kill -0 -- "-$WESTON_PID" 2>/dev/null; then
+    wait "$WESTON_PID" 2>/dev/null || true
+    WESTON_PID=""
+    break
+  fi
+  sleep 0.1
+done
+[ -z "$WESTON_PID" ] || { echo "FAIL: Weston process group did not exit"; exit 1; }
+echo "stage 8: OK (session restored and process groups exited)"
 
 echo
 echo "===================================="

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -271,7 +271,20 @@ done
   || { echo "FAIL: terminal command did not execute"; exit 1; }
 grep -Fq "$SCREEN_PROOF" "$LOG_DIR/stage1-screen.txt" \
   || { echo "FAIL: terminal output was not readable through read-screen"; exit 1; }
-echo "stage 1b: OK (surface realized, terminal command executed, screen readable)"
+
+SHIFTED_KEY_PROOF="$DEMO_DIR/shifted-key-proof"
+"$LIMUX_CLI" send --workspace limux "printf '" >"$LOG_DIR/stage1-shifted-prefix.txt"
+"$LIMUX_CLI" send-key --workspace limux '<Shift>a' >"$LOG_DIR/stage1-shifted-letter.txt"
+"$LIMUX_CLI" send-key --workspace limux '<Shift>1' >"$LOG_DIR/stage1-shifted-symbol.txt"
+"$LIMUX_CLI" send --workspace limux "' > '$SHIFTED_KEY_PROOF'" >"$LOG_DIR/stage1-shifted-suffix.txt"
+"$LIMUX_CLI" send-key --workspace limux Enter >"$LOG_DIR/stage1-shifted-enter.txt"
+for _ in $(seq 1 50); do
+  [ -f "$SHIFTED_KEY_PROOF" ] && break
+  sleep 0.1
+done
+[ "$(cat "$SHIFTED_KEY_PROOF" 2>/dev/null)" = 'A!' ] \
+  || { echo "FAIL: shifted send-key did not produce A!"; exit 1; }
+echo "stage 1b: OK (surface realized, terminal I/O and shifted keys verified)"
 
 # --- 5. Stage 2: live agent-team ------------------------------------------
 echo

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -53,10 +53,9 @@ LIMUX_CLI="$ROOT_DIR/$BIN_DIR/limux-cli"
 [ -x "$LIMUX_HOST" ] || { echo "FAIL: host binary missing at $LIMUX_HOST"; exit 2; }
 [ -x "$LIMUX_CLI" ]  || { echo "FAIL: cli binary missing at $LIMUX_CLI"; exit 2; }
 
-# The release host needs libghostty.so on the runtime path; debug finds
-# it via rpath.
+# Use the freshly built Ghostty shared library in every build profile.
 LIBGHOSTTY_DIR="$ROOT_DIR/ghostty/zig-out/lib"
-if [ "$PROFILE" = "release" ] && [ -d "$LIBGHOSTTY_DIR" ]; then
+if [ -d "$LIBGHOSTTY_DIR" ]; then
   export LD_LIBRARY_PATH="$LIBGHOSTTY_DIR:${LD_LIBRARY_PATH:-}"
 fi
 


### PR DESCRIPTION
## Summary

Make real GTK host behavior a blocking pull-request check instead of relying only on unit tests and socket startup.

Current Xvfb harness can open control socket while Ghostty surface creation has already failed. It also contains stale assumptions that `agent-team` creates one workspace per peer, so several later checks cannot exercise intended paths.

This PR moves live smoke to headless Weston and requires terminal surfaces to become realized with nonzero grid dimensions before continuing.

## Changes

- add required `GTK host smoke` CI job on Ubuntu 24.04
- run real host under headless Weston with Mesa software rendering
- verify terminal health, command submission, `read-screen`, exact-surface routing, pane creation, environment propagation, hook translation, session persistence, restart, and process cleanup
- parse CLI JSON structurally with `jq` instead of `sed` or text greps
- keep CLI help as raw multiline text so command additions produce focused diffs
- isolate test from inherited `LIMUX_*` pane and workspace IDs
- force GLAD archive symbols into host binaries and test executables
- submit `new-pane --command` through text plus Enter instead of pasted newline
- translate injected shifted keys through active GDK keymap and verify `A!` live

This branch carries two reviewed commits from #114 because blocking smoke reproduces that baseline defect: `send-key Enter` returns success on current `main` but leaves command at prompt. Authorship is preserved. Once this PR lands, #114 is superseded by same fix plus live regression coverage.

## Repro

Before fixes:

```bash
cd ghostty
zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline
cd ..
./scripts/check.sh
```

Host test link fails locally with unresolved `gladLoaderLoadGLContext` and `gladLoaderUnloadGLContext`.

Old Xvfb smoke reports socket ready while `surface-health` shows:

```json
{"healthy":false,"realized":false,"columns":0,"rows":0,"width_px":0,"height_px":0}
```

After switching to Weston, new blocking assertions exposed and fixed dropped Enter events, nonexecuting pane commands, inherited environment contamination, and stale peer-workspace assumptions.

## Testing

```bash
./scripts/check.sh
LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh
shellcheck scripts/xvfb-smoke-test.sh
bash -n scripts/xvfb-smoke-test.sh
git diff --check upstream/main...HEAD
```

Results:

- 295 Rust tests passed
- release-version checks passed
- 14 package SVG loader checks passed
- live GTK/Ghostty smoke passed repeatedly, including restart
- no ignored or filtered tests

## Did this cause any problems?

Revert this PR. Existing unit-test workflow remains independent from GTK smoke job.
