### PR TITLE
fix(host): guard popovers during terminal teardown

### DIFF
--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -188,9 +188,9 @@ pub fn retire_pane(pane_widget: &gtk::Widget) {
             std::mem::take(&mut tab_state.tabs)
         };
         for entry in entries {
+            entry.prepare_for_removal();
             internals.tab_strip.remove(&entry.tab_button);
             internals.content_stack.remove(&entry.content);
-            entry.prepare_for_removal();
         }
         unregister_pane(internals.pane_id);
     }
@@ -3265,9 +3265,9 @@ fn remove_tab(
         )
     };
 
+    entry.prepare_for_removal();
     tab_strip.remove(&entry.tab_button);
     content_stack.remove(&entry.content);
-    entry.prepare_for_removal();
 
     let Some(new_id) = new_id else {
         if removed_was_unread {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -984,7 +984,7 @@ unsafe extern "C" fn ghostty_action_cb(
                 SURFACE_MAP.with(|map| {
                     if let Some(entry) = map.borrow().get(&surface_key) {
                         match url {
-                            Some(url) => {
+                            Some(url) if widget_has_native_surface(&entry.gl_area) => {
                                 entry.link_label.set_text(&url);
                                 let (x, y) = entry.cursor_pos.get();
                                 // GTK default: PositionType::Top centers the
@@ -1002,7 +1002,7 @@ unsafe extern "C" fn ghostty_action_cb(
                                 ));
                                 entry.link_popover.popup();
                             }
-                            None => entry.link_popover.popdown(),
+                            Some(_) | None => entry.link_popover.popdown(),
                         }
                     }
                 });
@@ -1419,6 +1419,7 @@ fn free_terminal_surface(
 
     clipboard_context_cell.set(ptr::null_mut());
     if let Some(entry) = entry.as_ref() {
+        entry.link_popover.popdown();
         unregister_surface_identity(entry.identity);
     }
 
@@ -2139,7 +2140,9 @@ pub fn create_terminal(
     // in connect_realize when the widget is re-realized.
     {
         let surface_cell = surface_cell.clone();
+        let link_popover = link_popover.clone();
         let handler = gl_area.connect_unrealize(move |gl_area| {
+            link_popover.popdown();
             if let Some(surface) = *surface_cell.borrow() {
                 gl_area.make_current();
                 unsafe { ghostty_surface_display_unrealized(surface) };
@@ -2258,6 +2261,14 @@ fn build_floating_popover(
     popover
 }
 
+fn widget_has_native_surface(widget: &impl IsA<gtk::Widget>) -> bool {
+    widget.is_mapped()
+        && widget
+            .native()
+            .and_then(|native| native.surface())
+            .is_some()
+}
+
 /// 4 px box wrapper that matches the inner margin used by the right-click
 /// context menu items. Reused for the hover preview so both popovers have
 /// the same visual breathing room around their content.
@@ -2346,13 +2357,20 @@ fn show_terminal_context_menu(
             ids_popover.set_parent(&btn);
             let ids_popover_for_motion = ids_popover.clone();
             let motion = gtk::EventControllerMotion::new();
-            motion.connect_enter(move |_, _, _| {
-                ids_popover_for_motion.popup();
+            motion.connect_enter(move |motion, _, _| {
+                if motion
+                    .widget()
+                    .is_some_and(|widget| widget_has_native_surface(&widget))
+                {
+                    ids_popover_for_motion.popup();
+                }
             });
             btn.add_controller(motion);
             let ids_popover_for_click = ids_popover.clone();
-            btn.connect_clicked(move |_| {
-                ids_popover_for_click.popup();
+            btn.connect_clicked(move |btn| {
+                if widget_has_native_surface(btn) {
+                    ids_popover_for_click.popup();
+                }
             });
         }
         menu_box.append(&btn);


### PR DESCRIPTION
## Summary

- shut down terminal and browser state before unparenting tab widgets
- dismiss OSC 8 link previews when terminal unrealizes or shuts down
- present asynchronous and nested terminal popovers only while parent has live native surface

## Crash evidence

Kernel recorded `limux-host` segfault in `libgtk-4.so.1.1400.5`. Fault offset maps to `gtk_popover_realize`, where GTK creates popup from parent native surface and then dereferences null result.

Limux removed tab content before `prepare_for_removal()`. During synchronous widget unrealize, Ghostty surface and callback registry remained live. OSC 8 hover callback could therefore call `popup()` with detached `GLArea` parent. Nested IDs popover had same missing-surface risk while parent menu closed.

Not OOM: 53% memory remained and no kernel or earlyoom kill occurred.

## Validation

- `cargo check -p limux-host-linux`
- `./scripts/check.sh`
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`
  - 10 multi-pane teardown cycles returned to one child process
  - full terminal I/O, agent-team, split, notification, and restart flow passed

No new test added. Existing headless lifecycle smoke exercises teardown contract directly; pointer-driven GTK popover race is not deterministic in unit tests.