### PR TITLE
fix(host): restore terminal links and window controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Run the canonical local quality gate before committing:
 
 Repository maintainability rules live in [`docs/maintainability.md`](docs/maintainability.md).
 Release procedure lives in [`docs/releasing.md`](docs/releasing.md).
+Implementation handoff notes live in [`docs/session-logs/`](docs/session-logs/).
 
 ## Agent integrations
 

--- a/docs/session-logs/2026-08-10-terminal-links-and-window-controls.md
+++ b/docs/session-logs/2026-08-10-terminal-links-and-window-controls.md
@@ -1,0 +1,41 @@
+# 2026-08-10: Clickable terminal links and window controls
+
+## Delivered
+
+- Terminal links can be opened with `Ctrl` + primary click, even when a
+  Ghostty `open_url` key binding is absent from the user's configuration.
+- The terminal context menu now offers **Open Link** alongside **Copy URL**.
+- Link targets are handed to the system URL handler without a Limux scheme
+  allow-list. This supports registered application and local-file links as
+  well as web links, matching Ghostty's link-opening behavior. As with
+  opening a link manually, users should only activate links they trust.
+- Limux always draws its libadwaita header bar and ensures that minimize,
+  maximize, and close controls are all present. The pane toolbar's close
+  button remains a pane-only action.
+
+## Root cause and resolution
+
+On Wayland, Limux previously hid its header when the compositor advertised
+`zxdg_decoration_manager_v1`. Libadwaita had already selected client-side
+decorations for the application window, however, so the compositor did not
+provide replacement window controls. This was most visible on KDE Plasma/KWin
+and left the window with no minimize, maximize, or application-close buttons.
+
+The host now always retains the libadwaita header and completes the GTK
+decoration layout while preserving a user's preferred side and ordering when
+they already specify all three standard controls.
+
+## Validation
+
+The Linux host passed:
+
+```bash
+cargo fmt --check
+LD_LIBRARY_PATH=ghostty/zig-out/lib cargo test -p limux-host-linux
+cargo clippy -p limux-host-linux -- -D warnings
+cargo build --release -p limux-host-linux --bin limux
+```
+
+The host test suite completed with 227 passing tests. The full workspace suite
+still has the pre-existing `limux-cli` transcript-fallback test failure noted
+in `CLAUDE.md`; it is unrelated to this change.

--- a/docs/session-logs/README.md
+++ b/docs/session-logs/README.md
@@ -1,0 +1,7 @@
+# Session Logs
+
+Short implementation handoff notes for completed Limux work. They capture the
+user-visible behavior, the relevant technical decision, and the checks that
+were run so a future maintainer can quickly pick up the thread.
+
+- [2026-08-10: clickable terminal links and complete window controls](2026-08-10-terminal-links-and-window-controls.md)

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1312,42 +1312,18 @@ fn display_terminal_title(title: &str) -> String {
     format!("{}…", &title[..truncate_at])
 }
 
