### PR TITLE
fix(host): request KWin server-side decorations instead of hiding header bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-wayland"
-version = "0.11.0"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7027433b8f19075ab22f01d0e0ba4373e303ffdb4ce4f846a2763cb020ea9bdc"
+checksum = "32d95828dadc0357dee236cc6a5712808bd894d3217159982592ce24f2b8aaf7"
 dependencies = [
  "gdk4",
  "gdk4-wayland-sys",

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -1337,14 +1337,44 @@ row:selected .limux-ws-path {
 
 const CONTENT_BACKGROUND_RGB: (u8, u8, u8) = (23, 23, 23);
 
+/// Squares off the CSD window corners and drops the client-side shadow
+/// when the compositor draws the window decorations (see
+/// `compositor_provides_decorations`), so the window fills the KWin frame
+/// without transparent gaps at the corners.
+const SSD_CSS: &str = r#"
+window.csd,
+window.csd:backdrop {
+    --window-radius: 0px;
+    border-radius: 0;
+    box-shadow: none;
+    outline: none;
+}
+"#;
+
+/// True when the compositor speaks the KDE server-decoration protocol
+/// (KWin). In that case build_window() requests server-side decorations
+/// from the compositor and skips the in-app header bar.
+fn compositor_provides_decorations() -> bool {
+    gtk::gdk::Display::default()
+        .and_then(|display| display.downcast::<gdk4_wayland::WaylandDisplay>().ok())
+        .map(|display| display.query_registry("org_kde_kwin_server_decoration_manager"))
+        .unwrap_or(false)
+}
+
 fn app_css(background_opacity: f64, config: &app_config::AppConfig) -> String {
+    let ssd_css = if compositor_provides_decorations() {
+        SSD_CSS
+    } else {
+        ""
+    };
     format!(
-        "{}\n{}\n{}\n{}\n{}",
+        "{}\n{}\n{}\n{}\n{}\n{}",
         build_window_css(background_opacity),
         pane::PANE_CSS,
         keybind_editor::KEYBIND_EDITOR_CSS,
         crate::settings_editor::SETTINGS_CSS,
         crate::settings_editor::ui_scale_css(config),
+        ssd_css,
     )
 }
 
@@ -1432,17 +1462,16 @@ pub fn build_window(app: &adw::Application) {
         .build();
     apply_window_background_class(&window, background_opacity);
 
-    // On Wayland compositors with xdg-decoration support, the compositor
-    // already provides the window chrome, so keep Limux from rendering a
-    // duplicate header bar. X11 continues to use the in-app header.
-    let provides_decorations = display
-        .clone()
-        .downcast::<gdk4_wayland::WaylandDisplay>()
-        .ok()
-        .map(|display| display.query_registry("zxdg_decoration_manager_v1"))
-        .unwrap_or(false);
+    // libadwaita forces client-side decorations (it installs an invisible
+    // titlebar widget internally), so compositors never draw server-side
+    // decorations for Limux on their own. When the compositor speaks the
+    // KDE server-decoration protocol (KWin), skip the in-app header bar:
+    // build_window() explicitly requests SERVER mode after present(),
+    // which makes the compositor draw the window chrome. Everywhere else
+    // (mutter, X11, …) the in-app header bar is the only chrome we get.
+    let compositor_provides_decorations = compositor_provides_decorations();
 
-    let header = if provides_decorations {
+    let header = if compositor_provides_decorations {
         None
     } else {
         let bar = adw::HeaderBar::new();
@@ -1738,6 +1767,20 @@ pub fn build_window(app: &adw::Application) {
     crate::control_bridge::start(dispatch_control_command);
 
     window.present();
+
+    // Ask the compositor for server-side decorations when it supports the
+    // KDE server-decoration protocol (see the header-bar decision above).
+    // libadwaita marks the window client-decorated, which makes GtkWindow
+    // compute decorated=false at realize time; forcing the GDK-level
+    // property after present() makes GDK request SERVER mode from KWin via
+    // org_kde_kwin_server_decoration.
+    if compositor_provides_decorations {
+        if let Some(surface) = window.surface() {
+            if let Ok(toplevel) = surface.downcast::<gtk::gdk::Toplevel>() {
+                toplevel.set_decorated(true);
+            }
+        }
+    }
 }
 
 fn build_window_css(background_opacity: f64) -> String {


### PR DESCRIPTION
Fixes #141

## Problem

On KWin Wayland, Limux launched without any title bar or window borders. The existing code checked for `zxdg_decoration_manager_v1` to decide whether the compositor provides window chrome — but GTK4/libadwaita doesn't use that protocol (libadwaita always forces client-side decorations), so KWin never drew decorations and Limux also hid its in-app header bar. Result: no chrome at all.

## Fix

- Detect the KDE server-decoration protocol (`org_kde_kwin_server_decoration_manager`) via `gdk4-wayland`'s registry query — this is the protocol KWin actually implements and that GDK4 uses.
- When present: skip the in-app `adw::HeaderBar` and, after `window.present()`, force the GDK-level `decorated` property on the toplevel. GDK then requests SERVER mode from KWin, which draws a native Breeze title bar and borders.
- Add `SSD_CSS` (applied only in this case) to square off the CSD corners and drop the client-side shadow, so the window fills the KWin frame without transparent gaps at the corners.
- Non-KDE compositors (mutter, X11, …) are untouched: they keep the in-app header bar exactly as before.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (226 tests) all pass.
- Verified live on CachyOS / KDE Plasma (KWin Wayland): native Breeze title bar appears, square corners match the KWin frame, fullscreen and windowed both behave.