### PR TITLE
fix(host): free Ghostty surfaces on terminal teardown

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -181,7 +181,15 @@ pub fn retire_pane(pane_widget: &gtk::Widget) {
     };
     let internals = unsafe { outer.steal_data::<Rc<PaneInternals>>("limux-pane-internals") };
     if let Some(internals) = internals {
-        for entry in &internals.tab_state.borrow().tabs {
+        let entries = {
+            let mut tab_state = internals.tab_state.borrow_mut();
+            tab_state.active_tab = None;
+            tab_state.active_rename_tab = None;
+            std::mem::take(&mut tab_state.tabs)
+        };
+        for entry in entries {
+            internals.tab_strip.remove(&entry.tab_button);
+            internals.content_stack.remove(&entry.content);
             entry.prepare_for_removal();
         }
         unregister_pane(internals.pane_id);
@@ -965,8 +973,10 @@ struct TabEntry {
 
 impl TabEntry {
     fn prepare_for_removal(&self) {
-        if let TabKind::Browser { state } = &self.kind {
-            state.handles.prepare_for_removal();
+        match &self.kind {
+            TabKind::Terminal { state } => state.handle.shutdown(),
+            TabKind::Browser { state } => state.handles.prepare_for_removal(),
+            TabKind::Keybinds => {}
         }
     }
 }
@@ -3232,20 +3242,34 @@ fn remove_tab(
 ) {
     commit_active_tab_rename(tab_state);
 
-    let mut ts = tab_state.borrow_mut();
-    let Some(idx) = ts.tabs.iter().position(|e| e.id == tab_id) else {
-        return;
+    let (entry, removed_was_unread, closed_terminal, new_id, was_active) = {
+        let mut ts = tab_state.borrow_mut();
+        let Some(idx) = ts.tabs.iter().position(|e| e.id == tab_id) else {
+            return;
+        };
+        let entry = ts.tabs.remove(idx);
+        let removed_was_unread = entry.unread;
+        let closed_terminal = matches!(&entry.kind, TabKind::Terminal { .. });
+        let was_active = ts.active_tab.as_deref() == Some(tab_id);
+        let new_id = if ts.tabs.is_empty() {
+            None
+        } else {
+            Some(ts.tabs[idx.min(ts.tabs.len() - 1)].id.clone())
+        };
+        (
+            entry,
+            removed_was_unread,
+            closed_terminal,
+            new_id,
+            was_active,
+        )
     };
-    let entry = ts.tabs.remove(idx);
-    let removed_was_unread = entry.unread;
-    let closed_terminal = matches!(&entry.kind, TabKind::Terminal { .. });
 
-    entry.prepare_for_removal();
     tab_strip.remove(&entry.tab_button);
     content_stack.remove(&entry.content);
+    entry.prepare_for_removal();
 
-    if ts.tabs.is_empty() {
-        drop(ts);
+    let Some(new_id) = new_id else {
         if removed_was_unread {
             (callbacks.on_unread_changed)();
         }
@@ -3256,13 +3280,7 @@ fn remove_tab(
         };
         (callbacks.on_empty)(&pane_outer.clone().upcast(), empty_reason);
         return;
-    }
-
-    // Activate neighbor tab
-    let new_idx = idx.min(ts.tabs.len() - 1);
-    let new_id = ts.tabs[new_idx].id.clone();
-    let was_active = ts.active_tab.as_deref() == Some(tab_id);
-    drop(ts);
+    };
 
     if was_active {
         activate_tab(tab_strip, content_stack, tab_state, &new_id);

--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -37,6 +37,16 @@ impl SplitNode {
         matches!(self, SplitNode::Leaf { .. })
     }
 
+    fn collect_panes(&self, panes: &mut Vec<gtk::Widget>) {
+        match self {
+            SplitNode::Leaf { pane_widget } => panes.push(pane_widget.clone()),
+            SplitNode::Split { left, right, .. } => {
+                left.collect_panes(panes);
+                right.collect_panes(panes);
+            }
+        }
+    }
+
     /// Find the leaf containing `target` and replace it with `replacement`.
     pub(crate) fn replace(&mut self, target: &gtk::Widget, replacement: SplitNode) -> bool {
         match self {
@@ -195,6 +205,14 @@ impl SplitTreeContainer {
     /// Whether the tree is a single leaf (no splits).
     pub(crate) fn is_single_pane(&self) -> bool {
         self.tree.borrow().is_leaf()
+    }
+
+    pub(crate) fn retire_panes(&self) {
+        let mut panes = Vec::new();
+        self.tree.borrow().collect_panes(&mut panes);
+        for pane_widget in panes {
+            pane::retire_pane(&pane_widget);
+        }
     }
 
     pub(crate) fn toggle_zoom(self: &Rc<Self>, target: &gtk::Widget) -> bool {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -218,10 +218,16 @@ fn unregister_surface_identity(identity: SurfaceIdentity) {
 #[derive(Clone)]
 pub struct TerminalHandle {
     surface_cell: Rc<RefCell<Option<ghostty_surface_t>>>,
+    clipboard_context_cell: Rc<Cell<*mut ClipboardContext>>,
+    shutting_down: Rc<Cell<bool>>,
     gl_area: gtk::GLArea,
     search_bar: gtk::SearchBar,
     search_entry: gtk::SearchEntry,
     callbacks: Rc<RefCell<TerminalCallbacks>>,
+    im_context: gtk::IMMulticontext,
+    im_fallback: gtk::IMContextSimple,
+    signal_handlers: Rc<RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>>,
+    controllers: Rc<RefCell<Vec<gtk::EventController>>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -236,7 +242,37 @@ pub struct TerminalHealth {
 
 impl TerminalHandle {
     pub fn replace_callbacks(&self, callbacks: TerminalCallbacks) {
-        *self.callbacks.borrow_mut() = callbacks;
+        if !self.shutting_down.get() {
+            *self.callbacks.borrow_mut() = callbacks;
+        }
+    }
+
+    pub fn shutdown(&self) {
+        if self.shutting_down.replace(true) {
+            return;
+        }
+
+        for (object, handler) in self.signal_handlers.borrow_mut().drain(..) {
+            object.disconnect(handler);
+        }
+        for controller in self.controllers.borrow_mut().drain(..) {
+            self.gl_area.remove_controller(&controller);
+        }
+        self.im_context.set_client_widget(gtk::Widget::NONE);
+        self.im_fallback.set_client_widget(gtk::Widget::NONE);
+
+        if let Some(surface) = self.surface_cell.borrow_mut().take() {
+            free_terminal_surface(surface, &self.clipboard_context_cell);
+        } else {
+            let clipboard_context = self.clipboard_context_cell.replace(ptr::null_mut());
+            if !clipboard_context.is_null() {
+                unsafe {
+                    drop(Box::from_raw(clipboard_context));
+                }
+            }
+        }
+
+        *self.callbacks.borrow_mut() = TerminalCallbacks::disconnected();
     }
 
     pub fn focus_surface(&self) -> bool {
@@ -480,6 +516,18 @@ impl TerminalHandle {
         unsafe { ghostty_surface_free_text(surface, &mut text) };
         selection
     }
+}
+
+fn track_signal<T>(
+    handlers: &RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>,
+    object: &T,
+    handler: glib::SignalHandlerId,
+) where
+    T: IsA<glib::Object> + Clone,
+{
+    handlers
+        .borrow_mut()
+        .push((object.clone().upcast(), handler));
 }
 
 fn empty_ghostty_text() -> ghostty_text_s {
@@ -1315,6 +1363,27 @@ pub struct TerminalCallbacks {
     pub identity: Box<IdentityCallback>,
 }
 
+impl TerminalCallbacks {
+    fn disconnected() -> Self {
+        Self {
+            on_title_changed: Box::new(|_| {}),
+            on_pwd_changed: Box::new(|_| {}),
+            on_desktop_notification: Box::new(|_, _, _| {}),
+            on_bell: Box::new(|_| {}),
+            on_close: Box::new(|| {}),
+            on_open_url: Box::new(|_, _| {}),
+            on_open_browser_here: Box::new(|| {}),
+            on_split_right: Box::new(|| {}),
+            on_split_down: Box::new(|| {}),
+            on_open_keybinds: Box::new(|_| {}),
+            identity: Box::new(|| TerminalIdentity {
+                workspace_id: None,
+                surface_id: String::new(),
+            }),
+        }
+    }
+}
+
 pub struct TerminalOptions {
     pub hover_focus: Rc<dyn Fn() -> bool>,
     pub copy_selection_to_clipboard: Rc<dyn Fn() -> bool>,
@@ -1349,6 +1418,33 @@ pub(crate) fn default_font_size() -> f32 {
     *SIZE.get_or_init(crate::ghostty_config::read_font_size)
 }
 
+fn free_terminal_surface(
+    surface: ghostty_surface_t,
+    clipboard_context_cell: &Cell<*mut ClipboardContext>,
+) {
+    let surface_key = surface as usize;
+    let entry = SURFACE_MAP.with(|map| map.borrow_mut().remove(&surface_key));
+    let clipboard_context = entry
+        .as_ref()
+        .map(|entry| entry.clipboard_context)
+        .unwrap_or_else(|| clipboard_context_cell.get());
+
+    clipboard_context_cell.set(ptr::null_mut());
+    if let Some(entry) = entry.as_ref() {
+        unregister_surface_identity(entry.identity);
+    }
+
+    // Ghostty can invoke callbacks while its worker threads stop. Keep callback
+    // userdata and widgets alive until deinitialization finishes.
+    unsafe { ghostty_surface_free(surface) };
+    if !clipboard_context.is_null() {
+        unsafe {
+            drop(Box::from_raw(clipboard_context));
+        }
+    }
+    drop(entry);
+}
+
 /// Create a new Ghostty-powered terminal widget.
 /// Returns an Overlay (GLArea + toast layer) for embedding in the pane.
 pub fn create_terminal(
@@ -1374,12 +1470,15 @@ pub fn create_terminal(
     let extra_env = options.extra_env;
     let callbacks = Rc::new(RefCell::new(callbacks));
     let surface_cell: Rc<RefCell<Option<ghostty_surface_t>>> = Rc::new(RefCell::new(None));
+    let shutting_down = Rc::new(Cell::new(false));
     let had_focus = Rc::new(Cell::new(false));
     let scrollbar_syncing = Rc::new(Cell::new(false));
     let open_url_external = Rc::new(Cell::new(false));
     let clipboard_context_cell: Rc<Cell<*mut ClipboardContext>> =
         Rc::new(Cell::new(ptr::null_mut()));
     let cursor_pos: Rc<Cell<(f64, f64)>> = Rc::new(Cell::new((0.0, 0.0)));
+    let signal_handlers = Rc::new(RefCell::new(Vec::new()));
+    let controllers = Rc::new(RefCell::new(Vec::new()));
 
     // Popover used by the OSC 8 hover preview. Built via the same helpers
     // as the right-click context menu so the look matches by construction.
@@ -1434,39 +1533,63 @@ pub fn create_terminal(
 
     let handle = TerminalHandle {
         surface_cell: surface_cell.clone(),
+        clipboard_context_cell: clipboard_context_cell.clone(),
+        shutting_down: shutting_down.clone(),
         gl_area: gl_area.clone(),
         search_bar: search_bar.clone(),
         search_entry: search_entry.clone(),
         callbacks: callbacks.clone(),
+        im_context: im_context.clone(),
+        im_fallback: im_fallback.clone(),
+        signal_handlers: signal_handlers.clone(),
+        controllers: controllers.clone(),
     };
 
     {
         let surface_cell = surface_cell.clone();
-        gl_area.connect_map(move |gl_area| {
+        let handler = gl_area.connect_map(move |gl_area| {
             if let Some(surface) = *surface_cell.borrow() {
                 refresh_realized_surface_display(surface, gl_area);
             } else {
                 gl_area.queue_render();
             }
         });
+        track_signal(&signal_handlers, &gl_area, handler);
     }
 
     {
-        let handle = handle.clone();
-        search_entry.connect_search_changed(move |entry| {
-            handle.apply_search_query(entry.text().as_str());
+        let surface_cell = surface_cell.clone();
+        let handler = search_entry.connect_search_changed(move |entry| {
+            surface_action(
+                *surface_cell.borrow(),
+                &terminal_search_action(entry.text().as_str()),
+            );
         });
+        track_signal(&signal_handlers, &search_entry, handler);
     }
     {
-        let handle = handle.clone();
-        search_entry.connect_stop_search(move |_| {
-            handle.hide_find();
+        let surface_cell = surface_cell.clone();
+        let search_bar = search_bar.downgrade();
+        let gl_area = gl_area.downgrade();
+        let handler = search_entry.connect_stop_search(move |_| {
+            let Some(search_bar) = search_bar.upgrade() else {
+                return;
+            };
+            if !search_bar.is_search_mode() {
+                return;
+            }
+            surface_action(*surface_cell.borrow(), "end_search");
+            search_bar.set_search_mode(false);
+            if let Some(gl_area) = gl_area.upgrade() {
+                gl_area.grab_focus();
+            }
         });
+        track_signal(&signal_handlers, &search_entry, handler);
     }
     {
         let surface_cell = surface_cell.clone();
         let scrollbar_syncing = scrollbar_syncing.clone();
-        scrollbar_adjustment.connect_value_changed(move |adj| {
+        let handler = scrollbar_adjustment.connect_value_changed(move |adj| {
             if scrollbar_syncing.get() {
                 return;
             }
@@ -1474,6 +1597,7 @@ pub fn create_terminal(
             let row = adj.value().round() as usize;
             surface_action(*surface_cell.borrow(), &format!("scroll_to_row:{row}"));
         });
+        track_signal(&signal_handlers, &scrollbar_adjustment, handler);
     }
 
     // On realize: create the Ghostty surface
@@ -1492,7 +1616,11 @@ pub fn create_terminal(
         let scrollbar_syncing = scrollbar_syncing.clone();
         let open_url_external_for_map = open_url_external.clone();
         let extra_env = extra_env.clone();
-        gl_area.connect_realize(move |gl_area| {
+        let shutting_down = shutting_down.clone();
+        let handler = gl_area.connect_realize(move |gl_area| {
+            if shutting_down.get() {
+                return;
+            }
             gl_area.make_current();
             if let Some(err) = gl_area.error() {
                 eprintln!("limux: GLArea error after make_current: {err}");
@@ -1678,17 +1806,19 @@ pub fn create_terminal(
             // Grab GTK focus so key events reach this widget.
             request_terminal_focus(gl_area, &had_focus);
         });
+        track_signal(&signal_handlers, &gl_area, handler);
     }
 
     // On render: draw the surface.
     {
         let surface_cell = surface_cell.clone();
-        gl_area.connect_render(move |_gl_area, _context| {
+        let handler = gl_area.connect_render(move |_gl_area, _context| {
             if let Some(surface) = *surface_cell.borrow() {
                 unsafe { ghostty_surface_draw(surface) };
             }
             glib::Propagation::Stop
         });
+        track_signal(&signal_handlers, &gl_area, handler);
     }
 
     // On resize: update Ghostty's terminal grid size and queue a redraw.
@@ -1700,7 +1830,7 @@ pub fn create_terminal(
         let surface_cell = surface_cell.clone();
         let gl_for_resize = gl_area.clone();
         let had_focus = had_focus.clone();
-        gl_area.connect_resize(move |gl_area, width, height| {
+        let handler = gl_area.connect_resize(move |gl_area, width, height| {
             if let Some(surface) = *surface_cell.borrow() {
                 let w = width as u32;
                 let h = height as u32;
@@ -1716,6 +1846,7 @@ pub fn create_terminal(
                 });
             }
         });
+        track_signal(&signal_handlers, &gl_area, handler);
     }
 
     // Keyboard input
@@ -1808,6 +1939,9 @@ pub fn create_terminal(
             }
         });
 
+        controllers
+            .borrow_mut()
+            .push(key_controller.clone().upcast());
         gl_area.add_controller(key_controller);
     }
 
@@ -1865,6 +1999,7 @@ pub fn create_terminal(
                 }
             }
         });
+        controllers.borrow_mut().push(click.clone().upcast());
         gl_area.add_controller(click);
     }
 
@@ -1882,6 +2017,7 @@ pub fn create_terminal(
             show_terminal_context_menu(&gl, &overlay, surface, &callbacks, x, y, mods);
             gesture.set_state(gtk::EventSequenceState::Claimed);
         });
+        controllers.borrow_mut().push(right_click.clone().upcast());
         gl_area.add_controller(right_click);
     }
 
@@ -1928,6 +2064,7 @@ pub fn create_terminal(
                 unsafe { ghostty_surface_mouse_pos(surface, x, y, mods) };
             }
         });
+        controllers.borrow_mut().push(motion.clone().upcast());
         gl_area.add_controller(motion);
     }
 
@@ -1945,6 +2082,7 @@ pub fn create_terminal(
             }
             glib::Propagation::Stop
         });
+        controllers.borrow_mut().push(scroll.clone().upcast());
         gl_area.add_controller(scroll);
     }
 
@@ -1975,6 +2113,7 @@ pub fn create_terminal(
                 unsafe { ghostty_surface_set_focus(surface, false) };
             }
         });
+        controllers.borrow_mut().push(focus_ctrl.clone().upcast());
         gl_area.add_controller(focus_ctrl);
     }
 
@@ -2002,6 +2141,7 @@ pub fn create_terminal(
             }
             true
         });
+        controllers.borrow_mut().push(drop_target.clone().upcast());
         gl_area.add_controller(drop_target);
     }
 
@@ -2011,42 +2151,21 @@ pub fn create_terminal(
     // in connect_realize when the widget is re-realized.
     {
         let surface_cell = surface_cell.clone();
-        gl_area.connect_unrealize(move |gl_area| {
+        let handler = gl_area.connect_unrealize(move |gl_area| {
             if let Some(surface) = *surface_cell.borrow() {
                 gl_area.make_current();
                 unsafe { ghostty_surface_display_unrealized(surface) };
             }
         });
+        track_signal(&signal_handlers, &gl_area, handler);
     }
 
-    // Clean up only when the widget is actually destroyed.
+    // Explicit tab and pane teardown normally shuts down the surface first.
+    // Keep widget destruction as a fallback for any future removal path.
     {
-        let surface_cell = surface_cell.clone();
-        let clipboard_context_cell = clipboard_context_cell.clone();
-        let im_context = im_context.clone();
-        let im_fallback = im_fallback.clone();
-        overlay.connect_destroy(move |_| {
-            im_context.set_client_widget(gtk::Widget::NONE);
-            im_fallback.set_client_widget(gtk::Widget::NONE);
-            if let Some(surface) = surface_cell.borrow_mut().take() {
-                let surface_key = surface as usize;
-                SURFACE_MAP.with(|map| {
-                    if let Some(entry) = map.borrow_mut().remove(&surface_key) {
-                        unregister_surface_identity(entry.identity);
-                        unsafe {
-                            drop(Box::from_raw(entry.clipboard_context));
-                        }
-                    }
-                });
-                unsafe { ghostty_surface_free(surface) };
-            } else {
-                let clipboard_context = clipboard_context_cell.replace(ptr::null_mut());
-                if !clipboard_context.is_null() {
-                    unsafe {
-                        drop(Box::from_raw(clipboard_context));
-                    }
-                }
-            }
+        let handle = handle.clone();
+        root.connect_destroy(move |_| {
+            handle.shutdown();
         });
     }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -5435,8 +5435,8 @@ fn show_runtime_error(state: &State, title: &str, detail: &str) {
 }
 
 fn quit_app(state: &State) {
-    save_session_now(state);
-    state.borrow().app.quit();
+    let window = state.borrow().window.clone();
+    window.close();
 }
 
 fn spawn_new_instance(state: &State) -> bool {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -1755,6 +1755,15 @@ pub fn build_window(app: &adw::Application) {
         window.connect_close_request(move |_| {
             save_session_now(&state);
             stop_session_saves_for_shutdown(&state);
+            let split_containers: Vec<_> = state
+                .borrow()
+                .workspaces
+                .iter()
+                .map(|workspace| workspace.split_container.clone())
+                .collect();
+            for split_container in split_containers {
+                split_container.retire_panes();
+            }
             CONTROL_STATE.with(|slot| {
                 slot.borrow_mut().take();
             });
@@ -4924,8 +4933,20 @@ fn close_workspace_by_id_internal(
     persist: bool,
     preferred_active_workspace_id: Option<&str>,
 ) {
+    let split_container = {
+        let s = state.borrow();
+        s.workspaces
+            .iter()
+            .find(|workspace| workspace.id == id)
+            .map(|workspace| workspace.split_container.clone())
+    };
+    let Some(split_container) = split_container else {
+        return;
+    };
+    split_container.retire_panes();
+
     let mut s = state.borrow_mut();
-    let Some(idx) = s.workspaces.iter().position(|w| w.id == id) else {
+    let Some(idx) = s.workspaces.iter().position(|workspace| workspace.id == id) else {
         return;
     };
     let desired_active_workspace_id = preferred_active_workspace_id

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -223,6 +223,23 @@ wait_for_healthy_surfaces() {
   return 1
 }
 
+host_child_count() {
+  awk '{ count += NF } END { print count + 0 }' /proc/"$HOST_PID"/task/*/children
+}
+
+wait_for_host_child_count() {
+  local expected="$1"
+  for _ in $(seq 1 100); do
+    if [ "$(host_child_count)" -eq "$expected" ]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "FAIL: host child count is $(host_child_count), expected $expected"
+  return 1
+}
+
 cleanup() {
   local rc=$?
   echo
@@ -286,6 +303,36 @@ done
 [ "$(cat "$SHIFTED_KEY_PROOF" 2>/dev/null)" = '@A!' ] \
   || { echo "FAIL: plain and shifted send-key did not produce @A!"; exit 1; }
 echo "stage 1b: OK (surface realized, terminal I/O and key levels verified)"
+
+echo
+echo "== stage 1c: terminal teardown releases workspace processes =="
+BASELINE_CHILDREN="$(host_child_count)"
+for cycle in $(seq 1 10); do
+  "$LIMUX_CLI" --json new-workspace --cwd "$DEMO_DIR" \
+    >"$LOG_DIR/stage1c-workspace-$cycle.json"
+  TEARDOWN_WORKSPACE="$(jq -r '.workspace_ref' "$LOG_DIR/stage1c-workspace-$cycle.json")"
+  "$LIMUX_CLI" select-workspace --workspace "$TEARDOWN_WORKSPACE" \
+    >"$LOG_DIR/stage1c-select-$cycle.txt"
+  wait_for_host_child_count "$((BASELINE_CHILDREN + 1))"
+
+  "$LIMUX_CLI" --json new-pane --workspace "$TEARDOWN_WORKSPACE" --direction right \
+    >"$LOG_DIR/stage1c-pane-$cycle-1.json"
+  "$LIMUX_CLI" --json new-pane --workspace "$TEARDOWN_WORKSPACE" --direction down \
+    >"$LOG_DIR/stage1c-pane-$cycle-2.json"
+  wait_for_host_child_count "$((BASELINE_CHILDREN + 3))"
+
+  EXIT_SURFACE="$(jq -r '.surface_ref' "$LOG_DIR/stage1c-pane-$cycle-2.json")"
+  "$LIMUX_CLI" send --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" exit \
+    >"$LOG_DIR/stage1c-exit-$cycle.txt"
+  "$LIMUX_CLI" send-key --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" Enter \
+    >"$LOG_DIR/stage1c-exit-enter-$cycle.txt"
+  wait_for_host_child_count "$((BASELINE_CHILDREN + 2))"
+
+  "$LIMUX_CLI" close-workspace --workspace "$TEARDOWN_WORKSPACE" \
+    >"$LOG_DIR/stage1c-close-$cycle.txt"
+  wait_for_host_child_count "$BASELINE_CHILDREN"
+done
+echo "stage 1c: OK (10 multi-pane workspace cycles returned to $BASELINE_CHILDREN child process)"
 
 # --- 5. Stage 2: live agent-team ------------------------------------------
 echo


### PR DESCRIPTION
## Summary

- shut down Ghostty surfaces explicitly when terminal tabs, panes, workspaces, or app close
- drain pane tab ownership and break GTK callback, signal, and controller reference cycles
- keep callback widgets and clipboard userdata alive until Ghostty worker shutdown completes
- prevent retired terminal widgets from creating replacement surfaces during late realize events

Fixes #137.

## Root cause

`SURFACE_MAP` and terminal callbacks retained GTK pane state, while cleanup depended on widget destruction. Closed panes and workspaces could therefore keep terminal roots reachable, preventing `ghostty_surface_free` from running and leaving PTY shells plus three Ghostty threads per surface alive.

## Testing

- `./scripts/check.sh` (306 Rust tests and 14 packaging checks passed)
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`
- live Weston regression creates 10 three-terminal workspaces, exits one shell, closes each workspace, and verifies host child processes return from 4 to 1 every cycle
- existing smoke coverage verifies split/reparent, surface health, terminal I/O, session restore, and clean process-group shutdown
- `shellcheck scripts/xvfb-smoke-test.sh`
- `git diff --check`
