### PR TITLE
feat(packaging): restore AUR source package

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,6 +1,19 @@
 name: Publish to AUR
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/aur-publish.yml
+      - .cargo/config.toml
+      - Cargo.lock
+      - Cargo.toml
+      - LICENSE
+      - PKGBUILD-source.template
+      - PKGBUILD.template
+      - ghostty
+      - rust/**
+      - scripts/render-aur-source-pkgbuild.sh
+      - scripts/tests/test-aur-source-package.sh
   workflow_run:
     workflows: ["Build Linux Release Packages"]
     types: [completed]
@@ -14,61 +27,246 @@ permissions:
   contents: read
 
 jobs:
-  aur-publish:
+  prepare:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'pull_request' ||
         (
+          github.repository == 'am-will/limux' &&
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main'
+        ) ||
+        (
+          github.repository == 'am-will/limux' &&
           github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'release' &&
           startsWith(github.event.workflow_run.head_branch, 'v')
         )
       }}
+    outputs:
+      publish: ${{ steps.metadata.outputs.publish }}
+      version: ${{ steps.metadata.outputs.version }}
 
     steps:
-      - name: Check out repository
+      - name: Check out pull request head
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: Extract version
-        id: version
+      - name: Check out upstream
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve package metadata
+        id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PR_REPOSITORY: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          RELEASE_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event.workflow_run.head_branch }}" == v* ]]; then
-            echo "version=${{ github.event.workflow_run.head_branch }}" | sed 's/^version=v/version=/' >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+            source_repository="$PR_REPOSITORY"
+            source_commit="$PR_SHA"
+            publish=false
           else
-            echo "::error::Cannot infer release version from workflow_run head_branch '${{ github.event.workflow_run.head_branch }}'"
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              version="$INPUT_VERSION"
+            else
+              version="${RELEASE_BRANCH#v}"
+            fi
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid release version: $version"
+              exit 1
+            fi
+            git fetch --force origin "refs/tags/v${version}:refs/tags/v${version}"
+            source_repository="https://github.com/am-will/limux.git"
+            source_commit=$(git rev-list -n1 "v${version}")
+            tagged_version=$(git show "$source_commit:Cargo.toml" | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -1)
+            if [ "$tagged_version" != "$version" ]; then
+              echo "::error::Tag v${version} contains workspace version ${tagged_version}"
+              exit 1
+            fi
+            publish=true
+          fi
+
+          ghostty_commit=$(git ls-tree "$source_commit" ghostty | awk '{print $3}')
+          if [[ ! "$ghostty_commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Unable to resolve Ghostty gitlink from $source_commit"
             exit 1
           fi
 
-      - name: Generate AUR PKGBUILD
+          mkdir -p /tmp/aur-pkgbuilds
+          ./scripts/render-aur-source-pkgbuild.sh \
+            PKGBUILD-source.template \
+            /tmp/aur-pkgbuilds/PKGBUILD-source \
+            "$version" \
+            "$source_repository" \
+            "$source_commit" \
+            "$ghostty_commit"
+
+          if [ "$publish" = true ]; then
+            tarball_url="https://github.com/am-will/limux/releases/download/v${version}/limux-${version}-linux-x86_64.tar.gz"
+            curl --fail --location --retry 5 --retry-delay 10 \
+              "$tarball_url" -o /tmp/limux.tar.gz
+            tar -tzf /tmp/limux.tar.gz > /tmp/limux-tarball-files.txt
+            grep -Fxq "limux-${version}-linux-x86_64/limux" /tmp/limux-tarball-files.txt
+            grep -Fxq "limux-${version}-linux-x86_64/libexec/limux/limux-host" /tmp/limux-tarball-files.txt
+            sha256=$(sha256sum /tmp/limux.tar.gz | awk '{print $1}')
+            sed \
+              -e "s/@@VERSION@@/$version/g" \
+              -e "s/@@SHA256@@/$sha256/g" \
+              PKGBUILD.template > /tmp/aur-pkgbuilds/PKGBUILD-bin
+          fi
+
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload generated PKGBUILDs
+        uses: actions/upload-artifact@v7
+        with:
+          name: aur-pkgbuilds
+          path: /tmp/aur-pkgbuilds
+          if-no-files-found: error
+
+  validate-source:
+    needs: prepare
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+
+    steps:
+      - name: Download generated PKGBUILD
+        uses: actions/download-artifact@v8
+        with:
+          name: aur-pkgbuilds
+          path: /tmp/aur-pkgbuilds
+
+      - name: Install Arch build dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --needed --noconfirm \
+            curl \
+            git \
+            ghostty \
+            gtk4 \
+            libadwaita \
+            libepoxy \
+            minisign \
+            namcap \
+            rust \
+            webkitgtk-6.0
+
+      - name: Install Zig 0.15 package
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
-          TARBALL_URL="https://github.com/am-will/limux/releases/download/v${VERSION}/limux-${VERSION}-linux-x86_64.tar.gz"
+          useradd --create-home builder
+          git clone https://aur.archlinux.org/zig0.15-bin.git /tmp/zig-package
+          git -C /tmp/zig-package checkout --detach 6ec7dad0340e61aa0c98a895d09561ecf7b7270e
+          chown -R builder:builder /tmp/zig-package
+          runuser -u builder -- env HOME=/home/builder \
+            makepkg --dir /tmp/zig-package --cleanbuild --noconfirm
+          pacman -U --noconfirm /tmp/zig-package/zig0.15-bin-*.pkg.tar.zst
 
-          for i in {1..20}; do
-            curl -fL "$TARBALL_URL" -o /tmp/limux.tar.gz && break
-            if [ "$i" -eq 20 ]; then
-              echo "::error::Release tarball is not available after $i attempts: $TARBALL_URL"
-              exit 1
-            fi
-            echo "Attempt $i failed, retrying in 15s..."
-            sleep 15
+      - name: Build source package
+        run: |
+          set -euo pipefail
+          install -d -o builder -g builder /tmp/limux-package
+          install -o builder -g builder -m644 \
+            /tmp/aur-pkgbuilds/PKGBUILD-source \
+            /tmp/limux-package/PKGBUILD
+          runuser -u builder -- env HOME=/home/builder \
+            makepkg --dir /tmp/limux-package --cleanbuild --noconfirm
+
+      - name: Verify and install source package
+        run: |
+          set -euo pipefail
+          package=$(find /tmp/limux-package -maxdepth 1 -name 'limux-*.pkg.tar.zst' ! -name '*-debug-*' -print -quit)
+          test -n "$package"
+          bsdtar -tf "$package" > /tmp/limux-package-files.txt
+
+          for path in \
+            usr/bin/limux \
+            usr/libexec/limux/limux-host \
+            usr/lib/limux/libghostty.so \
+            usr/share/licenses/limux/LICENSE \
+            usr/share/applications/dev.limux.linux.desktop \
+            usr/share/metainfo/dev.limux.linux.metainfo.xml \
+            usr/share/limux/ghostty \
+            usr/share/limux/terminfo/x/xterm-ghostty; do
+            grep -Eq "^${path}(/|$)" /tmp/limux-package-files.txt
           done
-          SHA256=$(sha256sum /tmp/limux.tar.gz | awk '{print $1}')
+          if grep -Fxq usr/libexec/limux/limux /tmp/limux-package-files.txt; then
+            echo "::error::Source package contains legacy host entrypoint"
+            exit 1
+          fi
 
-          sed -e "s/@@VERSION@@/$VERSION/" \
-              -e "s/@@SHA256@@/$SHA256/" \
-              PKGBUILD.template > PKGBUILD
+          namcap "$package"
+          pacman -U --noconfirm "$package"
+          limux --help > /tmp/limux-help.txt
+          grep -q "limux CLI" /tmp/limux-help.txt
+          echo "CLI smoke check passed"
 
-      - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+          readelf -d /usr/libexec/limux/limux-host > /tmp/limux-dynamic.txt
+          grep -q '/usr/lib/limux' /tmp/limux-dynamic.txt
+          echo "Runtime library path check passed"
+
+          if ! ldd -r /usr/libexec/limux/limux-host > /tmp/limux-ldd.txt 2>&1; then
+            cat /tmp/limux-ldd.txt
+            exit 1
+          fi
+          cat /tmp/limux-ldd.txt
+          ! grep -Eq "not found|undefined symbol" /tmp/limux-ldd.txt
+
+  publish-bin:
+    needs: [prepare, validate-source]
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download generated PKGBUILDs
+        uses: actions/download-artifact@v8
+        with:
+          name: aur-pkgbuilds
+          path: /tmp/aur-pkgbuilds
+
+      - name: Publish limux-bin to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
           pkgname: limux-bin
-          pkgbuild: PKGBUILD
+          pkgbuild: /tmp/aur-pkgbuilds/PKGBUILD-bin
           commit_username: "limux-aurbot"
           commit_email: limux-aurbot@users.noreply.aur.archlinux.org
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "chore: bump to ${{ steps.version.outputs.version }}"
-          force_push: true
+          commit_message: "chore: bump to ${{ needs.prepare.outputs.version }}"
+
+  publish-source:
+    needs: [prepare, validate-source]
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download generated PKGBUILDs
+        uses: actions/download-artifact@v8
+        with:
+          name: aur-pkgbuilds
+          path: /tmp/aur-pkgbuilds
+
+      - name: Publish limux to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: limux
+          pkgbuild: /tmp/aur-pkgbuilds/PKGBUILD-source
+          commit_username: "limux-aurbot"
+          commit_email: limux-aurbot@users.noreply.aur.archlinux.org
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "chore: bump to ${{ needs.prepare.outputs.version }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,14 +780,12 @@ dependencies = [
 [[package]]
 name = "limux-ghostty-sys"
 version = "0.1.23"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "limux-host-linux"
 version = "0.1.23"
 dependencies = [
+ "cc",
  "dirs",
  "gdk4-wayland",
  "gtk4",

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Limux contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PKGBUILD-source.template
+++ b/PKGBUILD-source.template
@@ -1,0 +1,67 @@
+# Maintainer: Limux contributors
+# Contributor: Anton Barchukov <anton@barchukov.com>
+pkgname=limux
+pkgver=@@VERSION@@
+pkgrel=1
+pkgdesc="GPU-accelerated terminal workspace manager for Linux, powered by Ghostty's rendering engine (cmux port)"
+arch=('x86_64')
+url="https://github.com/am-will/limux"
+license=('MIT')
+depends=('fontconfig' 'glib2' 'gtk4' 'hicolor-icon-theme' 'libadwaita' 'pango' 'webkitgtk-6.0')
+makedepends=('ghostty' 'git' 'libepoxy' 'rust' 'zig0.15')
+conflicts=('limux-bin' 'limux-bin-debug')
+options=(!debug !lto)
+_limux_commit=@@SOURCE_COMMIT@@
+_ghostty_commit=@@GHOSTTY_COMMIT@@
+source=(
+    "$pkgname-$pkgver::git+@@SOURCE_REPOSITORY@@#commit=$_limux_commit"
+    "ghostty-$pkgver::git+https://github.com/am-will/ghostty.git#commit=$_ghostty_commit"
+)
+sha256sums=('SKIP' 'SKIP')
+
+prepare() {
+    cd "$srcdir/$pkgname-$pkgver"
+    rm -rf ghostty
+    ln -s "$srcdir/ghostty-$pkgver" ghostty
+}
+
+build() {
+    cd "$srcdir/$pkgname-$pkgver"
+    local zig_args=(-Doptimize=ReleaseFast -Dcpu=baseline -fno-sys=gtk4-layer-shell)
+
+    (
+        cd ghostty
+        zig-0.15 build -Dapp-runtime=none "${zig_args[@]}"
+    )
+
+    RUSTFLAGS="\
+        -C link-arg=-Wl,-rpath,/usr/lib/limux \
+        -C link-arg=-Wl,--export-dynamic" cargo build --release --locked
+}
+
+package() {
+    cd "$srcdir/$pkgname-$pkgver"
+
+    install -Dm755 target/release/limux-cli "$pkgdir/usr/bin/limux"
+    install -Dm755 target/release/limux "$pkgdir/usr/libexec/limux/limux-host"
+    install -Dm644 ghostty/zig-out/lib/libghostty.so "$pkgdir/usr/lib/limux/libghostty.so"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+    install -dm755 "$pkgdir/usr/share/limux/ghostty"
+    cp -a /usr/share/ghostty/. "$pkgdir/usr/share/limux/ghostty/"
+    install -Dm644 /usr/share/terminfo/x/xterm-ghostty \
+        "$pkgdir/usr/share/limux/terminfo/x/xterm-ghostty"
+
+    install -Dm644 rust/limux-host-linux/dev.limux.linux.desktop \
+        "$pkgdir/usr/share/applications/dev.limux.linux.desktop"
+    install -Dm644 rust/limux-host-linux/dev.limux.linux.metainfo.xml \
+        "$pkgdir/usr/share/metainfo/dev.limux.linux.metainfo.xml"
+
+    for size in 16 32 128 256 512; do
+        install -Dm644 "rust/limux-host-linux/icons/app/$size.png" \
+            "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/limux.png"
+    done
+    install -dm755 "$pkgdir/usr/share/icons/hicolor/scalable/actions"
+    install -m644 rust/limux-host-linux/icons/*.svg \
+        -t "$pkgdir/usr/share/icons/hicolor/scalable/actions/"
+}

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -1,4 +1,5 @@
-# Maintainer: Anton Barchukov <anton@barchukov.com>
+# Maintainer: Limux contributors
+# Contributor: Anton Barchukov <anton@barchukov.com>
 pkgname=limux-bin
 pkgver=@@VERSION@@
 pkgrel=1
@@ -6,9 +7,9 @@ pkgdesc="GPU-accelerated terminal workspace manager for Linux, powered by Ghostt
 arch=('x86_64')
 url="https://github.com/am-will/limux"
 license=('MIT')
-depends=('gtk4' 'libadwaita' 'webkitgtk-6.0')
+depends=('fontconfig' 'glib2' 'gtk4' 'hicolor-icon-theme' 'libadwaita' 'pango' 'webkitgtk-6.0')
 provides=('limux')
-conflicts=('limux')
+conflicts=('limux' 'limux-debug')
 options=(!debug !strip)
 source=("limux-${pkgver}.tar.gz::https://github.com/am-will/limux/releases/download/v${pkgver}/limux-${pkgver}-linux-x86_64.tar.gz")
 sha256sums=('@@SHA256@@')

--- a/README.md
+++ b/README.md
@@ -49,12 +49,16 @@ cd limux-*-linux-x86_64
 sudo ./install.sh
 ```
 
-**Arch Linux (unofficial AUR package)** — community-maintained by [antonbarchukov](https://github.com/antonbarchukov):
+**Arch Linux (AUR):**
 ```bash
+# Prebuilt release package
 yay -S limux-bin
+
+# Build Limux and Ghostty from source
+yay -S limux
 ```
 
-The AUR package is available at [`limux-bin`](https://aur.archlinux.org/packages/limux-bin). Thanks to [antonbarchukov](https://github.com/antonbarchukov) for packaging Limux for Arch users. Arch packaging is not currently maintained by upstream; please report AUR packaging issues to the package maintainer first. See [issue #5](https://github.com/am-will/limux/issues/5).
+Both [`limux-bin`](https://aur.archlinux.org/packages/limux-bin) and the source-built [`limux`](https://aur.archlinux.org/packages/limux) package are published from this repository. Thanks to [Anton Barchukov](https://github.com/antonbarchukov) for creating the original Arch packaging in [PR #50](https://github.com/am-will/limux/pull/50).
 
 To uninstall:
 ```bash

--- a/rust/limux-ghostty-sys/Cargo.toml
+++ b/rust/limux-ghostty-sys/Cargo.toml
@@ -5,6 +5,3 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 build = "build.rs"
-
-[build-dependencies]
-cc = "1"

--- a/rust/limux-ghostty-sys/build.rs
+++ b/rust/limux-ghostty-sys/build.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 fn main() {
     // Find libghostty relative to the workspace root.
@@ -12,22 +12,6 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", ghostty_lib.display());
     println!("cargo:rustc-link-lib=dylib=ghostty");
     println!("cargo:rustc-link-lib=dylib=epoxy");
-
-    // Compile glad (GL loader) which libghostty depends on but doesn't
-    // include when built as a shared library.
-    let glad_src = ghostty_root.join("vendor/glad/src/gl.c");
-    let glad_include = ghostty_root.join("vendor/glad/include");
-    if glad_src.exists() {
-        cc::Build::new()
-            .file(&glad_src)
-            .include(&glad_include)
-            .cargo_metadata(false)
-            .compile("glad");
-
-        let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set"));
-        println!("cargo:rustc-link-search=native={}", out_dir.display());
-        println!("cargo:rustc-link-lib=static:+whole-archive=glad");
-    }
 
     // Re-run if libghostty changes
     println!(

--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -462,6 +462,20 @@ extern "C" {
 }
 
 extern "C" {
+    #[link_name = "gladLoaderLoadGLContext"]
+    fn glad_loader_load_gl_context(context: *mut c_void) -> c_int;
+    #[link_name = "gladLoaderUnloadGLContext"]
+    fn glad_loader_unload_gl_context(context: *mut c_void);
+}
+
+/// Retain GLAD loader symbols in the final host executable for `libghostty.so`.
+#[inline(never)]
+pub fn ensure_glad_symbols_linked() {
+    std::hint::black_box(glad_loader_load_gl_context as unsafe extern "C" fn(*mut c_void) -> c_int);
+    std::hint::black_box(glad_loader_unload_gl_context as unsafe extern "C" fn(*mut c_void));
+}
+
+extern "C" {
     // Init
     pub fn ghostty_init(argc: usize, argv: *mut *mut c_char) -> c_int;
 

--- a/rust/limux-host-linux/Cargo.toml
+++ b/rust/limux-host-linux/Cargo.toml
@@ -29,3 +29,6 @@ shell-quote = { version = "0.7.2", default-features = false, features = ["bash"]
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[build-dependencies]
+cc = "1"

--- a/rust/limux-host-linux/build.rs
+++ b/rust/limux-host-linux/build.rs
@@ -1,0 +1,21 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ghostty_root = manifest_dir.join("../../ghostty");
+    let glad_src = ghostty_root.join("vendor/glad/src/gl.c");
+    let glad_include = ghostty_root.join("vendor/glad/include");
+
+    cc::Build::new()
+        .file(&glad_src)
+        .include(&glad_include)
+        .cargo_metadata(false)
+        .compile("glad");
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set"));
+    let glad_archive = out_dir.join("libglad.a");
+    println!("cargo:rustc-link-arg-bin=limux={}", glad_archive.display());
+
+    println!("cargo:rerun-if-changed={}", glad_src.display());
+    println!("cargo:rerun-if-changed={}", glad_include.display());
+}

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -181,6 +181,8 @@ fn gtk_runtime_at_least(major: u32, minor: u32, micro: u32) -> bool {
 }
 
 fn main() {
+    limux_ghostty_sys::ensure_glad_symbols_linked();
+
     // Handle --version flag
     if std::env::args().any(|a| a == "--version" || a == "-v") {
         println!("Limux {VERSION}");

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -20,3 +20,4 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace -- --test-threads=1
 ./scripts/tests/test-release-version.sh
 ./scripts/tests/test-package-svg-loader.sh
+./scripts/tests/test-aur-source-package.sh

--- a/scripts/render-aur-source-pkgbuild.sh
+++ b/scripts/render-aur-source-pkgbuild.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 6 ]; then
+    echo "Usage: $0 <template> <output> <version> <source-repository> <source-commit> <ghostty-commit>" >&2
+    exit 2
+fi
+
+TEMPLATE="$1"
+OUTPUT="$2"
+VERSION="$3"
+SOURCE_REPOSITORY="$4"
+SOURCE_COMMIT="$5"
+GHOSTTY_COMMIT="$6"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: invalid version: $VERSION" >&2
+    exit 1
+fi
+if [[ ! "$SOURCE_REPOSITORY" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(\.git)?$ ]]; then
+    echo "ERROR: invalid GitHub source repository: $SOURCE_REPOSITORY" >&2
+    exit 1
+fi
+if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: invalid source commit: $SOURCE_COMMIT" >&2
+    exit 1
+fi
+if [[ ! "$GHOSTTY_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: invalid Ghostty commit: $GHOSTTY_COMMIT" >&2
+    exit 1
+fi
+
+sed \
+    -e "s|@@VERSION@@|$VERSION|g" \
+    -e "s|@@SOURCE_REPOSITORY@@|$SOURCE_REPOSITORY|g" \
+    -e "s|@@SOURCE_COMMIT@@|$SOURCE_COMMIT|g" \
+    -e "s|@@GHOSTTY_COMMIT@@|$GHOSTTY_COMMIT|g" \
+    "$TEMPLATE" > "$OUTPUT"
+
+if grep -q '@@[A-Z_]*@@' "$OUTPUT"; then
+    echo "ERROR: unresolved placeholder in $OUTPUT" >&2
+    exit 1
+fi

--- a/scripts/tests/test-aur-source-package.sh
+++ b/scripts/tests/test-aur-source-package.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SOURCE_COMMIT="0123456789abcdef0123456789abcdef01234567"
+GHOSTTY_COMMIT="89abcdef0123456789abcdef0123456789abcdef"
+OUTPUT="$TMP_DIR/PKGBUILD"
+
+"$ROOT_DIR/scripts/render-aur-source-pkgbuild.sh" \
+    "$ROOT_DIR/PKGBUILD-source.template" \
+    "$OUTPUT" \
+    "1.2.3" \
+    "https://github.com/example/limux.git" \
+    "$SOURCE_COMMIT" \
+    "$GHOSTTY_COMMIT"
+
+bash -n "$OUTPUT"
+
+metadata=$(bash -c '
+    set -u
+    srcdir=$2
+    pkgdir=$3
+    source "$1"
+    printf "%s\n" "$pkgname" "$pkgver" "$_limux_commit" "$_ghostty_commit" "${source[@]}"
+' bash "$OUTPUT" "$TMP_DIR/src" "$TMP_DIR/pkg")
+
+expected=$(printf '%s\n' \
+    "limux" \
+    "1.2.3" \
+    "$SOURCE_COMMIT" \
+    "$GHOSTTY_COMMIT" \
+    "limux-1.2.3::git+https://github.com/example/limux.git#commit=$SOURCE_COMMIT" \
+    "ghostty-1.2.3::git+https://github.com/am-will/ghostty.git#commit=$GHOSTTY_COMMIT")
+[ "$metadata" = "$expected" ]
+
+if "$ROOT_DIR/scripts/render-aur-source-pkgbuild.sh" \
+    "$ROOT_DIR/PKGBUILD-source.template" \
+    "$OUTPUT" \
+    "not-a-version" \
+    "https://github.com/example/limux.git" \
+    "$SOURCE_COMMIT" \
+    "$GHOSTTY_COMMIT" >/dev/null 2>&1; then
+    echo "ERROR: invalid version was accepted" >&2
+    exit 1
+fi
+
+echo "AUR source package template validation: OK"


### PR DESCRIPTION
## Summary

- restore source-built `limux` AUR package from original work in #50
- pin Limux and Ghostty sources to exact release commits and build with Zig 0.15
- validate generated source package in a clean Arch container before publishing either AUR package
- harden release metadata validation and pin AUR deployment action by commit
- install current CLI/private-host layout, bundled resources, terminfo, icons, metadata, and MIT license
- link Ghostty GLAD loader symbols from host executable and verify all installed dynamic relocations

## Attribution

Anton Barchukov created original Arch source-package work in #50. This replacement keeps that contribution in package headers and commit co-author metadata while rebuilding implementation from current `main`.

Supersedes #50.

## Testing

- `./scripts/check.sh`
- `shellcheck scripts/render-aur-source-pkgbuild.sh scripts/tests/test-aur-source-package.sh`
- `actionlint .github/workflows/aur-publish.yml`
- clean Arch container: build pinned `zig0.15-bin`, run source `makepkg` as non-root user, verify archive, install package, smoke-test CLI, verify host RPATH, run `ldd -r`, and confirm exported GLAD loader symbols

## Operational prerequisite

`limux-aurbot` needs co-maintainer access to existing AUR `limux` package before first source-package publish. Existing `limux-bin` publishing remains unchanged.