### PR TITLE
chore: bump version to 0.1.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "limux-cli"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "limux-control"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "limux-core"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "limux-protocol",
@@ -779,14 +779,14 @@ dependencies = [
 
 [[package]]
 name = "limux-ghostty-sys"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "limux-host-linux"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "dirs",
  "gdk4-wayland",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "limux-protocol"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["limux contributors"]
 edition = "2021"
 license = "MIT"
-version = "0.1.22"
+version = "0.1.23"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

Prepare Limux v0.1.23 from current green main after landing Copy URL support.

## Changes

- bump workspace version from 0.1.22 to 0.1.23
- refresh all Limux package versions in Cargo.lock

## Testing

- `cargo check -p limux-protocol --offline`
- `./scripts/check.sh` (302 Rust tests and 14 packaging checks passed)
- `git diff --check`

## Did this cause any problems?

Revert this commit before publishing v0.1.23.