### PR TITLE
fix(ci): publish AUR files from workspace

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -237,13 +237,13 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: aur-pkgbuilds
-          path: /tmp/aur-pkgbuilds
+          path: aur-pkgbuilds
 
       - name: Publish limux-bin to AUR
         uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
           pkgname: limux-bin
-          pkgbuild: /tmp/aur-pkgbuilds/PKGBUILD-bin
+          pkgbuild: aur-pkgbuilds/PKGBUILD-bin
           commit_username: "limux-aurbot"
           commit_email: limux-aurbot@users.noreply.aur.archlinux.org
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
@@ -259,13 +259,13 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: aur-pkgbuilds
-          path: /tmp/aur-pkgbuilds
+          path: aur-pkgbuilds
 
       - name: Publish limux to AUR
         uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
           pkgname: limux
-          pkgbuild: /tmp/aur-pkgbuilds/PKGBUILD-source
+          pkgbuild: aur-pkgbuilds/PKGBUILD-source
           commit_username: "limux-aurbot"
           commit_email: limux-aurbot@users.noreply.aur.archlinux.org
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Fix v0.1.24 AUR publication after both publish jobs failed to find generated PKGBUILDs inside the deploy action container.

## Root cause

`actions/download-artifact` wrote PKGBUILDs under host `/tmp`, but the Docker action mounts only the GitHub workspace at `/github/workspace`. Both publish jobs therefore failed with `cp: cannot stat` before reaching AUR push.

## Changes

- download publish artifacts inside the mounted workspace
- pass workspace-relative PKGBUILD paths to both AUR publish jobs

## Testing

- `./scripts/check.sh` (306 Rust tests and 14 packaging checks passed)
- `git diff --check`
- verified relative path behavior against pinned deploy action `build.sh`

## Did this cause any problems?

Revert this commit. AUR publication would return to failing before push.