### PR TITLE
feat(host): upgrade embedded Ghostty

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -157,25 +157,19 @@ jobs:
           pacman -S --needed --noconfirm \
             curl \
             git \
-            ghostty \
             gtk4 \
             libadwaita \
             libepoxy \
             minisign \
             namcap \
             rust \
+            zig \
             webkitgtk-6.0
 
-      - name: Install Zig 0.15 package
+      - name: Create package builder user
         run: |
           set -euo pipefail
           useradd --create-home builder
-          git clone https://aur.archlinux.org/zig0.15-bin.git /tmp/zig-package
-          git -C /tmp/zig-package checkout --detach 6ec7dad0340e61aa0c98a895d09561ecf7b7270e
-          chown -R builder:builder /tmp/zig-package
-          runuser -u builder -- env HOME=/home/builder \
-            makepkg --dir /tmp/zig-package --cleanbuild --noconfirm
-          pacman -U --noconfirm /tmp/zig-package/zig0.15-bin-*.pkg.tar.zst
 
       - name: Build source package
         run: |
@@ -197,7 +191,7 @@ jobs:
           for path in \
             usr/bin/limux \
             usr/libexec/limux/limux-host \
-            usr/lib/limux/libghostty.so \
+            usr/lib/limux/libghostty-internal.so \
             usr/share/licenses/limux/LICENSE \
             usr/share/applications/dev.limux.linux.desktop \
             usr/share/metainfo/dev.limux.linux.metainfo.xml \

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install stable Rust
         run: |

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Determine version
         id: version

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install stable Rust with required components
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install stable Rust
         run: |

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -32,6 +32,7 @@ jobs:
           sudo apt-get install -y \
             blueprint-compiler \
             build-essential \
+            gettext \
             libadwaita-1-dev \
             libepoxy-dev \
             libgtk-4-dev \
@@ -72,6 +73,7 @@ jobs:
           sudo apt-get install -y \
             blueprint-compiler \
             build-essential \
+            gettext \
             jq \
             libadwaita-1-dev \
             libepoxy-dev \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ghostty"]
 	path = ghostty
-	url = https://github.com/am-will/ghostty.git
+	url = https://github.com/bvolpato/ghostty.git

--- a/PKGBUILD-source.template
+++ b/PKGBUILD-source.template
@@ -8,14 +8,14 @@ arch=('x86_64')
 url="https://github.com/am-will/limux"
 license=('MIT')
 depends=('fontconfig' 'glib2' 'gtk4' 'hicolor-icon-theme' 'libadwaita' 'pango' 'webkitgtk-6.0')
-makedepends=('ghostty' 'git' 'libepoxy' 'rust' 'zig0.15')
+makedepends=('git' 'libepoxy' 'rust' 'zig')
 conflicts=('limux-bin' 'limux-bin-debug')
 options=(!debug !lto)
 _limux_commit=@@SOURCE_COMMIT@@
 _ghostty_commit=@@GHOSTTY_COMMIT@@
 source=(
     "$pkgname-$pkgver::git+@@SOURCE_REPOSITORY@@#commit=$_limux_commit"
-    "ghostty-$pkgver::git+https://github.com/am-will/ghostty.git#commit=$_ghostty_commit"
+    "ghostty-$pkgver::git+https://github.com/bvolpato/ghostty.git#commit=$_ghostty_commit"
 )
 sha256sums=('SKIP' 'SKIP')
 
