### PR TITLE
fix(control): harden lifecycle and request parsing

### DIFF
--- a/rust/limux-control/src/ffi.rs
+++ b/rust/limux-control/src/ffi.rs
@@ -7,15 +7,15 @@ use tokio::runtime::{Builder, Runtime};
 
 use crate::Dispatcher;
 
-static DISPATCHER_CELL: OnceLock<Mutex<Option<Dispatcher>>> = OnceLock::new();
-static RUNTIME_CELL: OnceLock<Mutex<Option<Runtime>>> = OnceLock::new();
-
-fn dispatcher_slot() -> &'static Mutex<Option<Dispatcher>> {
-    DISPATCHER_CELL.get_or_init(|| Mutex::new(None))
+struct ControlSession {
+    dispatcher: Dispatcher,
+    runtime: Runtime,
 }
 
-fn runtime_slot() -> &'static Mutex<Option<Runtime>> {
-    RUNTIME_CELL.get_or_init(|| Mutex::new(None))
+static SESSION_CELL: OnceLock<Mutex<Option<ControlSession>>> = OnceLock::new();
+
+fn session_slot() -> &'static Mutex<Option<ControlSession>> {
+    SESSION_CELL.get_or_init(|| Mutex::new(None))
 }
 
 fn parse_request(input: &str) -> Result<V2Request, ()> {
@@ -35,19 +35,15 @@ pub extern "C" fn limux_control_init() -> i32 {
         Err(_) => return 1,
     };
 
-    let dispatcher = Dispatcher::new();
-
-    let mut runtime_guard = match runtime_slot().lock() {
-        Ok(guard) => guard,
-        Err(_) => return 1,
-    };
-    let mut dispatcher_guard = match dispatcher_slot().lock() {
+    let mut session_guard = match session_slot().lock() {
         Ok(guard) => guard,
         Err(_) => return 1,
     };
 
-    *runtime_guard = Some(runtime);
-    *dispatcher_guard = Some(dispatcher);
+    *session_guard = Some(ControlSession {
+        dispatcher: Dispatcher::new(),
+        runtime,
+    });
     0
 }
 
@@ -72,30 +68,27 @@ pub unsafe extern "C" fn limux_control_dispatch(message_ptr: *const u8, message_
         Err(_) => return 2,
     };
 
-    let mut runtime_guard = match runtime_slot().lock() {
-        Ok(guard) => guard,
-        Err(_) => return 1,
-    };
-    let mut dispatcher_guard = match dispatcher_slot().lock() {
+    let mut session_guard = match session_slot().lock() {
         Ok(guard) => guard,
         Err(_) => return 1,
     };
 
-    if runtime_guard.is_none() || dispatcher_guard.is_none() {
-        *runtime_guard = Builder::new_multi_thread().enable_all().build().ok();
-        *dispatcher_guard = Some(Dispatcher::new());
+    if session_guard.is_none() {
+        let runtime = match Builder::new_multi_thread().enable_all().build() {
+            Ok(runtime) => runtime,
+            Err(_) => return 1,
+        };
+        *session_guard = Some(ControlSession {
+            dispatcher: Dispatcher::new(),
+            runtime,
+        });
     }
 
-    let runtime = match runtime_guard.as_mut() {
-        Some(runtime) => runtime,
-        None => return 1,
-    };
-    let dispatcher = match dispatcher_guard.as_ref() {
-        Some(dispatcher) => dispatcher,
-        None => return 1,
-    };
+    let session = session_guard.as_mut().expect("session initialized above");
 
-    let response = runtime.block_on(dispatcher.dispatch(request));
+    let response = session
+        .runtime
+        .block_on(session.dispatcher.dispatch(request));
     if response.error.is_some() {
         3
     } else {
@@ -105,11 +98,8 @@ pub unsafe extern "C" fn limux_control_dispatch(message_ptr: *const u8, message_
 
 #[unsafe(no_mangle)]
 pub extern "C" fn limux_control_shutdown() {
-    if let Ok(mut dispatcher_guard) = dispatcher_slot().lock() {
-        *dispatcher_guard = None;
-    }
-    if let Ok(mut runtime_guard) = runtime_slot().lock() {
-        *runtime_guard = None;
+    if let Ok(mut session_guard) = session_slot().lock() {
+        *session_guard = None;
     }
 }
 

--- a/rust/limux-control/src/ffi.rs
+++ b/rust/limux-control/src/ffi.rs
@@ -107,6 +107,8 @@ pub extern "C" fn limux_control_shutdown() {
 mod tests {
     use super::*;
 
+    use std::sync::{Arc, Barrier};
+
     #[test]
     fn ffi_init_dispatch_shutdown_roundtrip() {
         assert_eq!(limux_control_init(), 0);
@@ -127,6 +129,41 @@ mod tests {
         assert_eq!(
             unsafe { limux_control_dispatch(bad.as_ptr(), bad.len()) },
             2
+        );
+        limux_control_shutdown();
+    }
+
+    #[test]
+    fn ffi_lifecycle_stays_consistent_under_concurrent_calls() {
+        const THREADS: usize = 6;
+        const ITERATIONS: usize = 18;
+        const MESSAGE: &[u8] = br#"{"id":"ffi-concurrent","method":"system.ping","params":{}}"#;
+
+        limux_control_shutdown();
+        let start = Arc::new(Barrier::new(THREADS));
+
+        std::thread::scope(|scope| {
+            for worker in 0..THREADS {
+                let start = Arc::clone(&start);
+                scope.spawn(move || {
+                    start.wait();
+                    for iteration in 0..ITERATIONS {
+                        match (worker + iteration) % 3 {
+                            0 => assert_eq!(limux_control_init(), 0),
+                            1 => assert_eq!(
+                                unsafe { limux_control_dispatch(MESSAGE.as_ptr(), MESSAGE.len()) },
+                                0
+                            ),
+                            _ => limux_control_shutdown(),
+                        }
+                    }
+                });
+            }
+        });
+
+        assert_eq!(
+            unsafe { limux_control_dispatch(MESSAGE.as_ptr(), MESSAGE.len()) },
+            0
         );
         limux_control_shutdown();
     }

--- a/rust/limux-control/src/server.rs
+++ b/rust/limux-control/src/server.rs
@@ -79,16 +79,23 @@ pub async fn handle_connection(stream: UnixStream, dispatcher: Dispatcher) -> io
             return Ok(());
         }
 
-        let incoming = std::str::from_utf8(&line_buf)
-            .map(|line| line.trim_end_matches(['\n', '\r']))
-            .unwrap_or("");
-        if incoming.is_empty() {
-            continue;
-        }
-
-        let response = match parse_request(incoming) {
-            Ok(request) => dispatcher.dispatch(request).await,
-            Err(message) => V2Response::error(None, -32700, message, None),
+        let response = match std::str::from_utf8(&line_buf) {
+            Ok(incoming) => {
+                let incoming = incoming.trim_end_matches(['\n', '\r']);
+                if incoming.is_empty() {
+                    continue;
+                }
+                match parse_request(incoming) {
+                    Ok(request) => dispatcher.dispatch(request).await,
+                    Err(message) => V2Response::error(None, -32700, message, None),
+                }
+            }
+            Err(error) => V2Response::error(
+                None,
+                -32700,
+                format!("invalid request payload: {error}"),
+                None,
+            ),
         };
 
         let mut payload = serde_json::to_string(&response)

--- a/rust/limux-control/tests/socket_roundtrip.rs
+++ b/rust/limux-control/tests/socket_roundtrip.rs
@@ -103,6 +103,56 @@ async fn socket_roundtrip_accepts_v1_envelope() {
 }
 
 #[tokio::test]
+async fn invalid_utf8_returns_parse_error_and_keeps_connection_open() {
+    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+    let socket_path = temp_dir.path().join("limux-control.sock");
+
+    let listener = UnixListener::bind(&socket_path).expect("listener should bind");
+    let server_task = tokio::spawn(async move {
+        let dispatcher = Dispatcher::new();
+        let _ = server::serve(listener, dispatcher).await;
+    });
+
+    let stream = UnixStream::connect(&socket_path)
+        .await
+        .expect("connect stream");
+    let (reader_half, mut writer_half) = stream.into_split();
+    let mut reader = BufReader::new(reader_half);
+
+    writer_half
+        .write_all(b"\xff\n{\"id\":\"after-error\",\"method\":\"system.ping\",\"params\":{}}\n")
+        .await
+        .expect("requests should write");
+    writer_half.flush().await.expect("requests should flush");
+
+    let mut response_line = String::new();
+    reader
+        .read_line(&mut response_line)
+        .await
+        .expect("parse error should read");
+    let response: Value =
+        serde_json::from_str(response_line.trim()).expect("response should be valid json");
+    assert_eq!(response["ok"], false);
+    assert_eq!(response["error"]["code"], -32700);
+    assert!(response["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.starts_with("invalid request payload:")));
+
+    response_line.clear();
+    reader
+        .read_line(&mut response_line)
+        .await
+        .expect("ping response should read");
+    let response: Value =
+        serde_json::from_str(response_line.trim()).expect("response should be valid json");
+    assert_eq!(response["id"], "after-error");
+    assert_eq!(response["result"]["pong"], true);
+
+    server_task.abort();
+    let _ = server_task.await;
+}
+
+#[tokio::test]
 async fn run_server_refuses_to_overwrite_non_socket_path() {
     let temp_dir = tempfile::tempdir().expect("temp dir should be created");
     let socket_path = temp_dir.path().join("limux-control.sock");

--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -719,14 +719,22 @@ fn handle_client(
             return Ok(());
         }
 
-        let input = std::str::from_utf8(&line_buf)
-            .map(|line| line.trim_end_matches(['\n', '\r']))
-            .unwrap_or("");
-        if input.is_empty() {
-            continue;
-        }
-
-        let response = dispatch_request(input, dispatch);
+        let response = match std::str::from_utf8(&line_buf) {
+            Ok(input) => {
+                let input = input.trim_end_matches(['\n', '\r']);
+                if input.is_empty() {
+                    continue;
+                }
+                dispatch_request(input, dispatch)
+            }
+            Err(error) => error_response(
+                None,
+                BridgeError::new(
+                    PARSE_ERROR_CODE,
+                    format!("invalid request payload: {error}"),
+                ),
+            ),
+        };
         let mut payload = serde_json::to_string(&response)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         payload.push('\n');
@@ -827,6 +835,7 @@ pub fn start(dispatch: fn(ControlCommand)) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::BufRead;
 
     #[test]
     fn parses_v2_request_directly() {
@@ -842,6 +851,53 @@ mod tests {
             .expect("v1 request should parse");
         assert_eq!(request.method, "workspace.create");
         assert_eq!(request.params["cwd"], "/tmp");
+    }
+
+    #[test]
+    fn invalid_utf8_returns_parse_error_and_keeps_connection_open() {
+        let (client, server) = UnixStream::pair().expect("socket pair should open");
+        let server_task = std::thread::spawn(move || {
+            handle_client(server, &|command| {
+                panic!("ping should not dispatch a GTK command: {command:?}")
+            })
+        });
+
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("read timeout should set");
+        let reader_stream = client.try_clone().expect("client should clone");
+        let mut reader = io::BufReader::new(reader_stream);
+        let mut writer = client;
+
+        writer
+            .write_all(b"\xff\n{\"id\":\"after-error\",\"method\":\"system.ping\",\"params\":{}}\n")
+            .expect("requests should write");
+        writer.flush().expect("requests should flush");
+
+        let mut response_line = String::new();
+        reader
+            .read_line(&mut response_line)
+            .expect("parse error should read");
+        let response: Value =
+            serde_json::from_str(response_line.trim()).expect("response should be valid json");
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], PARSE_ERROR_CODE);
+
+        response_line.clear();
+        reader
+            .read_line(&mut response_line)
+            .expect("ping response should read");
+        let response: Value =
+            serde_json::from_str(response_line.trim()).expect("response should be valid json");
+        assert_eq!(response["id"], "after-error");
+        assert_eq!(response["result"]["pong"], true);
+
+        drop(reader);
+        drop(writer);
+        server_task
+            .join()
+            .expect("server thread should join")
+            .expect("server should stop at EOF");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep FFI runtime and dispatcher in one locked session, so concurrent init, dispatch, and shutdown cannot leave partial state
- return parse errors for invalid UTF-8 frames in both standalone server and production GTK bridge
- keep each connection usable after malformed input

## Repro

Previously, an invalid UTF-8 frame was converted to an empty request and silently discarded. A client waiting for one response per frame could hang or associate the next response with the wrong request. The FFI lifecycle also stored runtime and dispatcher behind separate locks, allowing concurrent lifecycle calls to leave only one initialized.

## Testing

- `./scripts/check.sh`
- 309 workspace tests passed
- focused invalid UTF-8 regression tests cover standalone and GTK socket paths

## Did this cause any problems?

Rollback/revert this commit and redeploy the service.