### PR TITLE
fix(host): commit tab renames on outside click

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2476,7 +2476,9 @@ fn show_tab_context_menu(tab_btn: &gtk::Box, tab_id: &str, context: &TabContextM
     menu.popup();
 }
 
-fn find_tab_rename_entry<W: glib::object::IsA<gtk::Widget>>(root: &W) -> Option<gtk::Entry> {
+pub(crate) fn find_tab_rename_entry<W: glib::object::IsA<gtk::Widget>>(
+    root: &W,
+) -> Option<gtk::Entry> {
     fn find_entry(widget: &gtk::Widget) -> Option<gtk::Entry> {
         if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
             if entry.has_css_class(TAB_RENAME_ENTRY_CSS_CLASS) {

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -1660,18 +1660,13 @@ pub fn build_window(app: &adw::Application) {
         click_anywhere.connect_pressed(move |_, _, x, y| {
             let entry = find_active_rename_entry(&sl).or_else(|| pane::find_tab_rename_entry(&win));
             if let Some(entry) = entry {
-                // Translate click coords from window to the entry's coordinate space
-                if let Some((ex, ey)) = win.translate_coordinates(&entry, x, y) {
-                    let alloc = entry.allocation();
-                    if ex >= 0.0
-                        && ey >= 0.0
-                        && ex <= alloc.width() as f64
-                        && ey <= alloc.height() as f64
-                    {
-                        return; // click is inside the entry
-                    }
-                }
-                entry.emit_activate();
+                let allocation = entry.allocation();
+                commit_inline_rename_for_click(
+                    win.translate_coordinates(&entry, x, y),
+                    allocation.width(),
+                    allocation.height(),
+                    || entry.emit_activate(),
+                );
             }
         });
         window.add_controller(click_anywhere);
@@ -3162,6 +3157,20 @@ fn find_active_rename_entry(sidebar_list: &gtk::ListBox) -> Option<gtk::Entry> {
         row = r.next_sibling();
     }
     None
+}
+
+fn commit_inline_rename_for_click(
+    translated_click: Option<(f64, f64)>,
+    entry_width: i32,
+    entry_height: i32,
+    commit: impl FnOnce(),
+) {
+    let click_is_inside = translated_click.is_some_and(|(x, y)| {
+        x >= 0.0 && y >= 0.0 && x <= entry_width as f64 && y <= entry_height as f64
+    });
+    if !click_is_inside {
+        commit();
+    }
 }
 
 fn begin_workspace_inline_rename(state: &State, workspace_id: &str) {
@@ -6173,7 +6182,7 @@ fn show_desktop_notification(state: &State, request: DesktopNotificationRequest)
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::rc::Rc;
 
     use super::glib;
@@ -6182,8 +6191,9 @@ mod tests {
     use super::ToVariant;
     use super::{
         browser_command_requires_existing_target, build_window_css,
-        clamp_workspace_insert_index_for_pinning, desktop_notification_action_from_signal,
-        desktop_notification_actions, desktop_notification_activation_token_from_signal,
+        clamp_workspace_insert_index_for_pinning, commit_inline_rename_for_click,
+        desktop_notification_action_from_signal, desktop_notification_actions,
+        desktop_notification_activation_token_from_signal,
         desktop_notification_closed_id_from_signal, desktop_notification_id_from_response,
         directional_neighbor_score, favorites_prefix_len, find_leaf_pane, font_size_after_delta,
         ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
@@ -6480,6 +6490,21 @@ mod tests {
             [HOST_ENTRY_CSS_CLASS, WORKSPACE_RENAME_ENTRY_CSS_CLASS]
         );
         assert!(BASE_CSS.contains(".limux-ws-rename-entry"));
+    }
+
+    #[test]
+    fn outside_rename_click_commits_while_inside_click_preserves_editor() {
+        for (click, should_commit) in [
+            (Some((0.0, 0.0)), false),
+            (Some((120.0, 32.0)), false),
+            (Some((-0.1, 16.0)), true),
+            (Some((60.0, 32.1)), true),
+            (None, true),
+        ] {
+            let entry_present = Cell::new(true);
+            commit_inline_rename_for_click(click, 120, 32, || entry_present.set(false));
+            assert_eq!(entry_present.get(), !should_commit, "click: {click:?}");
+        }
     }
 
     #[test]

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -1650,15 +1650,16 @@ pub fn build_window(app: &adw::Application) {
     register_window_actions(&window, &state);
     install_key_capture(&window, &state);
 
-    // Any click anywhere in the window commits an active sidebar rename,
-    // UNLESS the click is inside the rename Entry itself.
+    // Any click anywhere in the window commits an active inline rename,
+    // unless the click is inside the rename entry itself.
     {
         let sl = sidebar_list.clone();
         let win = window.clone();
         let click_anywhere = gtk::GestureClick::new();
         click_anywhere.set_propagation_phase(gtk::PropagationPhase::Capture);
         click_anywhere.connect_pressed(move |_, _, x, y| {
-            if let Some(entry) = find_active_rename_entry(&sl) {
+            let entry = find_active_rename_entry(&sl).or_else(|| pane::find_tab_rename_entry(&win));
+            if let Some(entry) = entry {
                 // Translate click coords from window to the entry's coordinate space
                 if let Some((ex, ey)) = win.translate_coordinates(&entry, x, y) {
                     let alloc = entry.allocation();
@@ -1670,7 +1671,7 @@ pub fn build_window(app: &adw::Application) {
                         return; // click is inside the entry
                     }
                 }
-                commit_any_active_rename(&sl);
+                entry.emit_activate();
             }
         });
         window.add_controller(click_anywhere);
@@ -3161,32 +3162,6 @@ fn find_active_rename_entry(sidebar_list: &gtk::ListBox) -> Option<gtk::Entry> {
         row = r.next_sibling();
     }
     None
-}
-
-/// Find any active rename Entry in the sidebar and trigger its activate signal to commit.
-fn commit_any_active_rename(sidebar_list: &gtk::ListBox) {
-    let mut row = sidebar_list.first_child();
-    while let Some(r) = row {
-        // Walk into the row's children to find a gtk::Entry
-        fn find_entry(widget: &gtk::Widget) -> Option<gtk::Entry> {
-            if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
-                return Some(entry.clone());
-            }
-            let mut child = widget.first_child();
-            while let Some(c) = child {
-                if let Some(entry) = find_entry(&c) {
-                    return Some(entry);
-                }
-                child = c.next_sibling();
-            }
-            None
-        }
-        if let Some(entry) = find_entry(&r) {
-            entry.emit_activate();
-            return;
-        }
-        row = r.next_sibling();
-    }
 }
 
 fn begin_workspace_inline_rename(state: &State, workspace_id: &str) {


### PR DESCRIPTION
## Summary

Commit active tab rename when pointer is pressed outside rename entry. Empty header and tab-strip areas do not take focus, so blur-only cleanup left entry active and made terminal input appear stuck.

Fixes #139.

## Changes

- Extend existing window capture-phase rename handler to tab rename entries.
- Reuse entry activation path for commit and cleanup.
- Preserve editing when click lands inside active entry.

## Repro

1. Right-click terminal tab and select **Rename**.
2. Type new name.
3. Click empty header or tab-strip area.
4. Before fix, entry remains active and captures later keystrokes. After fix, rename commits and entry closes.

## Testing

- Live Xvfb GTK host repro before and after fix
- `PKG_CONFIG=/usr/bin/pkg-config ./scripts/check.sh`
- `cargo fmt --check`
- `git diff --check`

## Did this cause any problems?

Revert this commit.