-fn is_safe_browser_url(url: &str) -> bool {
-    // Minimal allow-list of URI schemes that may be handed to the system
-    // browser on Ctrl+click. The threat model is hostile terminal output:
-    // anything that ends up in a pane's scrollback can craft an OSC 8
-    // hyperlink, and clicking it must not lead to code execution.
-    //
-    // Why only http/https/mailto?
-    // - `javascript:`, `vbscript:`, `data:` are classic XSS sinks (Gitea
-    //   blocks these unconditionally — github.com/go-gitea/gitea#25960).
-    // - `file://` directly opens local files via the registered handler;
-    //   a hostile `cat` of a crafted .desktop file would be RCE.
-    // - `ftp://`, `ftps://`, `smb://`, `nfs://`, `dav://`, `sftp://` all
-    //   auto-mount via gvfs and can execute binaries on the mounted share
-    //   (positive.security/blog/url-open-rce).
-    // - Custom schemes (`vscode://`, `slack://`, `obsidian://`, ...) have
-    //   historically had RCE CVEs in their handlers; we don't second-guess
-    //   that surface area here.
-    //
-    // RFC 3986 §3.1: scheme matching is case-insensitive.
-    let Some(colon) = url.find(':') else {
-        return false;
-    };
-    let scheme = url[..colon].to_ascii_lowercase();
-    let rest = &url[colon..];
-    match scheme.as_str() {
-        "https" | "http" => rest.starts_with("://"),
-        "mailto" => rest.starts_with(':'),
-        _ => false,
-    }
-}
-
 fn open_url_in_external_browser(url: &str) {
-    if !is_safe_browser_url(url) {
-        eprintln!("limux: refusing to open URL with unrecognized scheme: {url}");
-        return;
-    }
+    // No scheme allow-list: every URL that reaches here is handed straight to
+    // the system handler, matching upstream Ghostty, which passes link clicks
+    // to `internal_os.open` unfiltered. This deliberately re-enables `file://`
+    // and app-specific schemes (`obsidian://`, `vscode://`, ...) so links in
+    // scrollback open in their registered handler.
+    //
+    // Note the trade-off: terminal scrollback is attacker-influenced — an OSC 8
+    // hyperlink from a remote shell, or a `cat` of a crafted file — and the
+    // system handler for `file://` will happily run a `.desktop` entry or
+    // script. Ctrl+clicking an untrusted link is now equivalent to opening it
+    // by hand.
 
     // Use the GDK display's launch context so GIO emits an xdg-activation
     // token. Without it, the target app (e.g. Firefox) receives the URL but
@@ -3964,12 +3940,12 @@ fn create_browser_widget(
 mod tests {
     use super::{
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
-        effective_drop_target_dimensions, is_localhost_input, is_safe_browser_url,
-        next_active_after_tab_removal, normalize_browser_entry_input,
-        normalize_reorder_insert_index, pane_action_tooltip, surface_hint_matches, ContentDropZone,
-        TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
-        BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
-        TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
+        effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
+        normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
+        surface_hint_matches, ContentDropZone, TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS,
+        BROWSER_SEARCH_ENTRY_CSS_CLASSES, BROWSER_URL_ENTRY_CSS_CLASS,
+        BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS, TAB_RENAME_ENTRY_CSS_CLASS,
+        TAB_RENAME_ENTRY_CSS_CLASSES,
     };
     #[cfg(feature = "webkit")]
     use super::{
@@ -4273,76 +4249,6 @@ mod tests {
 
         for (input, expected) in cases {
             assert_eq!(normalize_browser_entry_input(input), expected, "{input}");
-        }
-    }
-
-    #[test]
-    fn is_safe_browser_url_accepts_navigable_schemes() {
-        // Web + email only — see the rationale on `is_safe_browser_url`.
-        for url in [
-            "https://example.com",
-            "https://example.com/path?x=1&y=2",
-            "http://example.com",
-            "http://localhost:8080/foo",
-            "mailto:user@example.com",
-            "mailto:user@example.com?subject=hi",
-        ] {
-            assert!(is_safe_browser_url(url), "should accept {url}");
-        }
-    }
-
-    #[test]
-    fn is_safe_browser_url_is_scheme_case_insensitive() {
-        // RFC 3986 §3.1: scheme matching is case-insensitive. OSC 8 hyperlinks
-        // sometimes preserve the original case from upstream sources, so we
-        // must not reject syntactically valid uppercase/mixed-case schemes.
-        for url in [
-            "HTTPS://example.com",
-            "Https://example.com",
-            "HTTP://example.com",
-            "MAILTO:user@example.com",
-        ] {
-            assert!(is_safe_browser_url(url), "should accept {url}");
-        }
-    }
-
-    #[test]
-    fn is_safe_browser_url_rejects_unsupported_or_dangerous_schemes() {
-        // Threat model: hostile terminal output can craft any OSC 8 hyperlink.
-        // The schemes below are either classic XSS sinks (`javascript:`,
-        // `data:`, `vbscript:`), gvfs auto-mount + exec vectors
-        // (`smb:`, `nfs:`, `dav:`, `davs:`, `sftp:`, `ftp:`, `ftps:`), local
-        // RCE via the file handler (`file:`), or app-specific URIs whose
-        // handlers have a history of RCE CVEs (`vscode:`, `slack:`, etc.).
-        // Leading whitespace and bare paths are also rejected as malformed.
-        for url in [
-            "javascript:alert(1)",
-            "JavaScript:alert(1)",
-            "data:text/html,<script>alert(1)</script>",
-            "vbscript:msgbox(1)",
-            "file:///etc/passwd",
-            "File:///home/manu/notes.md",
-            "ftp://ftp.example.com/pub/file",
-            "ftps://ftp.example.com/pub/file",
-            "smb://server/share",
-            "nfs://server/export",
-            "dav://server/path",
-            "davs://server/path",
-            "sftp://user@host/path",
-            "ssh://user@host",
-            "magnet:?xt=urn:btih:abc",
-            "chrome://settings",
-            "about:blank",
-            "vscode://file/path",
-            "slack://open?team=T",
-            "  https://example.com",
-            "/etc/passwd",
-            "example.com",
-            "",
-            "https:",
-            "http:/example.com",
-        ] {
-            assert!(!is_safe_browser_url(url), "should reject {url:?}");
         }
     }
 }

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -1816,6 +1816,14 @@ pub fn create_terminal(
         let surface_cell = surface_cell.clone();
         let open_url_external_for_press = open_url_external.clone();
         let open_url_external_for_release = open_url_external.clone();
+        // Resolve Ctrl+click links in the host instead of relying on Ghostty's
+        // configurable `open_url` binding. A user configuration can remove
+        // that binding, but it must not make links in an embedded Limux
+        // terminal inert.
+        let link_click_consumed = Rc::new(Cell::new(false));
+        let link_click_consumed_for_press = link_click_consumed.clone();
+        let link_click_consumed_for_release = link_click_consumed.clone();
+        let callbacks_for_link_click = callbacks.clone();
         let click = gtk::GestureClick::new();
         click.set_button(0); // all buttons
         let sc = surface_cell.clone();
@@ -1836,6 +1844,16 @@ pub fn create_terminal(
                     _ => GHOSTTY_MOUSE_UNKNOWN,
                 };
                 let mods = translate_mouse_mods(gesture.current_event_state());
+                link_click_consumed_for_press.set(false);
+                if is_link_activation_click(button, mods) {
+                    if let Some(url) = url_at_position(Some(surface), x, y, mods) {
+                        let callbacks = callbacks_for_link_click.borrow();
+                        (callbacks.on_open_url)(&url, true);
+                        link_click_consumed_for_press.set(true);
+                        gesture.set_state(gtk::EventSequenceState::Claimed);
+                        return;
+                    }
+                }
                 unsafe {
                     ghostty_surface_mouse_pos(surface, x, y, mods);
                     open_url_external_for_press.set(mods & GHOSTTY_MODS_CTRL != 0);
@@ -1848,6 +1866,9 @@ pub fn create_terminal(
         click.connect_released(move |gesture, _n, x, y| {
             let btn = gesture.current_button();
             if btn == 3 {
+                return;
+            }
+            if link_click_consumed_for_release.replace(false) {
                 return;
             }
             if let Some(surface) = *sc2.borrow() {
@@ -2084,6 +2105,10 @@ fn surface_action(surface: Option<ghostty_surface_t>, action: &str) {
     }
 }
 
+fn is_link_activation_click(button: c_int, mods: c_int) -> bool {
+    button == GHOSTTY_MOUSE_LEFT && mods & GHOSTTY_MODS_CTRL != 0
+}
+
 fn url_at_position(
     surface: Option<ghostty_surface_t>,
     x: f64,
@@ -2181,6 +2206,7 @@ fn show_terminal_context_menu(
 
     let mut items: Vec<(&str, bool)> = vec![("Copy", has_selection)];
     if url.is_some() {
+        items.push(("Open Link", true));
         items.push(("Copy URL", true));
     }
     items.extend([
@@ -2272,6 +2298,12 @@ fn show_terminal_context_menu(
                 pop.popdown();
                 match label.as_str() {
                     "Copy" => surface_action(surface, "copy_to_clipboard"),
+                    "Open Link" => {
+                        if let Some(url) = url.as_deref() {
+                            let callbacks = cb.borrow();
+                            (callbacks.on_open_url)(url, true);
+                        }
+                    }
                     "Copy URL" => {
                         if let Some(url) = url.as_deref() {
                             copy_text_to_clipboards(url);
@@ -2796,6 +2828,26 @@ mod tests {
         };
 
         assert_eq!(ghostty_open_url_to_string(action), None);
+    }
+
+    #[test]
+    fn ctrl_primary_click_activates_a_link() {
+        assert!(is_link_activation_click(
+            GHOSTTY_MOUSE_LEFT,
+            GHOSTTY_MODS_CTRL
+        ));
+        assert!(is_link_activation_click(
+            GHOSTTY_MOUSE_LEFT,
+            GHOSTTY_MODS_CTRL | GHOSTTY_MODS_SHIFT
+        ));
+        assert!(!is_link_activation_click(
+            GHOSTTY_MOUSE_LEFT,
+            GHOSTTY_MODS_NONE
+        ));
+        assert!(!is_link_activation_click(
+            GHOSTTY_MOUSE_MIDDLE,
+            GHOSTTY_MODS_CTRL
+        ));
     }
 
     #[test]

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -1432,21 +1432,31 @@ pub fn build_window(app: &adw::Application) {
         .build();
     apply_window_background_class(&window, background_opacity);
 
-    // On Wayland compositors with xdg-decoration support, the compositor
-    // already provides the window chrome, so keep Limux from rendering a
-    // duplicate header bar. X11 continues to use the in-app header.
-    let provides_decorations = display
-        .clone()
-        .downcast::<gdk4_wayland::WaylandDisplay>()
-        .ok()
-        .map(|display| display.query_registry("zxdg_decoration_manager_v1"))
-        .unwrap_or(false);
-
-    let header = if provides_decorations {
-        None
-    } else {
+    // Always render the header bar. `adw::ApplicationWindow` installs its own
+    // empty titlebar, which pins GTK4 to client-side decorations, so it never
+    // negotiates server-side decorations even on compositors that offer them.
+    //
+    // A previous version skipped the header whenever the Wayland display
+    // advertised `zxdg_decoration_manager_v1`. Advertising that global only
+    // means the compositor *can* draw server-side decorations, not that it
+    // drew them for this window — and because libadwaita already opted into
+    // CSD, it never did. On KWin/Plasma (and other compositors that advertise
+    // the manager: wlroots, Hyprland) that left the window with no minimize,
+    // maximize or close controls at all. Mutter does not advertise the global,
+    // which is why the bug only showed up outside GNOME.
+    let header = {
         let bar = adw::HeaderBar::new();
         bar.set_title_widget(Some(&gtk::Label::builder().label(&title).build()));
+        // Guarantee the three standard controls are present. GTK's built-in
+        // default for `gtk-decoration-layout` is "menu:close", so on a desktop
+        // that ships no GTK integration the only button would be a lone close
+        // "X" — easily mistaken for the pane toolbar's "Close pane" X.
+        bar.set_decoration_layout(Some(&ensure_window_controls(
+            gtk::Settings::for_display(&display)
+                .gtk_decoration_layout()
+                .as_deref()
+                .unwrap_or_default(),
+        )));
         Some(bar)
     };
 
@@ -1865,6 +1875,57 @@ fn sidebar_width(sidebar_shell: &gtk::Box) -> i32 {
 fn sidebar_min_width(sidebar: &gtk::Box) -> i32 {
     let (minimum, _, _, _) = sidebar.measure(gtk::Orientation::Horizontal, -1);
     minimum.max(1)
+}
+
+/// The three controls a normal desktop window is expected to offer, in the
+/// order GTK draws them.
+const WINDOW_CONTROL_BUTTONS: [&str; 3] = ["minimize", "maximize", "close"];
+
+/// Complete a `gtk-decoration-layout` value so minimize, maximize and close
+/// are all present.
+///
+/// The layout format is `start:end`, where each side is a comma-separated list
+/// of `icon`, `menu`, `minimize`, `maximize`, `close` and `spacer` (GTK splits
+/// on the first colon only). A desktop that already asks for all three
+/// controls is returned untouched, so button order and left/right placement
+/// stay exactly as the user configured them. Otherwise the controls are
+/// re-emitted as a complete set on whichever side already hosted one of them,
+/// which keeps left-handed layouts left-handed; non-control tokens keep their
+/// side.
+fn ensure_window_controls(layout: &str) -> String {
+    let (start, end) = layout.split_once(':').unwrap_or((layout, ""));
+    let tokens = |side: &str| -> Vec<String> {
+        side.split(',')
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .map(str::to_owned)
+            .collect()
+    };
+    let (mut start, mut end) = (tokens(start), tokens(end));
+
+    let holds = |side: &[String], name: &str| side.iter().any(|token| token == name);
+    if WINDOW_CONTROL_BUTTONS
+        .iter()
+        .all(|name| holds(&start, name) || holds(&end, name))
+    {
+        return layout.to_owned();
+    }
+
+    let controls_on_start = WINDOW_CONTROL_BUTTONS
+        .iter()
+        .any(|name| holds(&start, name));
+    let is_control = |token: &String| WINDOW_CONTROL_BUTTONS.contains(&token.as_str());
+    start.retain(|token| !is_control(token));
+    end.retain(|token| !is_control(token));
+
+    let side = if controls_on_start {
+        &mut start
+    } else {
+        &mut end
+    };
+    side.extend(WINDOW_CONTROL_BUTTONS.iter().map(|name| (*name).to_owned()));
+
+    format!("{}:{}", start.join(","), end.join(","))
 }
 
 fn sanitize_background_opacity(background_opacity: f64) -> f64 {
@@ -6210,8 +6271,8 @@ mod tests {
         clamp_workspace_insert_index_for_pinning, desktop_notification_action_from_signal,
         desktop_notification_actions, desktop_notification_activation_token_from_signal,
         desktop_notification_closed_id_from_signal, desktop_notification_id_from_response,
-        directional_neighbor_score, favorites_prefix_len, find_leaf_pane, font_size_after_delta,
-        ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
+        directional_neighbor_score, ensure_window_controls, favorites_prefix_len, find_leaf_pane,
+        font_size_after_delta, ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
         keep_workspace_open_after_empty_pane, next_active_workspace_index,
         pane_create_split_placement, queue_session_save_request, resolve_pane_create_source_id,
         resolved_system_prefers_dark, sanitize_background_opacity,
@@ -6282,6 +6343,63 @@ mod tests {
             crate::pane::PaneEmptyReason::MovedLastTabOut,
             true,
         ));
+    }
+
+    #[test]
+    fn gtk_default_decoration_layout_gains_minimize_and_maximize() {
+        // GTK's built-in default. Without completion the window would show a
+        // lone close "X", which reads as the pane toolbar's "Close pane".
+        assert_eq!(
+            ensure_window_controls("menu:close"),
+            "menu:minimize,maximize,close"
+        );
+        assert_eq!(ensure_window_controls(""), ":minimize,maximize,close");
+        assert_eq!(
+            ensure_window_controls("appmenu:close"),
+            "appmenu:minimize,maximize,close"
+        );
+    }
+
+    #[test]
+    fn complete_decoration_layouts_are_left_untouched() {
+        // KDE (via kde-gtk-config) and a fully specified GNOME layout already
+        // ask for all three controls; their order and placement must survive.
+        for layout in [
+            "icon:minimize,maximize,close",
+            "appmenu:minimize,maximize,close",
+            "close,maximize,minimize:",
+            "icon,menu:maximize,minimize,close",
+        ] {
+            assert_eq!(ensure_window_controls(layout), layout);
+        }
+    }
+
+    #[test]
+    fn completed_controls_stay_on_the_side_that_already_held_them() {
+        // Left-handed layouts keep their controls on the left.
+        assert_eq!(ensure_window_controls("close:"), "minimize,maximize,close:");
+        assert_eq!(
+            ensure_window_controls("close:icon"),
+            "minimize,maximize,close:icon"
+        );
+        // No controls anywhere: default to the end side.
+        assert_eq!(
+            ensure_window_controls("icon:"),
+            "icon:minimize,maximize,close"
+        );
+    }
+
+    #[test]
+    fn decoration_layout_completion_dedupes_and_tolerates_whitespace() {
+        // A partial layout must not end up with a duplicated control.
+        assert_eq!(
+            ensure_window_controls("menu:maximize,close"),
+            "menu:minimize,maximize,close"
+        );
+        assert_eq!(
+            ensure_window_controls("  menu : close  "),
+            "menu:minimize,maximize,close"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Restore reliable terminal link activation with Ctrl+primary-click and a context-menu **Open Link** action.
- Let registered system handlers receive link schemes, including application and local-file links, to match Ghostty's behavior.
- Always render the Limux libadwaita header and guarantee minimize, maximize, and application-close controls.
- Add a linked implementation handoff at `docs/session-logs/2026-08-10-terminal-links-and-window-controls.md`.

## Why

Terminal links could become inert when a user Ghostty configuration did not define an `open_url` binding. Separately, on Wayland compositors that advertise `zxdg_decoration_manager_v1` (notably KWin/Plasma), Limux suppressed its header even though libadwaita had already selected client-side decorations, leaving no window controls.

## Validation

- `cargo fmt --check`
- `LD_LIBRARY_PATH=ghostty/zig-out/lib cargo test -p limux-host-linux` (227 passed)
- `cargo clippy -p limux-host-linux -- -D warnings`
- `cargo build --release -p limux-host-linux --bin limux`
