### PR TITLE
fix(deps): bump anyhow to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"


### PR DESCRIPTION
## Summary

- update locked `anyhow` version from 1.0.102 to 1.0.103
- resolve unsoundness advisory RUSTSEC-2026-0190

## Testing

- `cargo audit` (0 vulnerabilities, 0 warnings)
- `cargo fmt --all -- --check`
- `./scripts/check.sh`

## Did this cause any problems?

No runtime behavior change expected. Revert this commit to restore previous lockfile entry.
