### PR TITLE
fix(control): preserve plain symbol key levels

### DIFF
--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -2125,7 +2125,7 @@ fn translated_keyval_for_keycode(
     keycode: u32,
     modifier: gtk::gdk::ModifierType,
 ) -> gtk::gdk::Key {
-    if keycode == 0 {
+    if keycode == 0 || !modifier.contains(gtk::gdk::ModifierType::SHIFT_MASK) {
         return keyval;
     }
 

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -274,6 +274,7 @@ grep -Fq "$SCREEN_PROOF" "$LOG_DIR/stage1-screen.txt" \
 
 SHIFTED_KEY_PROOF="$DEMO_DIR/shifted-key-proof"
 "$LIMUX_CLI" send --workspace limux "printf '" >"$LOG_DIR/stage1-shifted-prefix.txt"
+"$LIMUX_CLI" send-key --workspace limux at >"$LOG_DIR/stage1-plain-symbol.txt"
 "$LIMUX_CLI" send-key --workspace limux '<Shift>a' >"$LOG_DIR/stage1-shifted-letter.txt"
 "$LIMUX_CLI" send-key --workspace limux '<Shift>1' >"$LOG_DIR/stage1-shifted-symbol.txt"
 "$LIMUX_CLI" send --workspace limux "' > '$SHIFTED_KEY_PROOF'" >"$LOG_DIR/stage1-shifted-suffix.txt"
@@ -282,9 +283,9 @@ for _ in $(seq 1 50); do
   [ -f "$SHIFTED_KEY_PROOF" ] && break
   sleep 0.1
 done
-[ "$(cat "$SHIFTED_KEY_PROOF" 2>/dev/null)" = 'A!' ] \
-  || { echo "FAIL: shifted send-key did not produce A!"; exit 1; }
-echo "stage 1b: OK (surface realized, terminal I/O and shifted keys verified)"
+[ "$(cat "$SHIFTED_KEY_PROOF" 2>/dev/null)" = '@A!' ] \
+  || { echo "FAIL: plain and shifted send-key did not produce @A!"; exit 1; }
+echo "stage 1b: OK (surface realized, terminal I/O and key levels verified)"
 
 # --- 5. Stage 2: live agent-team ------------------------------------------
 echo


### PR DESCRIPTION
## Summary

Fix regression introduced by #128 where control-socket `send-key` retranslates plain shifted-level keysyms through level zero. For example, `send-key at` emits `2` instead of `@`.

## Changes

- preserve requested keysym when Shift is absent
- use active GDK keymap translation only for explicit Shift
- retain Ctrl/Alt modifiers while preserving printable symbol text
- extend blocking live GTK smoke assertion from `A!` to `@A!`

## Testing

```bash
export LD_LIBRARY_PATH="$PWD/ghostty/zig-out/lib:${LD_LIBRARY_PATH:-}"
./scripts/check.sh
LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh
shellcheck scripts/xvfb-smoke-test.sh
git diff --check
```

Results:

- 296 Rust tests passed
- 14 packaging checks passed
- live GTK bridge produced `@A!` through plain and shifted `send-key` calls
- independent deep review approved with no blocking findings

## Did this cause any problems?

Revert this PR to restore #128 behavior.