### PR TITLE
Keep workspace open after final terminal exits

### DIFF
--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -46,11 +46,18 @@ pub struct AppConfig {
     #[serde(skip)]
     pub appearance: AppearanceConfig,
     #[serde(skip)]
+    pub workspace: WorkspaceConfig,
+    #[serde(skip)]
     pub notifications: NotificationConfig,
     #[serde(skip)]
     pub clipboard: ClipboardConfig,
     #[serde(skip)]
     pub font_size: Option<f32>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceConfig {
+    pub keep_open_after_last_terminal_closes: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -306,6 +313,12 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .and_then(Value::as_bool)
         .unwrap_or(true);
 
+    let workspace = root.get("workspace").and_then(Value::as_object);
+    let keep_open_after_last_terminal_closes = workspace
+        .and_then(|workspace| workspace.get("keep_open_after_last_terminal_closes"))
+        .and_then(Value::as_bool)
+        .unwrap_or_default();
+
     let notifications = root.get("notifications").and_then(Value::as_object);
     let notification_defaults = NotificationConfig::default();
     let notifications_enabled = notifications
@@ -340,6 +353,9 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
             ghostty_color_scheme,
             ui_scale,
             show_workspace_path,
+        },
+        workspace: WorkspaceConfig {
+            keep_open_after_last_terminal_closes,
         },
         notifications: NotificationConfig {
             enabled: notifications_enabled,
@@ -387,6 +403,14 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
     root.insert(
         "focus".to_string(),
         json!({ "hover_terminal_focus": config.focus.hover_terminal_focus }),
+    );
+    root.insert(
+        "workspace".to_string(),
+        json!({
+            "keep_open_after_last_terminal_closes": config
+                .workspace
+                .keep_open_after_last_terminal_closes,
+        }),
     );
     root.insert(
         "notifications".to_string(),
@@ -516,6 +540,9 @@ fn ensure_default_config_file(path: &Path) -> std::io::Result<()> {
         "focus": {
             "hover_terminal_focus": false
         },
+        "workspace": {
+            "keep_open_after_last_terminal_closes": false
+        },
         "notifications": {
             "enabled": true,
             "sound": "default"
@@ -598,6 +625,10 @@ mod tests {
         assert_eq!(
             parsed["appearance"]["show_workspace_path"],
             Value::Bool(true)
+        );
+        assert_eq!(
+            parsed["workspace"]["keep_open_after_last_terminal_closes"],
+            Value::Bool(false)
         );
         assert_eq!(parsed["notifications"]["enabled"], Value::Bool(true));
         assert_eq!(
@@ -770,6 +801,28 @@ mod tests {
     }
 
     #[test]
+    fn load_from_path_reads_workspace_lifecycle_preference() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+        fs::write(
+            &path,
+            r#"{
+  "workspace": {
+    "keep_open_after_last_terminal_closes": true
+  }
+}
+"#,
+        )
+        .expect("write config");
+
+        let loaded = load_from_path(&path);
+
+        assert!(loaded.warnings.is_empty());
+        assert!(loaded.config.workspace.keep_open_after_last_terminal_closes);
+    }
+
+    #[test]
     fn save_writes_gtk_and_ghostty_color_schemes() {
         let dir = TempDir::new().expect("temp dir");
         let path = settings_path_in(dir.path());
@@ -824,6 +877,24 @@ mod tests {
         assert_eq!(
             parsed["appearance"]["show_workspace_path"],
             Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn save_to_path_writes_workspace_lifecycle_preference() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+
+        let mut config = AppConfig::default();
+        config.workspace.keep_open_after_last_terminal_closes = true;
+        save_to_path(&path, &config).expect("save workspace lifecycle preference");
+
+        let raw = fs::read_to_string(&path).expect("read config");
+        let parsed: Value = serde_json::from_str(&raw).expect("parse config");
+        assert_eq!(
+            parsed["workspace"]["keep_open_after_last_terminal_closes"],
+            Value::Bool(true)
         );
     }
 

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -105,6 +105,7 @@ enum ContentDropZone {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PaneEmptyReason {
+    ClosedLastTerminal,
     ClosedLastTab,
     MovedLastTabOut,
 }
@@ -3235,6 +3236,7 @@ fn remove_tab(
     };
     let entry = ts.tabs.remove(idx);
     let removed_was_unread = entry.unread;
+    let closed_terminal = matches!(&entry.kind, TabKind::Terminal { .. });
 
     entry.prepare_for_removal();
     tab_strip.remove(&entry.tab_button);
@@ -3245,6 +3247,11 @@ fn remove_tab(
         if removed_was_unread {
             (callbacks.on_unread_changed)();
         }
+        let empty_reason = if empty_reason == PaneEmptyReason::ClosedLastTab && closed_terminal {
+            PaneEmptyReason::ClosedLastTerminal
+        } else {
+            empty_reason
+        };
         (callbacks.on_empty)(&pane_outer.clone().upcast(), empty_reason);
         return;
     }

--- a/rust/limux-host-linux/src/settings_editor.rs
+++ b/rust/limux-host-linux/src/settings_editor.rs
@@ -285,6 +285,25 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
     workspace_path_row.set_activatable_widget(Some(&workspace_path_switch));
     group.add(&workspace_path_row);
 
+    let keep_workspace_open_row = adw::ActionRow::builder()
+        .title("Keep workspace open")
+        .subtitle("Keep the workspace available after its final terminal exits")
+        .build();
+    keep_workspace_open_row.set_title_lines(1);
+    keep_workspace_open_row.set_subtitle_lines(2);
+    let keep_workspace_open_switch = gtk::Switch::new();
+    keep_workspace_open_switch.set_active(
+        input
+            .config
+            .borrow()
+            .workspace
+            .keep_open_after_last_terminal_closes,
+    );
+    keep_workspace_open_switch.set_valign(gtk::Align::Center);
+    keep_workspace_open_row.add_suffix(&keep_workspace_open_switch);
+    keep_workspace_open_row.set_activatable_widget(Some(&keep_workspace_open_switch));
+    group.add(&keep_workspace_open_row);
+
     let auto_copy_row = adw::ActionRow::builder()
         .title("Copy selection automatically")
         .subtitle("Copy selected terminal text to the regular clipboard")
@@ -389,6 +408,16 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
                 switch.set_active(effective);
                 syncing.set(false);
             }
+        });
+    }
+    {
+        let config = input.config.clone();
+        let on_changed = input.on_config_changed.clone();
+        keep_workspace_open_switch.connect_active_notify(move |switch| {
+            let keep_open = switch.is_active();
+            apply_config_change(&config, &*on_changed, move |c| {
+                c.workspace.keep_open_after_last_terminal_closes = keep_open;
+            });
         });
     }
     {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -4779,7 +4779,14 @@ pub(crate) fn create_pane_for_workspace(
             });
         }),
         on_empty: Box::new(move |pane_widget, reason| {
-            let persist = matches!(reason, pane::PaneEmptyReason::ClosedLastTab);
+            if should_keep_workspace_open_for_empty_pane(&state_for_empty, &ws_id_empty, reason) {
+                request_session_save(&state_for_empty);
+                return;
+            }
+            let persist = matches!(
+                reason,
+                pane::PaneEmptyReason::ClosedLastTerminal | pane::PaneEmptyReason::ClosedLastTab
+            );
             remove_pane_internal(&state_for_empty, &ws_id_empty, pane_widget, persist);
         }),
         on_state_changed: Box::new({
@@ -5230,6 +5237,34 @@ fn remove_pane(state: &State, ws_id: &str, pane_widget: &gtk::Widget) {
     remove_pane_internal(state, ws_id, pane_widget, true);
 }
 
+fn should_keep_workspace_open_for_empty_pane(
+    state: &State,
+    ws_id: &str,
+    reason: pane::PaneEmptyReason,
+) -> bool {
+    let s = state.borrow();
+    let enabled = s
+        .config
+        .borrow()
+        .workspace
+        .keep_open_after_last_terminal_closes;
+    let is_only_pane = s
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == ws_id)
+        .is_some_and(|workspace| workspace.split_container.is_single_pane());
+
+    keep_workspace_open_after_empty_pane(enabled, reason, is_only_pane)
+}
+
+fn keep_workspace_open_after_empty_pane(
+    enabled: bool,
+    reason: pane::PaneEmptyReason,
+    is_only_pane: bool,
+) -> bool {
+    enabled && reason == pane::PaneEmptyReason::ClosedLastTerminal && is_only_pane
+}
+
 fn remove_pane_internal(state: &State, ws_id: &str, pane_widget: &gtk::Widget, persist: bool) {
     let container = {
         let s = state.borrow();
@@ -5543,9 +5578,15 @@ fn close_focused_tab(state: &State) {
         return;
     };
 
+    let config = state.borrow().config.clone();
+    let keep_workspace_open = config
+        .borrow()
+        .workspace
+        .keep_open_after_last_terminal_closes;
     if let Some(parent) = pane_widget.parent() {
         if parent.downcast_ref::<gtk::Stack>().is_some()
             && pane::tab_count_in_pane(&pane_widget) <= 1
+            && !keep_workspace_open
         {
             return;
         }
@@ -6171,8 +6212,9 @@ mod tests {
         desktop_notification_closed_id_from_signal, desktop_notification_id_from_response,
         directional_neighbor_score, favorites_prefix_len, find_leaf_pane, font_size_after_delta,
         ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
-        next_active_workspace_index, pane_create_split_placement, queue_session_save_request,
-        resolve_pane_create_source_id, resolved_system_prefers_dark, sanitize_background_opacity,
+        keep_workspace_open_after_empty_pane, next_active_workspace_index,
+        pane_create_split_placement, queue_session_save_request, resolve_pane_create_source_id,
+        resolved_system_prefers_dark, sanitize_background_opacity,
         shortcut_allowed_while_browser_find_active, shortcut_blocked_by_editable,
         shortcut_command_from_key_event, shortcut_dispatch_propagation,
         should_emit_desktop_notification, tab_drag_workspace_seed, use_opaque_window_background,
@@ -6211,6 +6253,35 @@ mod tests {
     fn favorites_prefix_len_counts_only_leading_favorites() {
         let flags = [true, true, false, true, false];
         assert_eq!(favorites_prefix_len(&flags), 2);
+    }
+
+    #[test]
+    fn workspace_lifecycle_preference_only_preserves_a_single_closed_pane() {
+        assert!(keep_workspace_open_after_empty_pane(
+            true,
+            crate::pane::PaneEmptyReason::ClosedLastTerminal,
+            true,
+        ));
+        assert!(!keep_workspace_open_after_empty_pane(
+            false,
+            crate::pane::PaneEmptyReason::ClosedLastTerminal,
+            true,
+        ));
+        assert!(!keep_workspace_open_after_empty_pane(
+            true,
+            crate::pane::PaneEmptyReason::ClosedLastTerminal,
+            false,
+        ));
+        assert!(!keep_workspace_open_after_empty_pane(
+            true,
+            crate::pane::PaneEmptyReason::ClosedLastTab,
+            true,
+        ));
+        assert!(!keep_workspace_open_after_empty_pane(
+            true,
+            crate::pane::PaneEmptyReason::MovedLastTabOut,
+            true,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a persisted General preference named Keep workspace open
- retain a single-pane workspace after its final terminal exits
- preserve existing explicit workspace closure, pane closure, and tab-move behavior
- allow Close Tab to close the final terminal when the preference is enabled