@@ -31,7 +31,7 @@ build() {
 
     (
         cd ghostty
-        zig-0.15 build -Dapp-runtime=none "${zig_args[@]}"
+        zig build -Dapp-runtime=none "${zig_args[@]}"
     )
 
     RUSTFLAGS="\
@@ -44,12 +44,12 @@ package() {
 
     install -Dm755 target/release/limux-cli "$pkgdir/usr/bin/limux"
     install -Dm755 target/release/limux "$pkgdir/usr/libexec/limux/limux-host"
-    install -Dm644 ghostty/zig-out/lib/libghostty.so "$pkgdir/usr/lib/limux/libghostty.so"
+    install -Dm644 ghostty/zig-out/lib/libghostty-internal.so "$pkgdir/usr/lib/limux/libghostty-internal.so"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
     install -dm755 "$pkgdir/usr/share/limux/ghostty"
-    cp -a /usr/share/ghostty/. "$pkgdir/usr/share/limux/ghostty/"
-    install -Dm644 /usr/share/terminfo/x/xterm-ghostty \
+    cp -a ghostty/zig-out/share/ghostty/. "$pkgdir/usr/share/limux/ghostty/"
+    install -Dm644 ghostty/zig-out/share/terminfo/x/xterm-ghostty \
         "$pkgdir/usr/share/limux/terminfo/x/xterm-ghostty"
 
     install -Dm644 rust/limux-host-linux/dev.limux.linux.desktop \

--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -19,7 +19,7 @@ package() {
 
     install -Dm755 limux "${pkgdir}/usr/bin/limux"
     install -Dm755 libexec/limux/limux-host "${pkgdir}/usr/libexec/limux/limux-host"
-    install -Dm644 lib/libghostty.so "${pkgdir}/usr/lib/limux/libghostty.so"
+    install -Dm644 lib/libghostty-internal.so "${pkgdir}/usr/lib/limux/libghostty-internal.so"
 
     install -Dm644 /dev/stdin "${pkgdir}/etc/ld.so.conf.d/limux.conf" <<< "/usr/lib/limux"
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo apt install libgtk-4-1 libadwaita-1-0 libwebkitgtk-6.0-4
 ### Prerequisites
 
 - Rust toolchain (stable)
-- Zig
+- Zig 0.16.0
 - GTK4, libadwaita, WebKitGTK dev packages
 - Initialized Ghostty submodule
 
@@ -96,7 +96,7 @@ git submodule update --init --recursive
 # Build limux
 cargo build --release
 
-# Run (point to libghostty.so location)
+# Run (point to libghostty-internal.so location)
 LD_LIBRARY_PATH=../ghostty/zig-out/lib:$LD_LIBRARY_PATH ./target/release/limux
 ```
 
@@ -106,8 +106,8 @@ LD_LIBRARY_PATH=../ghostty/zig-out/lib:$LD_LIBRARY_PATH ./target/release/limux
 ./scripts/package.sh
 ```
 
-This builds the binary, bundles `libghostty.so`, icons, and an install script into a tarball.
-`package.sh` also rebuilds `libghostty.so` with `ReleaseFast` and `-Dcpu=baseline`, so Zig and the initialized Ghostty submodule must be present.
+This builds the binary, bundles `libghostty-internal.so`, icons, and an install script into a tarball.
+`package.sh` also rebuilds `libghostty-internal.so` with `ReleaseFast` and `-Dcpu=baseline`, so Zig 0.16.0 and initialized Ghostty submodule must be present.
 
 ## Development
 
@@ -251,7 +251,7 @@ rust/
   limux-cli/           # CLI client
 ```
 
-The terminal rendering is handled entirely by Ghostty's embedded library (`libghostty.so`), which provides GPU-accelerated OpenGL rendering. The UI layer is native GTK4 with libadwaita.
+The terminal rendering is handled entirely by Ghostty's embedded library (`libghostty-internal.so`), which provides GPU-accelerated OpenGL rendering. The UI layer is native GTK4 with libadwaita.
 
 ## License
 

--- a/rust/limux-ghostty-sys/build.rs
+++ b/rust/limux-ghostty-sys/build.rs
@@ -4,18 +4,26 @@ fn main() {
     // Find libghostty relative to the workspace root.
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let ghostty_root = manifest_dir.join("../../ghostty");
+    let ghostty_library = "libghostty-internal.so";
     let ghostty_lib = ghostty_root
         .join("zig-out/lib")
         .canonicalize()
-        .expect("libghostty not found — run: cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast");
+        .expect("Ghostty library directory not found — run: cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast");
+
+    if !ghostty_lib.join(ghostty_library).is_file() {
+        panic!(
+            "{ghostty_library} not found at {} — run: cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast",
+            ghostty_lib.display()
+        );
+    }
 
     println!("cargo:rustc-link-search=native={}", ghostty_lib.display());
-    println!("cargo:rustc-link-lib=dylib=ghostty");
+    println!("cargo:rustc-link-lib=dylib=ghostty-internal");
     println!("cargo:rustc-link-lib=dylib=epoxy");
 
-    // Re-run if libghostty changes
+    // Re-run if libghostty changes.
     println!(
         "cargo:rerun-if-changed={}",
-        ghostty_lib.join("libghostty.so").display()
+        ghostty_lib.join(ghostty_library).display()
     );
 }

--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -22,7 +22,10 @@ pub type ghostty_surface_t = *mut c_void;
 pub const GHOSTTY_PLATFORM_INVALID: c_int = 0;
 pub const GHOSTTY_PLATFORM_MACOS: c_int = 1;
 pub const GHOSTTY_PLATFORM_IOS: c_int = 2;
-pub const GHOSTTY_PLATFORM_LINUX: c_int = 3;
+pub const GHOSTTY_PLATFORM_OPENGL: c_int = 3;
+pub const GHOSTTY_PLATFORM_METAL_EXTERNAL: c_int = 4;
+pub const GHOSTTY_PLATFORM_METAL_EXTERNAL_LEASED: c_int = 5;
+pub const GHOSTTY_PLATFORM_LINUX: c_int = 6;
 
 pub const GHOSTTY_CLIPBOARD_STANDARD: c_int = 0;
 pub const GHOSTTY_CLIPBOARD_SELECTION: c_int = 1;
@@ -75,17 +78,17 @@ pub const GHOSTTY_ACTION_SCROLLBAR: c_int = 26;
 pub const GHOSTTY_ACTION_RENDER: c_int = 27;
 pub const GHOSTTY_ACTION_DESKTOP_NOTIFICATION: c_int = 31;
 pub const GHOSTTY_ACTION_SET_TITLE: c_int = 32;
-pub const GHOSTTY_ACTION_PWD: c_int = 34;
-pub const GHOSTTY_ACTION_MOUSE_SHAPE: c_int = 35;
-pub const GHOSTTY_ACTION_MOUSE_VISIBILITY: c_int = 36;
-pub const GHOSTTY_ACTION_MOUSE_OVER_LINK: c_int = 37;
-pub const GHOSTTY_ACTION_COLOR_CHANGE: c_int = 45;
-pub const GHOSTTY_ACTION_RELOAD_CONFIG: c_int = 46;
-pub const GHOSTTY_ACTION_CONFIG_CHANGE: c_int = 47;
-pub const GHOSTTY_ACTION_CLOSE_WINDOW: c_int = 48;
-pub const GHOSTTY_ACTION_RING_BELL: c_int = 49;
-pub const GHOSTTY_ACTION_OPEN_URL: c_int = 53;
-pub const GHOSTTY_ACTION_SHOW_CHILD_EXITED: c_int = 54;
+pub const GHOSTTY_ACTION_PWD: c_int = 35;
+pub const GHOSTTY_ACTION_MOUSE_SHAPE: c_int = 36;
+pub const GHOSTTY_ACTION_MOUSE_VISIBILITY: c_int = 37;
+pub const GHOSTTY_ACTION_MOUSE_OVER_LINK: c_int = 38;
+pub const GHOSTTY_ACTION_COLOR_CHANGE: c_int = 46;
+pub const GHOSTTY_ACTION_RELOAD_CONFIG: c_int = 47;
+pub const GHOSTTY_ACTION_CONFIG_CHANGE: c_int = 48;
+pub const GHOSTTY_ACTION_CLOSE_WINDOW: c_int = 49;
+pub const GHOSTTY_ACTION_RING_BELL: c_int = 50;
+pub const GHOSTTY_ACTION_OPEN_URL: c_int = 54;
+pub const GHOSTTY_ACTION_SHOW_CHILD_EXITED: c_int = 55;
 
 pub type ghostty_action_mouse_shape_e = c_int;
 
@@ -238,11 +241,28 @@ pub struct ghostty_platform_linux_s {
     pub reserved: *mut c_void,
 }
 
+pub type ghostty_opengl_make_current_cb = unsafe extern "C" fn(*mut c_void) -> bool;
+pub type ghostty_opengl_clear_current_cb = unsafe extern "C" fn(*mut c_void);
+pub type ghostty_opengl_get_proc_address_cb =
+    unsafe extern "C" fn(*mut c_void, *const c_char) -> *mut c_void;
+pub type ghostty_opengl_swap_buffers_cb = unsafe extern "C" fn(*mut c_void);
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ghostty_platform_opengl_s {
+    pub userdata: *mut c_void,
+    pub make_current: ghostty_opengl_make_current_cb,
+    pub clear_current: ghostty_opengl_clear_current_cb,
+    pub get_proc_address: ghostty_opengl_get_proc_address_cb,
+    pub swap_buffers: ghostty_opengl_swap_buffers_cb,
+}
+
 #[repr(C)]
 pub union ghostty_platform_u {
     pub macos: ghostty_platform_macos_s,
     pub ios: ghostty_platform_ios_s,
-    pub linux: ghostty_platform_linux_s,
+    pub opengl: ghostty_platform_opengl_s,
+    pub linux_platform: ghostty_platform_linux_s,
 }
 
 #[repr(C)]
@@ -269,6 +289,8 @@ pub struct ghostty_input_key_s {
 }
 
 pub type ghostty_io_write_cb = unsafe extern "C" fn(*mut c_void, *const c_char, usize);
+pub type ghostty_renderer_event_cb = unsafe extern "C" fn(*mut c_void, c_int);
+pub type ghostty_pty_tee_cb = unsafe extern "C" fn(*mut c_void, *const c_char, usize);
 
 #[repr(C)]
 pub struct ghostty_surface_config_s {
@@ -287,6 +309,9 @@ pub struct ghostty_surface_config_s {
     pub io_mode: c_int, // ghostty_surface_io_mode_e (0 = exec)
     pub io_write_cb: Option<ghostty_io_write_cb>,
     pub io_write_userdata: *mut c_void,
+    pub renderer_event_cb: Option<ghostty_renderer_event_cb>,
+    pub pty_tee_cb: Option<ghostty_pty_tee_cb>,
+    pub pty_tee_userdata: *mut c_void,
 }
 
 #[repr(C)]
@@ -402,6 +427,8 @@ pub struct ghostty_action_set_title_s {
 #[derive(Clone, Copy)]
 pub struct ghostty_action_pwd_s {
     pub pwd: *const c_char,
+    pub scrollbar: *const ghostty_action_scrollbar_s,
+    pub scrollbar_revision: u64,
 }
 
 #[repr(C)]
@@ -430,13 +457,15 @@ pub struct ghostty_surface_message_childexited_s {
 pub type ghostty_runtime_wakeup_cb = unsafe extern "C" fn(*mut c_void);
 pub type ghostty_runtime_action_cb =
     unsafe extern "C" fn(ghostty_app_t, ghostty_target_s, ghostty_action_s) -> bool;
-pub type ghostty_runtime_clipboard_has_text_cb = unsafe extern "C" fn(*mut c_void, c_int) -> bool;
-pub type ghostty_runtime_read_clipboard_cb = unsafe extern "C" fn(*mut c_void, c_int, *mut c_void);
+pub type ghostty_runtime_read_clipboard_cb =
+    unsafe extern "C" fn(*mut c_void, c_int, *mut c_void) -> bool;
 pub type ghostty_runtime_confirm_read_clipboard_cb =
     unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_void, c_int);
 pub type ghostty_runtime_write_clipboard_cb =
     unsafe extern "C" fn(*mut c_void, c_int, *const ghostty_clipboard_content_s, usize, bool);
 pub type ghostty_runtime_close_surface_cb = unsafe extern "C" fn(*mut c_void, bool);
+pub type ghostty_runtime_tmux_control_cb =
+    unsafe extern "C" fn(*mut c_void, c_int, u32, *const u8, usize);
 
 #[repr(C)]
 pub struct ghostty_runtime_config_s {
@@ -444,11 +473,11 @@ pub struct ghostty_runtime_config_s {
     pub supports_selection_clipboard: bool,
     pub wakeup_cb: ghostty_runtime_wakeup_cb,
     pub action_cb: ghostty_runtime_action_cb,
-    pub clipboard_has_text_cb: ghostty_runtime_clipboard_has_text_cb,
     pub read_clipboard_cb: ghostty_runtime_read_clipboard_cb,
     pub confirm_read_clipboard_cb: ghostty_runtime_confirm_read_clipboard_cb,
     pub write_clipboard_cb: ghostty_runtime_write_clipboard_cb,
     pub close_surface_cb: ghostty_runtime_close_surface_cb,
+    pub tmux_control_cb: Option<ghostty_runtime_tmux_control_cb>,
 }
 
 // -------------------------------------------------------------------
@@ -569,4 +598,33 @@ extern "C" {
         state: *mut c_void,
         confirmed: bool,
     );
+}
+
+#[cfg(all(test, target_pointer_width = "64"))]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    #[test]
+    fn embedding_struct_layouts_match_ghostty_header() {
+        assert_eq!(size_of::<ghostty_platform_u>(), 40);
+        assert_eq!(align_of::<ghostty_platform_u>(), 8);
+
+        assert_eq!(size_of::<ghostty_surface_config_s>(), 168);
+        assert_eq!(align_of::<ghostty_surface_config_s>(), 8);
+        assert_eq!(offset_of!(ghostty_surface_config_s, renderer_event_cb), 144);
+        assert_eq!(offset_of!(ghostty_surface_config_s, pty_tee_cb), 152);
+        assert_eq!(offset_of!(ghostty_surface_config_s, pty_tee_userdata), 160);
+
+        assert_eq!(size_of::<ghostty_runtime_config_s>(), 72);
+        assert_eq!(align_of::<ghostty_runtime_config_s>(), 8);
+        assert_eq!(offset_of!(ghostty_runtime_config_s, read_clipboard_cb), 32);
+        assert_eq!(offset_of!(ghostty_runtime_config_s, tmux_control_cb), 64);
+
+        assert_eq!(size_of::<ghostty_action_u>(), 24);
+        assert_eq!(size_of::<ghostty_action_s>(), 32);
+        assert_eq!(offset_of!(ghostty_action_s, action), 8);
+        assert_eq!(size_of::<ghostty_action_pwd_s>(), 24);
+        assert_eq!(size_of::<ghostty_surface_message_childexited_s>(), 16);
+    }
 }

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -624,11 +624,11 @@ pub fn init_ghostty() {
             supports_selection_clipboard: true,
             wakeup_cb: ghostty_wakeup_cb,
             action_cb: ghostty_action_cb,
-            clipboard_has_text_cb: ghostty_clipboard_has_text_cb,
             read_clipboard_cb: ghostty_read_clipboard_cb,
             confirm_read_clipboard_cb: ghostty_confirm_read_clipboard_cb,
             write_clipboard_cb: ghostty_write_clipboard_cb,
             close_surface_cb: ghostty_close_surface_cb,
+            tmux_control_cb: None,
         };
 
         let app = unsafe { ghostty_app_new(&runtime_config, config) };
@@ -1157,22 +1157,19 @@ unsafe extern "C" fn ghostty_read_clipboard_cb(
     userdata: *mut c_void,
     clipboard_type: c_int,
     state: *mut c_void,
-) {
+) -> bool {
     let surface_ptr = match unsafe { clipboard_surface_from_userdata(userdata) } {
         Some(surface) => surface,
-        None => return,
+        None => return false,
     };
 
-    let display = match gtk::gdk::Display::default() {
-        Some(d) => d,
-        None => {
-            unsafe {
-                complete_clipboard_request(surface_ptr, ptr::null(), state, true);
-            }
-            return;
-        }
+    let Some(display) = gtk::gdk::Display::default() else {
+        return false;
     };
     let clipboard = clipboard_from_type(&display, clipboard_type);
+    if !clipboard_has_text(&clipboard) {
+        return false;
+    }
 
     clipboard.read_text_async(gtk::gio::Cancellable::NONE, move |result| {
         let text = result.ok().flatten().map(|s| s.to_string());
@@ -1181,6 +1178,8 @@ unsafe extern "C" fn ghostty_read_clipboard_cb(
             complete_clipboard_request(surface_ptr, cstr.as_ptr(), state, true);
         }
     });
+
+    true
 }
 
 fn clipboard_from_type(display: &gtk::gdk::Display, clipboard_type: c_int) -> gtk::gdk::Clipboard {
@@ -1222,17 +1221,6 @@ fn clipboard_formats_include_text<'a>(
         mime.eq_ignore_ascii_case("text/plain")
             || mime.eq_ignore_ascii_case("text/plain;charset=utf-8")
     })
-}
-
-unsafe extern "C" fn ghostty_clipboard_has_text_cb(
-    _userdata: *mut c_void,
-    clipboard_type: c_int,
-) -> bool {
-    let Some(display) = gtk::gdk::Display::default() else {
-        return false;
-    };
-    let clipboard = clipboard_from_type(&display, clipboard_type);
-    clipboard_has_text(&clipboard)
 }
 
 unsafe extern "C" fn ghostty_confirm_read_clipboard_cb(
@@ -1649,7 +1637,7 @@ pub fn create_terminal(
             }));
             config.platform_tag = GHOSTTY_PLATFORM_LINUX;
             config.platform = ghostty_platform_u {
-                linux: ghostty_platform_linux_s {
+                linux_platform: ghostty_platform_linux_s {
                     reserved: ptr::null_mut(),
                 },
             };

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 GHOSTTY_LIB_DIR="$ROOT_DIR/ghostty/zig-out/lib"
-GHOSTTY_SO="$GHOSTTY_LIB_DIR/libghostty.so"
+GHOSTTY_SO="$GHOSTTY_LIB_DIR/libghostty-internal.so"
 
 if [ ! -f "$GHOSTTY_SO" ]; then
-  echo "ERROR: libghostty.so not found at $GHOSTTY_SO" >&2
-  echo "Build it with: (cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline)" >&2
+  echo "ERROR: libghostty-internal.so not found at $GHOSTTY_SO" >&2
+  echo "Build it with Zig 0.16: (cd ghostty && zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline)" >&2
   exit 1
 fi
 

--- a/scripts/limux.spec
+++ b/scripts/limux.spec
@@ -58,7 +58,7 @@ appstreamcli refresh-cache --force 2>/dev/null || true
 %files
 %{_bindir}/limux
 %{_libexecdir}/limux/limux-host
-/usr/lib/limux/libghostty.so
+/usr/lib/limux/libghostty-internal.so
 %{_datadir}/limux/
 %{_datadir}/applications/dev.limux.linux.desktop
 %{_datadir}/metainfo/dev.limux.linux.metainfo.xml

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -15,7 +15,8 @@ RPM_ARCH="x86_64"
 PKG_BASE="limux-${VERSION}-linux-${ARCH}"
 STAGE="/tmp/limux-staging"
 GHOSTTY_INSTALL_ROOT="/tmp/limux-ghostty-install"
-GHOSTTY_SO="${ROOT_DIR}/ghostty/zig-out/lib/libghostty.so"
+GHOSTTY_LIBRARY_NAME="libghostty-internal.so"
+GHOSTTY_SO="${ROOT_DIR}/ghostty/zig-out/lib/${GHOSTTY_LIBRARY_NAME}"
 MAX_GLIBC_VERSION="${LIMUX_MAX_GLIBC:-2.39}"
 GHOSTTY_SHARE_DIR=""
 GHOSTTY_TERMINFO_DIR=""
@@ -213,6 +214,7 @@ build_ghostty_resources() {
         DESTDIR="$GHOSTTY_INSTALL_ROOT" \
             zig build \
             --prefix /usr \
+            -Dapp-runtime=none \
             "${GHOSTTY_ZIG_ARGS[@]}" \
             -Demit-docs=false
     )
@@ -250,7 +252,7 @@ echo "Building libghostty (ReleaseFast, cpu=baseline)..."
 build_ghostty_resources
 
 if [ ! -f "$GHOSTTY_SO" ]; then
-    echo "ERROR: libghostty.so not found at ${GHOSTTY_SO} after build"
+    echo "ERROR: ${GHOSTTY_LIBRARY_NAME} not found at ${GHOSTTY_SO} after build"
     exit 1
 fi
 
@@ -301,7 +303,7 @@ if [ ! -f "$HOST_BINARY" ]; then
     exit 1
 fi
 
-assert_glibc_compatibility "$GHOSTTY_SO" "libghostty.so"
+assert_glibc_compatibility "$GHOSTTY_SO" "$GHOSTTY_LIBRARY_NAME"
 assert_glibc_compatibility "$CLI_BINARY" "limux CLI"
 assert_glibc_compatibility "$HOST_BINARY" "limux host"
 assert_cli_entrypoint "$CLI_BINARY" "target/release/limux-cli"
@@ -342,9 +344,9 @@ populate_tree() {
     assert_no_legacy_host_entrypoint "$libexecdir/limux" "packaged $prefix libexec tree"
 
     # Shared library
-    cp "$GHOSTTY_SO" "$libdir/libghostty.so"
+    cp "$GHOSTTY_SO" "$libdir/$GHOSTTY_LIBRARY_NAME"
     if [ "$strip_files" = "true" ]; then
-        strip --strip-debug "$libdir/libghostty.so"
+        strip --strip-debug "$libdir/$GHOSTTY_LIBRARY_NAME"
     fi
 
     # Ghostty resources required for named themes and shell integration
@@ -439,8 +441,8 @@ strip "$TARBALL_STAGE/limux"
 strip "$TARBALL_STAGE/libexec/limux/limux-host"
 chmod 755 "$TARBALL_STAGE/limux" "$TARBALL_STAGE/libexec/limux/limux-host"
 assert_cli_entrypoint "$TARBALL_STAGE/limux" "tarball limux"
-cp "$GHOSTTY_SO" "$TARBALL_STAGE/lib/libghostty.so"
-strip --strip-debug "$TARBALL_STAGE/lib/libghostty.so"
+cp "$GHOSTTY_SO" "$TARBALL_STAGE/lib/$GHOSTTY_LIBRARY_NAME"
+strip --strip-debug "$TARBALL_STAGE/lib/$GHOSTTY_LIBRARY_NAME"
 cp -r "$GHOSTTY_SHARE_DIR"/. "$TARBALL_STAGE/share/limux/ghostty"
 copy_ghostty_terminfo_entries "$GHOSTTY_TERMINFO_DIR" "$TARBALL_STAGE/share/limux/terminfo"
 cp "$DESKTOP_FILE" "$TARBALL_STAGE/share/applications/dev.limux.linux.desktop"
@@ -468,6 +470,8 @@ cat > "$TARBALL_STAGE/install.sh" << 'INSTALL_EOF'
 set -euo pipefail
 
 PREFIX="/usr/local"
+GHOSTTY_LIBRARY_NAME="libghostty-internal.so"
+LEGACY_GHOSTTY_LIBRARY_NAME="libghostty.so"
 UNINSTALL=false
 
 for arg in "$@"; do
@@ -614,7 +618,8 @@ echo "Installing Limux to ${PREFIX}..."
 install -Dm755 "$SCRIPT_DIR/limux" "$PREFIX/bin/limux"
 clean_legacy_limux_entrypoints
 install -Dm755 "$SCRIPT_DIR/libexec/limux/limux-host" "$PREFIX/libexec/limux/limux-host"
-install -Dm644 "$SCRIPT_DIR/lib/libghostty.so" "$PREFIX/lib/limux/libghostty.so"
+rm -f "$PREFIX/lib/limux/$LEGACY_GHOSTTY_LIBRARY_NAME"
+install -Dm644 "$SCRIPT_DIR/lib/$GHOSTTY_LIBRARY_NAME" "$PREFIX/lib/limux/$GHOSTTY_LIBRARY_NAME"
 if [ -d "$SCRIPT_DIR/share/limux" ]; then
     cp -r "$SCRIPT_DIR/share/limux" "$PREFIX/share/"
 fi
@@ -636,7 +641,7 @@ echo ""
 echo "Limux installed successfully!"
 echo "  CLI:     $PREFIX/bin/limux"
 echo "  Host:    $PREFIX/libexec/limux/limux-host"
-echo "  Library: $PREFIX/lib/limux/libghostty.so"
+echo "  Library: $PREFIX/lib/limux/$GHOSTTY_LIBRARY_NAME"
 echo "  App:     limux"
 echo ""
 echo "System dependencies (install if missing):"
@@ -752,8 +757,8 @@ chmod 755 "$APPDIR/usr/bin/limux" "$APPDIR/usr/libexec/limux/limux-host"
 assert_cli_entrypoint "$APPDIR/usr/bin/limux" "AppImage usr/bin/limux"
 
 # Shared library
-cp "$GHOSTTY_SO" "$APPDIR/usr/lib/libghostty.so"
-strip --strip-debug "$APPDIR/usr/lib/libghostty.so"
+cp "$GHOSTTY_SO" "$APPDIR/usr/lib/$GHOSTTY_LIBRARY_NAME"
+strip --strip-debug "$APPDIR/usr/lib/$GHOSTTY_LIBRARY_NAME"
 
 # WebKitGTK runtime, helper processes, and non-glibc library dependencies.
 copy_appimage_webkit_runtime "$APPDIR"

--- a/scripts/tests/test-aur-source-package.sh
+++ b/scripts/tests/test-aur-source-package.sh
@@ -33,7 +33,7 @@ expected=$(printf '%s\n' \
     "$SOURCE_COMMIT" \
     "$GHOSTTY_COMMIT" \
     "limux-1.2.3::git+https://github.com/example/limux.git#commit=$SOURCE_COMMIT" \
-    "ghostty-1.2.3::git+https://github.com/am-will/ghostty.git#commit=$GHOSTTY_COMMIT")
+    "ghostty-1.2.3::git+https://github.com/bvolpato/ghostty.git#commit=$GHOSTTY_COMMIT")
 [ "$metadata" = "$expected" ]
 
 if "$ROOT_DIR/scripts/render-aur-source-pkgbuild.sh" \


### PR DESCRIPTION
## Summary

- upgrade Ghostty from `81ab8ffa9` to `1a89efa4d`, based on current `manaflow-ai/ghostty`
- preserve GTK `GLArea` main-thread rendering and display lifecycle support
- sync Rust FFI layouts, callbacks, action tags, and clipboard contract with current header
- migrate builds and packages to Zig 0.16.0 and `libghostty-internal.so`
- package resources and terminfo from the exact pinned Ghostty build

Limux no longer depends on `am-will/ghostty`. The temporary pin lives in `bvolpato/ghostty`, forked directly from `manaflow-ai/ghostty`; compatibility changes are submitted upstream in [manaflow-ai/ghostty#196](https://github.com/manaflow-ai/ghostty/pull/196). Once merged, this pin can move back to the maintained repository without code changes. GTK integration work retains FreeMeWat’s credit in the Ghostty commit.

## Why a compatibility branch remains

Current generic OpenGL callbacks may run on Ghostty’s renderer thread. GTK `GLArea` owns a main-thread offscreen framebuffer, so using generic callbacks directly risks wrong-context rendering. Compatibility patch keeps only required main-thread and realize/unrealize hooks, rebased onto maintained Ghostty head.

## Validation

- `zig build -Dapp-runtime=none -Doptimize=ReleaseFast -Dcpu=baseline`
- focused Ghostty OpenGL presentation and FreeType face tests
- C/Rust ABI layout probe
- `./scripts/check.sh`
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`
- `ldd -r target/debug/limux`
- AUR source template validation

Full unfiltered Ghostty test process was killed with exit 137 under workstation memory pressure. Changed-path Ghostty tests, complete Limux suite, and live GTK smoke all pass.