### PR TITLE
feat(host): add native workspace autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ https://github.com/user-attachments/assets/6f3047c2-e2b6-49f2-b536-570a1570d0f8
 
 - **GPU-rendered terminals** via embedded Ghostty (OpenGL)
 - **Workspaces** with folder-based naming, persistence across restarts, and sidebar management
+- **Workspace autostart** commands configured directly from the workspace menu
 - **Split panes** (horizontal/vertical) with keyboard navigation
 - **Tabbed terminals** within each pane
 - **Built-in browser** (WebKitGTK)
@@ -126,6 +127,14 @@ Run the canonical local quality gate before committing:
 
 Repository maintainability rules live in [`docs/maintainability.md`](docs/maintainability.md).
 Release procedure lives in [`docs/releasing.md`](docs/releasing.md).
+
+## Workspace autostart
+
+Right-click a workspace in the sidebar and select **Set Autostart…** to run a
+command whenever Limux creates a terminal in that workspace. The command is
+stored as part of the workspace session and runs inside the terminal, so
+interactive commands such as `ssh codex` work without modifying `.bashrc`.
+Open **Edit Autostart…** and save an empty command to disable it.
 
 ## Agent integrations
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,13 @@ stored as part of the workspace session and runs inside the terminal, so
 interactive commands such as `ssh user@server` work without modifying `.bashrc`.
 Open **Edit Autostart…** and save an empty command to disable it.
 
-Autostart applies to interactive shell terminals. If Ghostty is configured to
-launch a non-shell command such as `command = direct:/usr/bin/vim`, Limux skips
-autostart for that terminal so it does not inject keystrokes into the program.
+Limux writes the command to a private, self-deleting `/bin/sh` script and asks
+the interactive terminal shell to source it. Autostart is enabled only when
+Ghostty's finalized configuration launches a recognized shell with no arguments
+other than interactive/login flags. Non-shell commands such as
+`command = direct:/usr/bin/vim` and non-interactive wrappers such as
+`command = direct:/bin/bash -lc "exec /usr/bin/vim"` skip autostart, so Limux
+does not inject keystrokes into the launched program.
 
 ## Agent integrations
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ stored as part of the workspace session and runs inside the terminal, so
 interactive commands such as `ssh user@server` work without modifying `.bashrc`.
 Open **Edit Autostart…** and save an empty command to disable it.
 
+Autostart applies to interactive shell terminals. If Ghostty is configured to
+launch a non-shell command such as `command = direct:/usr/bin/vim`, Limux skips
+autostart for that terminal so it does not inject keystrokes into the program.
+
 ## Agent integrations
 
 Limux ships first-class hooks for coding agents (Codex, Claude Code, and

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Release procedure lives in [`docs/releasing.md`](docs/releasing.md).
 Right-click a workspace in the sidebar and select **Set Autostart…** to run a
 command whenever Limux creates a terminal in that workspace. The command is
 stored as part of the workspace session and runs inside the terminal, so
-interactive commands such as `ssh codex` work without modifying `.bashrc`.
+interactive commands such as `ssh user@server` work without modifying `.bashrc`.
 Open **Edit Autostart…** and save an empty command to disable it.
 
 ## Agent integrations

--- a/README.md
+++ b/README.md
@@ -137,9 +137,11 @@ interactive commands such as `ssh user@server` work without modifying `.bashrc`.
 Open **Edit Autostart…** and save an empty command to disable it.
 
 Limux writes the command to a private, self-deleting `/bin/sh` script and asks
-the interactive terminal shell to source it. Autostart is enabled only when
-Ghostty's finalized configuration launches a recognized shell with no arguments
-other than interactive/login flags. Non-shell commands such as
+the interactive terminal shell to source it, so changes such as `cd` and
+`export` remain in that shell. Autostart is enabled only when both `command` and
+`initial-command` in Ghostty's finalized configuration launch a recognized
+POSIX-compatible shell with no arguments other than interactive/login flags.
+Non-shell commands such as
 `command = direct:/usr/bin/vim` and non-interactive wrappers such as
 `command = direct:/bin/bash -lc "exec /usr/bin/vim"` skip autostart, so Limux
 does not inject keystrokes into the launched program.

--- a/rust/limux-ghostty-sys/src/lib.rs
+++ b/rust/limux-ghostty-sys/src/lib.rs
@@ -15,6 +15,14 @@ pub type ghostty_app_t = *mut c_void;
 pub type ghostty_config_t = *mut c_void;
 pub type ghostty_surface_t = *mut c_void;
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ghostty_string_s {
+    pub ptr: *const c_char,
+    pub len: usize,
+    pub sentinel: bool,
+}
+
 // -------------------------------------------------------------------
 // Enums
 // -------------------------------------------------------------------
@@ -520,6 +528,8 @@ extern "C" {
     pub fn ghostty_config_load_default_files(config: ghostty_config_t);
     pub fn ghostty_config_load_recursive_files(config: ghostty_config_t);
     pub fn ghostty_config_finalize(config: ghostty_config_t);
+    pub fn ghostty_config_serialize(config: ghostty_config_t) -> ghostty_string_s;
+    pub fn ghostty_string_free(value: ghostty_string_s);
 
     // App
     pub fn ghostty_app_new(

--- a/rust/limux-host-linux/src/ghostty_config.rs
+++ b/rust/limux-host-linux/src/ghostty_config.rs
@@ -8,7 +8,7 @@ fn ghostty_config_contents() -> Option<String> {
 }
 
 fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
-    for line in contents.lines() {
+    for line in contents.lines().rev() {
         let line = line.trim();
         if let Some(rest) = line.strip_prefix(key) {
             let rest = rest.trim();
@@ -18,6 +18,43 @@ fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
         }
     }
     None
+}
+
+pub fn terminal_command_accepts_shell_input() -> bool {
+    let configured_command =
+        ghostty_config_contents().and_then(|contents| read_ghostty_value(&contents, "command"));
+
+    match configured_command {
+        Some(command) => command_launches_interactive_shell(&command),
+        None => std::env::var_os("SHELL")
+            .map(|shell| command_launches_interactive_shell(&shell.to_string_lossy()))
+            // Ghostty falls back to the user's passwd shell when SHELL is
+            // absent, so the default command remains an interactive shell.
+            .unwrap_or(true),
+    }
+}
+
+fn command_launches_interactive_shell(command: &str) -> bool {
+    let command = command.trim();
+    let command = command
+        .strip_prefix("direct:")
+        .or_else(|| command.strip_prefix("shell:"))
+        .unwrap_or(command)
+        .trim_start();
+    let executable = command
+        .split_ascii_whitespace()
+        .next()
+        .unwrap_or_default()
+        .trim_matches(['\'', '"']);
+    let name = std::path::Path::new(executable)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+
+    matches!(
+        name,
+        "sh" | "bash" | "dash" | "zsh" | "fish" | "ksh" | "mksh" | "nu" | "elvish" | "xonsh"
+    )
 }
 
 /// Read background-opacity from the Ghostty config file.
@@ -39,4 +76,43 @@ pub fn read_font_size() -> f32 {
         .and_then(|v| v.parse::<f32>().ok())
         .map(|v| v.clamp(1.0, 255.0))
         .unwrap_or(DEFAULT_FONT_SIZE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{command_launches_interactive_shell, read_ghostty_value};
+
+    #[test]
+    fn last_ghostty_value_wins() {
+        let contents = "command = /usr/bin/vim\ncommand = direct:/usr/bin/zsh -l\n";
+        assert_eq!(
+            read_ghostty_value(contents, "command").as_deref(),
+            Some("direct:/usr/bin/zsh -l")
+        );
+    }
+
+    #[test]
+    fn terminal_command_classification_rejects_non_shell_commands() {
+        for command in [
+            "direct:/usr/bin/vim",
+            "/usr/bin/nvim file.txt",
+            "shell:tmux new-session",
+            "",
+        ] {
+            assert!(!command_launches_interactive_shell(command), "{command}");
+        }
+    }
+
+    #[test]
+    fn terminal_command_classification_accepts_supported_shells() {
+        for command in [
+            "/bin/bash",
+            "direct:/usr/bin/zsh -l",
+            "shell:fish --login",
+            "'sh'",
+            "nu",
+        ] {
+            assert!(command_launches_interactive_shell(command), "{command}");
+        }
+    }
 }

--- a/rust/limux-host-linux/src/ghostty_config.rs
+++ b/rust/limux-host-linux/src/ghostty_config.rs
@@ -20,7 +20,7 @@ pub(crate) fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
     None
 }
 
-pub(crate) fn terminal_command_accepts_shell_input(configured_command: Option<&str>) -> bool {
+pub(crate) fn terminal_command_accepts_posix_source(configured_command: Option<&str>) -> bool {
     match configured_command {
         Some(command) => command_launches_interactive_shell(command),
         None => std::env::var_os("SHELL")
@@ -29,6 +29,16 @@ pub(crate) fn terminal_command_accepts_shell_input(configured_command: Option<&s
             // absent, so the default command remains an interactive shell.
             .unwrap_or(true),
     }
+}
+
+pub(crate) fn terminal_commands_accept_posix_source(
+    command: Option<&str>,
+    initial_command: Option<&str>,
+) -> bool {
+    terminal_command_accepts_posix_source(command)
+        && initial_command
+            .map(|command| terminal_command_accepts_posix_source(Some(command)))
+            .unwrap_or(true)
 }
 
 fn command_launches_interactive_shell(command: &str) -> bool {
@@ -48,10 +58,7 @@ fn command_launches_interactive_shell(command: &str) -> bool {
         .and_then(|name| name.to_str())
         .unwrap_or_default();
 
-    let supported_shell = matches!(
-        name,
-        "sh" | "bash" | "dash" | "zsh" | "fish" | "ksh" | "mksh" | "nu" | "elvish" | "xonsh"
-    );
+    let supported_shell = matches!(name, "sh" | "bash" | "dash" | "zsh" | "ksh" | "mksh");
 
     supported_shell && arguments.all(is_interactive_shell_argument)
 }
@@ -88,7 +95,7 @@ pub fn read_font_size() -> f32 {
 mod tests {
     use super::{
         command_launches_interactive_shell, read_ghostty_value,
-        terminal_command_accepts_shell_input,
+        terminal_command_accepts_posix_source, terminal_commands_accept_posix_source,
     };
 
     #[test]
@@ -109,6 +116,10 @@ mod tests {
             "direct:/bin/bash -lc exec-vim",
             "shell:/usr/bin/zsh -c nvim",
             "/bin/fish script.fish",
+            "fish --login",
+            "nu",
+            "elvish",
+            "xonsh",
             "",
         ] {
             assert!(!command_launches_interactive_shell(command), "{command}");
@@ -121,9 +132,8 @@ mod tests {
             "/bin/bash",
             "direct:/usr/bin/zsh -l",
             "direct:/usr/bin/zsh -il",
-            "shell:fish --login",
             "'sh'",
-            "nu",
+            "ksh -il",
         ] {
             assert!(command_launches_interactive_shell(command), "{command}");
         }
@@ -131,6 +141,18 @@ mod tests {
 
     #[test]
     fn absent_command_uses_shell_fallback() {
-        assert!(terminal_command_accepts_shell_input(None));
+        assert!(terminal_command_accepts_posix_source(None));
+    }
+
+    #[test]
+    fn initial_command_must_also_be_an_interactive_posix_shell() {
+        assert!(terminal_commands_accept_posix_source(
+            Some("direct:/bin/bash"),
+            Some("direct:/bin/zsh -l")
+        ));
+        assert!(!terminal_commands_accept_posix_source(
+            Some("direct:/bin/bash"),
+            Some("direct:/usr/bin/vim")
+        ));
     }
 }

--- a/rust/limux-host-linux/src/ghostty_config.rs
+++ b/rust/limux-host-linux/src/ghostty_config.rs
@@ -7,7 +7,7 @@ fn ghostty_config_contents() -> Option<String> {
     std::fs::read_to_string(&path).ok()
 }
 
-fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
+pub(crate) fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
     for line in contents.lines().rev() {
         let line = line.trim();
         if let Some(rest) = line.strip_prefix(key) {
@@ -20,12 +20,9 @@ fn read_ghostty_value(contents: &str, key: &str) -> Option<String> {
     None
 }
 
-pub fn terminal_command_accepts_shell_input() -> bool {
-    let configured_command =
-        ghostty_config_contents().and_then(|contents| read_ghostty_value(&contents, "command"));
-
+pub(crate) fn terminal_command_accepts_shell_input(configured_command: Option<&str>) -> bool {
     match configured_command {
-        Some(command) => command_launches_interactive_shell(&command),
+        Some(command) => command_launches_interactive_shell(command),
         None => std::env::var_os("SHELL")
             .map(|shell| command_launches_interactive_shell(&shell.to_string_lossy()))
             // Ghostty falls back to the user's passwd shell when SHELL is
@@ -41,8 +38,8 @@ fn command_launches_interactive_shell(command: &str) -> bool {
         .or_else(|| command.strip_prefix("shell:"))
         .unwrap_or(command)
         .trim_start();
-    let executable = command
-        .split_ascii_whitespace()
+    let mut arguments = command.split_ascii_whitespace();
+    let executable = arguments
         .next()
         .unwrap_or_default()
         .trim_matches(['\'', '"']);
@@ -51,10 +48,19 @@ fn command_launches_interactive_shell(command: &str) -> bool {
         .and_then(|name| name.to_str())
         .unwrap_or_default();
 
-    matches!(
+    let supported_shell = matches!(
         name,
         "sh" | "bash" | "dash" | "zsh" | "fish" | "ksh" | "mksh" | "nu" | "elvish" | "xonsh"
-    )
+    );
+
+    supported_shell && arguments.all(is_interactive_shell_argument)
+}
+
+fn is_interactive_shell_argument(argument: &str) -> bool {
+    matches!(argument, "-i" | "--interactive" | "-l" | "--login")
+        || argument.strip_prefix('-').is_some_and(|flags| {
+            !flags.is_empty() && flags.chars().all(|flag| matches!(flag, 'i' | 'l'))
+        })
 }
 
 /// Read background-opacity from the Ghostty config file.
@@ -80,7 +86,10 @@ pub fn read_font_size() -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_launches_interactive_shell, read_ghostty_value};
+    use super::{
+        command_launches_interactive_shell, read_ghostty_value,
+        terminal_command_accepts_shell_input,
+    };
 
     #[test]
     fn last_ghostty_value_wins() {
@@ -97,6 +106,9 @@ mod tests {
             "direct:/usr/bin/vim",
             "/usr/bin/nvim file.txt",
             "shell:tmux new-session",
+            "direct:/bin/bash -lc exec-vim",
+            "shell:/usr/bin/zsh -c nvim",
+            "/bin/fish script.fish",
             "",
         ] {
             assert!(!command_launches_interactive_shell(command), "{command}");
@@ -108,11 +120,17 @@ mod tests {
         for command in [
             "/bin/bash",
             "direct:/usr/bin/zsh -l",
+            "direct:/usr/bin/zsh -il",
             "shell:fish --login",
             "'sh'",
             "nu",
         ] {
             assert!(command_launches_interactive_shell(command), "{command}");
         }
+    }
+
+    #[test]
+    fn absent_command_uses_shell_fallback() {
+        assert!(terminal_command_accepts_shell_input(None));
     }
 }

--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -1087,7 +1087,7 @@ mod tests {
                 favorite: false,
                 cwd: Some("/tmp".to_string()),
                 folder_path: Some("/tmp".to_string()),
-                autostart_command: Some("ssh codex".to_string()),
+                autostart_command: Some("ssh user@server".to_string()),
                 layout: LayoutNodeState::Pane(PaneState::fallback(Some("/tmp"))),
             }],
             ..AppSessionState::default()
@@ -1106,7 +1106,7 @@ mod tests {
         assert_eq!(decoded.workspaces[0].name, "workspace");
         assert_eq!(
             decoded.workspaces[0].autostart_command.as_deref(),
-            Some("ssh codex")
+            Some("ssh user@server")
         );
     }
 

--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -60,6 +60,8 @@ pub struct WorkspaceState {
     pub cwd: Option<String>,
     #[serde(default)]
     pub folder_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub autostart_command: Option<String>,
     pub layout: LayoutNodeState,
 }
 
@@ -439,6 +441,7 @@ impl AppSessionState {
                     favorite: workspace.favorite,
                     cwd: workspace.cwd,
                     folder_path: workspace.folder_path,
+                    autostart_command: None,
                     // Legacy files only knew "workspace exists"; rehydrate a fresh terminal at the
                     // last known directory instead of pretending process state can be restored.
                     layout: LayoutNodeState::Pane(PaneState {
@@ -982,6 +985,7 @@ mod tests {
                 favorite: true,
                 cwd: Some("/canonical".to_string()),
                 folder_path: Some("/canonical".to_string()),
+                autostart_command: None,
                 layout: LayoutNodeState::Pane(PaneState::fallback(Some("/canonical"))),
             }],
             ..AppSessionState::default()
@@ -1083,6 +1087,7 @@ mod tests {
                 favorite: false,
                 cwd: Some("/tmp".to_string()),
                 folder_path: Some("/tmp".to_string()),
+                autostart_command: Some("ssh codex".to_string()),
                 layout: LayoutNodeState::Pane(PaneState::fallback(Some("/tmp"))),
             }],
             ..AppSessionState::default()
@@ -1099,6 +1104,10 @@ mod tests {
             Some("22222222-2222-4222-8222-222222222222")
         );
         assert_eq!(decoded.workspaces[0].name, "workspace");
+        assert_eq!(
+            decoded.workspaces[0].autostart_command.as_deref(),
+            Some("ssh codex")
+        );
     }
 
     #[test]
@@ -1602,6 +1611,7 @@ mod tests {
                 favorite: false,
                 cwd: None,
                 folder_path: None,
+                autostart_command: None,
                 layout: LayoutNodeState::Pane(PaneState {
                     pane_id: None,
                     active_tab_id: Some("keybinds-1".to_string()),

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1610,6 +1610,10 @@ fn create_workspace_autostart_script(command: &str) -> Option<PathBuf> {
             "workspace-autostart-{}-{suffix}.sh",
             std::process::id()
         ));
+        let Some(script) = workspace_autostart_script(command, &path) else {
+            eprintln!("limux: workspace autostart path is not valid UTF-8");
+            return None;
+        };
         let file = OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -1617,7 +1621,6 @@ fn create_workspace_autostart_script(command: &str) -> Option<PathBuf> {
             .open(&path);
         match file {
             Ok(mut file) => {
-                let script = workspace_autostart_script(command);
                 if let Err(error) = file.write_all(script.as_bytes()) {
                     let _ = std::fs::remove_file(&path);
                     eprintln!("limux: failed to write workspace autostart script: {error}");
@@ -1637,16 +1640,20 @@ fn create_workspace_autostart_script(command: &str) -> Option<PathBuf> {
     None
 }
 
-fn workspace_autostart_script(command: &str) -> String {
-    format!("#!/bin/sh\nrm -f -- \"$0\"\n{command}\n")
+fn workspace_autostart_script(command: &str, script_path: &Path) -> Option<String> {
+    let script_path = script_path.to_str()?;
+    Some(format!(
+        "#!/bin/sh\nrm -f -- {}\n{command}\n",
+        shell_quote(script_path)
+    ))
 }
 
 fn workspace_autostart_initial_input(script_path: &Path) -> Option<String> {
     let script_path = script_path.to_str()?;
     // Only the private script path enters terminal input. The configured
     // autostart text stays out of shell history and scrollback, while Ghostty's
-    // configured shell/custom command remains untouched.
-    Some(format!("{}\n", shell_quote(script_path)))
+    // configured interactive shell remains untouched.
+    Some(format!(". {}\n", shell_quote(script_path)))
 }
 
 fn shell_quote(value: &str) -> String {
@@ -4151,11 +4158,17 @@ mod tests {
                 "/run/user/1000/limux/workspace-autostart-42-0.sh"
             ))
             .as_deref(),
-            Some("/run/user/1000/limux/workspace-autostart-42-0.sh\n")
+            Some(". /run/user/1000/limux/workspace-autostart-42-0.sh\n")
         );
         assert_eq!(
-            workspace_autostart_script("echo ready"),
-            "#!/bin/sh\nrm -f -- \"$0\"\necho ready\n"
+            workspace_autostart_script(
+                "echo ready",
+                std::path::Path::new("/run/user/1000/limux/workspace-autostart-42-0.sh")
+            )
+            .as_deref(),
+            Some(
+                "#!/bin/sh\nrm -f -- /run/user/1000/limux/workspace-autostart-42-0.sh\necho ready\n"
+            )
         );
     }
 

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1480,11 +1480,18 @@ fn add_terminal_tab_inner(
     );
     let mut initial_input = None;
     if let Some(command) = workspace_autostart_command.as_deref() {
-        eprintln!(
-            "limux: running workspace autostart workspace={} surface={}:{}",
-            internals.callbacks.workspace_id, internals.pane_id, tab_id
-        );
-        initial_input = prepare_workspace_autostart(command);
+        if crate::ghostty_config::terminal_command_accepts_shell_input() {
+            eprintln!(
+                "limux: running workspace autostart workspace={} surface={}:{}",
+                internals.callbacks.workspace_id, internals.pane_id, tab_id
+            );
+            initial_input = prepare_workspace_autostart(command);
+        } else {
+            eprintln!(
+                "limux: skipping workspace autostart for non-shell terminal command workspace={} surface={}:{}",
+                internals.callbacks.workspace_id, internals.pane_id, tab_id
+            );
+        }
     }
 
     let term = terminal::create_terminal(
@@ -4102,12 +4109,11 @@ fn create_browser_widget(
 mod tests {
     use super::{
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
-        effective_drop_target_dimensions, is_localhost_input, is_safe_browser_url,
-        next_active_after_tab_removal, normalize_browser_entry_input,
-        normalize_reorder_insert_index, pane_action_tooltip, select_terminal_commands,
-        resolved_link_destination, surface_hint_matches, workspace_autostart_initial_input,
-        workspace_autostart_script, ContentDropZone, TabDragPayload,
-        BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
+        effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
+        normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
+        resolved_link_destination, select_terminal_commands, surface_hint_matches,
+        workspace_autostart_initial_input, workspace_autostart_script, ContentDropZone,
+        TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
         TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
     };

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -5,8 +5,13 @@
 //! All on one line. Tabs left-justified, icons right-justified.
 
 use std::cell::{Cell, RefCell};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::OnceLock;
 
 use gtk::glib;
 #[allow(unused_imports)]
@@ -234,6 +239,8 @@ type PaneWorkspaceLookupCallback = dyn Fn(&gtk::Widget) -> Option<String>;
 
 pub struct PaneCallbacks {
     pub workspace_id: String,
+    pub autostart_command: Rc<RefCell<Option<String>>>,
+    pub suppress_next_autostart: Cell<bool>,
     pub on_split: Box<PaneSplitCallback>,
     pub on_close_pane: Box<PaneWidgetCallback>,
     pub on_bell: Box<PaneBellCallback>,
@@ -1456,15 +1463,36 @@ fn add_terminal_tab_inner(
     {
         extra_env.push(("LIMUX_SOCKET".to_string(), sock.to_string()));
     }
-    let startup_command = options
+    let restored_agent_command = options
         .as_ref()
         .and_then(|value| value.agent.as_ref())
         .and_then(|agent| agent.resume_command());
-    if let Some(command) = startup_command.as_deref() {
+    if let Some(command) = restored_agent_command.as_deref() {
         eprintln!(
             "limux: restoring agent terminal surface={}:{} command={}",
             internals.pane_id, tab_id, command
         );
+    }
+    let suppress_autostart = internals.callbacks.suppress_next_autostart.replace(false);
+    let (mut startup_command, workspace_autostart_command) = select_terminal_commands(
+        restored_agent_command,
+        internals.callbacks.autostart_command.borrow().clone(),
+        suppress_autostart,
+    );
+    let mut injected_autostart_command = None;
+    if let Some(command) = workspace_autostart_command.as_deref() {
+        eprintln!(
+            "limux: running workspace autostart workspace={} surface={}:{} command={}",
+            internals.callbacks.workspace_id, internals.pane_id, tab_id, command
+        );
+        if let Some(command_line) = prepare_bash_workspace_autostart(command, &mut extra_env) {
+            startup_command = Some(command_line);
+        } else {
+            // Keep non-Bash shells functional until they gain a native startup
+            // adapter of their own. Bash is adapted through its rc startup so
+            // the command is not visibly typed into the terminal or history.
+            injected_autostart_command = Some(command.to_string());
+        }
     }
 
     let term = terminal::create_terminal(
@@ -1478,6 +1506,9 @@ fn add_terminal_tab_inner(
         },
         term_callbacks,
     );
+    if let Some(command) = injected_autostart_command {
+        send_workspace_autostart_when_ready(term.handle.clone(), command);
+    }
     let widget = term.root.clone();
     internals.content_stack.add_named(&widget, Some(&tab_id));
 
@@ -1537,6 +1568,153 @@ fn add_terminal_tab_inner(
     term.handle.focus_surface();
     if options.is_none() {
         (internals.callbacks.on_state_changed)();
+    }
+}
+
+fn select_terminal_commands(
+    restored_agent_command: Option<String>,
+    autostart_command: Option<String>,
+    suppress_autostart: bool,
+) -> (Option<String>, Option<String>) {
+    if restored_agent_command.is_some() {
+        return (restored_agent_command, None);
+    }
+    if suppress_autostart {
+        return (None, None);
+    }
+    (None, autostart_command)
+}
+
+fn send_workspace_autostart_when_ready(handle: terminal::TerminalHandle, command: String) {
+    let mut attempts = 0;
+    let mut command_sent = false;
+    glib::timeout_add_local(std::time::Duration::from_millis(50), move || {
+        attempts += 1;
+        if !command_sent {
+            command_sent = handle.send_text(&command);
+        }
+        if command_sent && handle.send_key("Enter") {
+            return glib::ControlFlow::Break;
+        }
+        if attempts >= 40 {
+            eprintln!("limux: workspace autostart terminal never became writable");
+            glib::ControlFlow::Break
+        } else {
+            glib::ControlFlow::Continue
+        }
+    });
+}
+
+const BASH_AUTOSTART_ENV: &str = "LIMUX_WORKSPACE_AUTOSTART_COMMAND";
+const BASH_AUTOSTART_RC: &str = r#"# Limux workspace autostart adapter.
+# Ghostty sources this file in place of ~/.bashrc when --rcfile is used.
+if [[ ${LIMUX_WORKSPACE_AUTOSTART_COMMAND+x} ]]; then
+  __limux_workspace_autostart_command=$LIMUX_WORKSPACE_AUTOSTART_COMMAND
+  builtin unset LIMUX_WORKSPACE_AUTOSTART_COMMAND
+fi
+
+[[ -r "$HOME/.bashrc" ]] && builtin source "$HOME/.bashrc"
+
+function __limux_run_workspace_autostart {
+  if [[ ${__limux_workspace_autostart_command+x} ]]; then
+    builtin local __limux_command="$__limux_workspace_autostart_command"
+    builtin unset __limux_workspace_autostart_command
+    builtin eval "$__limux_command"
+  fi
+}
+
+if [[ $(builtin declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a "* ]]; then
+  PROMPT_COMMAND=("__limux_run_workspace_autostart" "${PROMPT_COMMAND[@]}")
+elif [[ -n ${PROMPT_COMMAND-} ]]; then
+  PROMPT_COMMAND="__limux_run_workspace_autostart;${PROMPT_COMMAND}"
+else
+  PROMPT_COMMAND="__limux_run_workspace_autostart"
+fi
+"#;
+
+fn prepare_bash_workspace_autostart(
+    command: &str,
+    extra_env: &mut Vec<(String, String)>,
+) -> Option<String> {
+    if command.contains('\0') {
+        eprintln!("limux: workspace autostart contains a NUL byte; refusing to run it");
+        return None;
+    }
+
+    let shell = std::env::var_os("SHELL")?;
+    let shell_path = Path::new(&shell);
+    if shell_path.file_name().and_then(|name| name.to_str()) != Some("bash") {
+        return None;
+    }
+    let shell_path = shell_path.to_str()?;
+    let rc_path = bash_autostart_rc_path()?;
+    let rc_path = rc_path.to_str()?;
+
+    extra_env.push((BASH_AUTOSTART_ENV.to_string(), command.to_string()));
+    Some(format!(
+        "{} --rcfile {}",
+        shell_quote(shell_path),
+        shell_quote(rc_path)
+    ))
+}
+
+fn bash_autostart_rc_path() -> Option<&'static PathBuf> {
+    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+    PATH.get_or_init(create_bash_autostart_rc).as_ref()
+}
+
+fn create_bash_autostart_rc() -> Option<PathBuf> {
+    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
+    if runtime_dir.is_empty() {
+        eprintln!("limux: XDG_RUNTIME_DIR is unset; falling back to terminal input autostart");
+        return None;
+    }
+
+    let dir = PathBuf::from(runtime_dir).join("limux");
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        eprintln!("limux: failed to create autostart runtime directory: {error}");
+        return None;
+    }
+
+    for suffix in 0..100_u8 {
+        let path = dir.join(format!(
+            "workspace-autostart-bashrc-{}-{suffix}",
+            std::process::id()
+        ));
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path);
+        match file {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(BASH_AUTOSTART_RC.as_bytes()) {
+                    let _ = std::fs::remove_file(&path);
+                    eprintln!("limux: failed to write Bash autostart adapter: {error}");
+                    return None;
+                }
+                return Some(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                eprintln!("limux: failed to create Bash autostart adapter: {error}");
+                return None;
+            }
+        }
+    }
+
+    eprintln!("limux: failed to allocate a unique Bash autostart adapter path");
+    None
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 }
 
@@ -3989,8 +4167,9 @@ fn create_browser_widget(
 mod tests {
     use super::{
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
-        effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
-        normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
+        effective_drop_target_dimensions, is_localhost_input, is_safe_browser_url,
+        next_active_after_tab_removal, normalize_browser_entry_input,
+        normalize_reorder_insert_index, pane_action_tooltip, select_terminal_commands,
         resolved_link_destination, surface_hint_matches, ContentDropZone, TabDragPayload,
         BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
@@ -4002,6 +4181,26 @@ mod tests {
     };
     use crate::shortcut_config::{default_shortcuts, resolve_shortcuts_from_str, ShortcutId};
     use crate::{app_config::LinkOpenDestination, terminal::LinkOpenRequest};
+
+    #[test]
+    fn explicit_terminal_command_can_suppress_workspace_autostart() {
+        assert_eq!(
+            select_terminal_commands(None, Some("ssh codex".to_string()), true),
+            (None, None)
+        );
+        assert_eq!(
+            select_terminal_commands(None, Some("ssh codex".to_string()), false),
+            (None, Some("ssh codex".to_string()))
+        );
+        assert_eq!(
+            select_terminal_commands(
+                Some("codex resume abc".to_string()),
+                Some("ssh codex".to_string()),
+                true,
+            ),
+            (Some("codex resume abc".to_string()), None)
+        );
+    }
 
     #[test]
     fn terminal_title_truncation_preserves_utf8_boundaries() {

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -5,13 +5,8 @@
 //! All on one line. Tabs left-justified, icons right-justified.
 
 use std::cell::{Cell, RefCell};
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::os::unix::fs::OpenOptionsExt;
-use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::OnceLock;
 
 use gtk::glib;
 #[allow(unused_imports)]
@@ -1474,25 +1469,18 @@ fn add_terminal_tab_inner(
         );
     }
     let suppress_autostart = internals.callbacks.suppress_next_autostart.replace(false);
-    let (mut startup_command, workspace_autostart_command) = select_terminal_commands(
+    let (startup_command, workspace_autostart_command) = select_terminal_commands(
         restored_agent_command,
         internals.callbacks.autostart_command.borrow().clone(),
         suppress_autostart,
     );
-    let mut injected_autostart_command = None;
+    let mut initial_input = None;
     if let Some(command) = workspace_autostart_command.as_deref() {
         eprintln!(
-            "limux: running workspace autostart workspace={} surface={}:{} command={}",
-            internals.callbacks.workspace_id, internals.pane_id, tab_id, command
+            "limux: running workspace autostart workspace={} surface={}:{}",
+            internals.callbacks.workspace_id, internals.pane_id, tab_id
         );
-        if let Some(command_line) = prepare_bash_workspace_autostart(command, &mut extra_env) {
-            startup_command = Some(command_line);
-        } else {
-            // Keep non-Bash shells functional until they gain a native startup
-            // adapter of their own. Bash is adapted through its rc startup so
-            // the command is not visibly typed into the terminal or history.
-            injected_autostart_command = Some(command.to_string());
-        }
+        initial_input = workspace_autostart_initial_input(command);
     }
 
     let term = terminal::create_terminal(
@@ -1502,13 +1490,11 @@ fn add_terminal_tab_inner(
             copy_selection_to_clipboard,
             saved_font_size: (internals.callbacks.current_config)().borrow().font_size,
             startup_command,
+            initial_input,
             extra_env,
         },
         term_callbacks,
     );
-    if let Some(command) = injected_autostart_command {
-        send_workspace_autostart_when_ready(term.handle.clone(), command);
-    }
     let widget = term.root.clone();
     internals.content_stack.add_named(&widget, Some(&tab_id));
 
@@ -1585,137 +1571,16 @@ fn select_terminal_commands(
     (None, autostart_command)
 }
 
-fn send_workspace_autostart_when_ready(handle: terminal::TerminalHandle, command: String) {
-    let mut attempts = 0;
-    let mut command_sent = false;
-    glib::timeout_add_local(std::time::Duration::from_millis(50), move || {
-        attempts += 1;
-        if !command_sent {
-            command_sent = handle.send_text(&command);
-        }
-        if command_sent && handle.send_key("Enter") {
-            return glib::ControlFlow::Break;
-        }
-        if attempts >= 40 {
-            eprintln!("limux: workspace autostart terminal never became writable");
-            glib::ControlFlow::Break
-        } else {
-            glib::ControlFlow::Continue
-        }
-    });
-}
-
-const BASH_AUTOSTART_ENV: &str = "LIMUX_WORKSPACE_AUTOSTART_COMMAND";
-const BASH_AUTOSTART_RC: &str = r#"# Limux workspace autostart adapter.
-# Ghostty sources this file in place of ~/.bashrc when --rcfile is used.
-if [[ ${LIMUX_WORKSPACE_AUTOSTART_COMMAND+x} ]]; then
-  __limux_workspace_autostart_command=$LIMUX_WORKSPACE_AUTOSTART_COMMAND
-  builtin unset LIMUX_WORKSPACE_AUTOSTART_COMMAND
-fi
-
-[[ -r "$HOME/.bashrc" ]] && builtin source "$HOME/.bashrc"
-
-function __limux_run_workspace_autostart {
-  if [[ ${__limux_workspace_autostart_command+x} ]]; then
-    builtin local __limux_command="$__limux_workspace_autostart_command"
-    builtin unset __limux_workspace_autostart_command
-    builtin eval "$__limux_command"
-  fi
-}
-
-if [[ $(builtin declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a "* ]]; then
-  PROMPT_COMMAND=("__limux_run_workspace_autostart" "${PROMPT_COMMAND[@]}")
-elif [[ -n ${PROMPT_COMMAND-} ]]; then
-  PROMPT_COMMAND="__limux_run_workspace_autostart;${PROMPT_COMMAND}"
-else
-  PROMPT_COMMAND="__limux_run_workspace_autostart"
-fi
-"#;
-
-fn prepare_bash_workspace_autostart(
-    command: &str,
-    extra_env: &mut Vec<(String, String)>,
-) -> Option<String> {
+fn workspace_autostart_initial_input(command: &str) -> Option<String> {
     if command.contains('\0') {
         eprintln!("limux: workspace autostart contains a NUL byte; refusing to run it");
         return None;
     }
-
-    let shell = std::env::var_os("SHELL")?;
-    let shell_path = Path::new(&shell);
-    if shell_path.file_name().and_then(|name| name.to_str()) != Some("bash") {
-        return None;
-    }
-    let shell_path = shell_path.to_str()?;
-    let rc_path = bash_autostart_rc_path()?;
-    let rc_path = rc_path.to_str()?;
-
-    extra_env.push((BASH_AUTOSTART_ENV.to_string(), command.to_string()));
-    Some(format!(
-        "{} --rcfile {}",
-        shell_quote(shell_path),
-        shell_quote(rc_path)
-    ))
-}
-
-fn bash_autostart_rc_path() -> Option<&'static PathBuf> {
-    static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
-    PATH.get_or_init(create_bash_autostart_rc).as_ref()
-}
-
-fn create_bash_autostart_rc() -> Option<PathBuf> {
-    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
-    if runtime_dir.is_empty() {
-        eprintln!("limux: XDG_RUNTIME_DIR is unset; falling back to terminal input autostart");
-        return None;
-    }
-
-    let dir = PathBuf::from(runtime_dir).join("limux");
-    if let Err(error) = std::fs::create_dir_all(&dir) {
-        eprintln!("limux: failed to create autostart runtime directory: {error}");
-        return None;
-    }
-
-    for suffix in 0..100_u8 {
-        let path = dir.join(format!(
-            "workspace-autostart-bashrc-{}-{suffix}",
-            std::process::id()
-        ));
-        let file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&path);
-        match file {
-            Ok(mut file) => {
-                if let Err(error) = file.write_all(BASH_AUTOSTART_RC.as_bytes()) {
-                    let _ = std::fs::remove_file(&path);
-                    eprintln!("limux: failed to write Bash autostart adapter: {error}");
-                    return None;
-                }
-                return Some(path);
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => {
-                eprintln!("limux: failed to create Bash autostart adapter: {error}");
-                return None;
-            }
-        }
-    }
-
-    eprintln!("limux: failed to allocate a unique Bash autostart adapter path");
-    None
-}
-
-fn shell_quote(value: &str) -> String {
-    if value
-        .bytes()
-        .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
-    {
-        value.to_string()
-    } else {
-        format!("'{}'", value.replace('\'', "'\\''"))
-    }
+    // Let Ghostty launch its configured command unchanged. Clearing the input
+    // line immediately before execution keeps the injected command out of the
+    // rendered terminal while remaining compatible with common interactive
+    // shells (Bash, Zsh, and Fish).
+    Some(format!("printf '\\033[2K\\r'; {command}\n"))
 }
 
 fn add_browser_tab_inner(internals: &Rc<PaneInternals>, options: Option<BrowserTabOptions<'_>>) {
@@ -4170,7 +4035,8 @@ mod tests {
         effective_drop_target_dimensions, is_localhost_input, is_safe_browser_url,
         next_active_after_tab_removal, normalize_browser_entry_input,
         normalize_reorder_insert_index, pane_action_tooltip, select_terminal_commands,
-        resolved_link_destination, surface_hint_matches, ContentDropZone, TabDragPayload,
+        resolved_link_destination, surface_hint_matches, workspace_autostart_initial_input,
+        ContentDropZone, TabDragPayload,
         BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
         TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
@@ -4200,6 +4066,15 @@ mod tests {
             ),
             (Some("codex resume abc".to_string()), None)
         );
+    }
+
+    #[test]
+    fn workspace_autostart_uses_hidden_initial_input() {
+        assert_eq!(
+            workspace_autostart_initial_input("echo ready").as_deref(),
+            Some("printf '\\033[2K\\r'; echo ready\n")
+        );
+        assert_eq!(workspace_autostart_initial_input("echo bad\0input"), None);
     }
 
     #[test]

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1480,7 +1480,7 @@ fn add_terminal_tab_inner(
     );
     let mut initial_input = None;
     if let Some(command) = workspace_autostart_command.as_deref() {
-        if crate::ghostty_config::terminal_command_accepts_shell_input() {
+        if terminal::terminal_command_accepts_shell_input() {
             eprintln!(
                 "limux: running workspace autostart workspace={} surface={}:{}",
                 internals.callbacks.workspace_id, internals.pane_id, tab_id

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -5,6 +5,10 @@
 //! All on one line. Tabs left-justified, icons right-justified.
 
 use std::cell::{Cell, RefCell};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -1480,7 +1484,7 @@ fn add_terminal_tab_inner(
             "limux: running workspace autostart workspace={} surface={}:{}",
             internals.callbacks.workspace_id, internals.pane_id, tab_id
         );
-        initial_input = workspace_autostart_initial_input(command);
+        initial_input = prepare_workspace_autostart(command);
     }
 
     let term = terminal::create_terminal(
@@ -1571,16 +1575,82 @@ fn select_terminal_commands(
     (None, autostart_command)
 }
 
-fn workspace_autostart_initial_input(command: &str) -> Option<String> {
+fn prepare_workspace_autostart(command: &str) -> Option<String> {
     if command.contains('\0') {
         eprintln!("limux: workspace autostart contains a NUL byte; refusing to run it");
         return None;
     }
-    // Let Ghostty launch its configured command unchanged. Clearing the input
-    // line immediately before execution keeps the injected command out of the
-    // rendered terminal while remaining compatible with common interactive
-    // shells (Bash, Zsh, and Fish).
-    Some(format!("printf '\\033[2K\\r'; {command}\n"))
+
+    let script_path = create_workspace_autostart_script(command)?;
+    workspace_autostart_initial_input(&script_path)
+}
+
+fn create_workspace_autostart_script(command: &str) -> Option<PathBuf> {
+    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")?;
+    if runtime_dir.is_empty() {
+        eprintln!("limux: XDG_RUNTIME_DIR is unset; workspace autostart was not started");
+        return None;
+    }
+
+    let dir = PathBuf::from(runtime_dir).join("limux");
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        eprintln!("limux: failed to create autostart runtime directory: {error}");
+        return None;
+    }
+
+    for suffix in 0..100_u8 {
+        let path = dir.join(format!(
+            "workspace-autostart-{}-{suffix}.sh",
+            std::process::id()
+        ));
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o700)
+            .open(&path);
+        match file {
+            Ok(mut file) => {
+                let script = workspace_autostart_script(command);
+                if let Err(error) = file.write_all(script.as_bytes()) {
+                    let _ = std::fs::remove_file(&path);
+                    eprintln!("limux: failed to write workspace autostart script: {error}");
+                    return None;
+                }
+                return Some(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                eprintln!("limux: failed to create workspace autostart script: {error}");
+                return None;
+            }
+        }
+    }
+
+    eprintln!("limux: failed to allocate a unique workspace autostart script path");
+    None
+}
+
+fn workspace_autostart_script(command: &str) -> String {
+    format!("#!/bin/sh\nrm -f -- \"$0\"\n{command}\n")
+}
+
+fn workspace_autostart_initial_input(script_path: &Path) -> Option<String> {
+    let script_path = script_path.to_str()?;
+    // Only the private script path enters terminal input. The configured
+    // autostart text stays out of shell history and scrollback, while Ghostty's
+    // configured shell/custom command remains untouched.
+    Some(format!("{}\n", shell_quote(script_path)))
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || b"_@%+=:,./-".contains(&byte))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 fn add_browser_tab_inner(internals: &Rc<PaneInternals>, options: Option<BrowserTabOptions<'_>>) {
@@ -4036,7 +4106,7 @@ mod tests {
         next_active_after_tab_removal, normalize_browser_entry_input,
         normalize_reorder_insert_index, pane_action_tooltip, select_terminal_commands,
         resolved_link_destination, surface_hint_matches, workspace_autostart_initial_input,
-        ContentDropZone, TabDragPayload,
+        workspace_autostart_script, ContentDropZone, TabDragPayload,
         BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
         TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
@@ -4071,10 +4141,16 @@ mod tests {
     #[test]
     fn workspace_autostart_uses_hidden_initial_input() {
         assert_eq!(
-            workspace_autostart_initial_input("echo ready").as_deref(),
-            Some("printf '\\033[2K\\r'; echo ready\n")
+            workspace_autostart_initial_input(std::path::Path::new(
+                "/run/user/1000/limux/workspace-autostart-42-0.sh"
+            ))
+            .as_deref(),
+            Some("/run/user/1000/limux/workspace-autostart-42-0.sh\n")
         );
-        assert_eq!(workspace_autostart_initial_input("echo bad\0input"), None);
+        assert_eq!(
+            workspace_autostart_script("echo ready"),
+            "#!/bin/sh\nrm -f -- \"$0\"\necho ready\n"
+        );
     }
 
     #[test]

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -4185,17 +4185,17 @@ mod tests {
     #[test]
     fn explicit_terminal_command_can_suppress_workspace_autostart() {
         assert_eq!(
-            select_terminal_commands(None, Some("ssh codex".to_string()), true),
+            select_terminal_commands(None, Some("ssh user@server".to_string()), true),
             (None, None)
         );
         assert_eq!(
-            select_terminal_commands(None, Some("ssh codex".to_string()), false),
-            (None, Some("ssh codex".to_string()))
+            select_terminal_commands(None, Some("ssh user@server".to_string()), false),
+            (None, Some("ssh user@server".to_string()))
         );
         assert_eq!(
             select_terminal_commands(
                 Some("codex resume abc".to_string()),
-                Some("ssh codex".to_string()),
+                Some("ssh user@server".to_string()),
                 true,
             ),
             (Some("codex resume abc".to_string()), None)

--- a/rust/limux-host-linux/src/split_tree.rs
+++ b/rust/limux-host-linux/src/split_tree.rs
@@ -585,6 +585,7 @@ pub(crate) fn build_split_node_from_layout(
     shortcuts: &Rc<crate::shortcut_config::ResolvedShortcutConfig>,
     ws_id: &str,
     working_directory: Option<&str>,
+    autostart_command: &Rc<RefCell<Option<String>>>,
     layout: &LayoutNodeState,
 ) -> SplitNode {
     match layout {
@@ -594,8 +595,12 @@ pub(crate) fn build_split_node_from_layout(
                 shortcuts,
                 ws_id,
                 working_directory,
-                Some(pane_state),
-                false,
+                autostart_command.clone(),
+                crate::window::PaneCreationOptions {
+                    initial_state: Some(pane_state),
+                    skip_default_tab: false,
+                    suppress_initial_autostart: false,
+                },
             );
             SplitNode::Leaf {
                 pane_widget: pane.upcast(),
@@ -616,6 +621,7 @@ pub(crate) fn build_split_node_from_layout(
                     shortcuts,
                     ws_id,
                     working_directory,
+                    autostart_command,
                     &split_state.start,
                 )),
                 right: Box::new(build_split_node_from_layout(
@@ -623,6 +629,7 @@ pub(crate) fn build_split_node_from_layout(
                     shortcuts,
                     ws_id,
                     working_directory,
+                    autostart_command,
                     &split_state.end,
                 )),
             }

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -1421,6 +1421,7 @@ pub struct TerminalOptions {
     pub copy_selection_to_clipboard: Rc<dyn Fn() -> bool>,
     pub saved_font_size: Option<f32>,
     pub startup_command: Option<String>,
+    pub initial_input: Option<String>,
     /// Extra environment variables to expose to the spawned shell
     /// (e.g. `LIMUX_WORKSPACE_ID`, `LIMUX_SURFACE_ID`, `LIMUX_PANE_ID`, `LIMUX_SOCKET`).
     ///
@@ -1438,6 +1439,7 @@ impl Default for TerminalOptions {
             copy_selection_to_clipboard: Rc::new(|| true),
             saved_font_size: None,
             startup_command: None,
+            initial_input: None,
             extra_env: Vec::new(),
         }
     }
@@ -1498,6 +1500,7 @@ pub fn create_terminal(
     let wd = working_directory.map(|s| s.to_string());
     let saved_font_size = options.saved_font_size;
     let startup_command = options.startup_command;
+    let initial_input = options.initial_input;
     let hover_focus = options.hover_focus;
     let copy_selection_to_clipboard = options.copy_selection_to_clipboard;
     let extra_env = options.extra_env;
@@ -1738,6 +1741,13 @@ pub fn create_terminal(
                     "limux: starting restored terminal command={}",
                     command.to_string_lossy()
                 );
+            }
+
+            let c_initial_input = initial_input
+                .as_ref()
+                .and_then(|input| CString::new(input.as_str()).ok());
+            if let Some(ref input) = c_initial_input {
+                config.initial_input = input.as_ptr();
             }
 
             let surface = unsafe { ghostty_surface_new(app, &config) };

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -669,7 +669,15 @@ fn load_command_accepts_shell_input(config: ghostty_config_t) -> bool {
     let command = contents
         .as_deref()
         .and_then(|contents| crate::ghostty_config::read_ghostty_value(contents, "command"));
-    crate::ghostty_config::terminal_command_accepts_shell_input(command.as_deref())
+    let initial_command = contents
+        .as_deref()
+        .and_then(|contents| crate::ghostty_config::read_ghostty_value(contents, "initial-command"))
+        .filter(|command| !command.trim().is_empty());
+
+    crate::ghostty_config::terminal_commands_accept_posix_source(
+        command.as_deref(),
+        initial_command.as_deref(),
+    )
 }
 
 /// Initialize the global Ghostty app. Must be called once before creating surfaces.

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -36,6 +36,7 @@ unsafe impl Sync for GhosttyState {}
 static GHOSTTY: OnceLock<GhosttyState> = OnceLock::new();
 static CURRENT_COLOR_SCHEME: AtomicI32 = AtomicI32::new(GHOSTTY_COLOR_SCHEME_LIGHT);
 static CURRENT_SCROLLBAR_ENABLED: AtomicBool = AtomicBool::new(true);
+static CURRENT_COMMAND_ACCEPTS_SHELL_INPUT: AtomicBool = AtomicBool::new(true);
 static WAKEUP_IDLE_QUEUED: AtomicBool = AtomicBool::new(false);
 static EMPTY_CLIPBOARD_TEXT: [u8; 1] = [0];
 
@@ -654,6 +655,23 @@ fn load_ghostty_config() -> ghostty_config_t {
     }
 }
 
+fn load_command_accepts_shell_input(config: ghostty_config_t) -> bool {
+    let serialized = unsafe { ghostty_config_serialize(config) };
+    let contents = if serialized.ptr.is_null() {
+        None
+    } else {
+        let bytes =
+            unsafe { std::slice::from_raw_parts(serialized.ptr.cast::<u8>(), serialized.len) };
+        Some(String::from_utf8_lossy(bytes).into_owned())
+    };
+    unsafe { ghostty_string_free(serialized) };
+
+    let command = contents
+        .as_deref()
+        .and_then(|contents| crate::ghostty_config::read_ghostty_value(contents, "command"));
+    crate::ghostty_config::terminal_command_accepts_shell_input(command.as_deref())
+}
+
 /// Initialize the global Ghostty app. Must be called once before creating surfaces.
 pub fn init_ghostty() {
     GHOSTTY.get_or_init(|| {
@@ -664,6 +682,8 @@ pub fn init_ghostty() {
         let config = load_ghostty_config();
         let background_opacity = load_background_opacity(config);
         CURRENT_SCROLLBAR_ENABLED.store(load_scrollbar_enabled(config), Ordering::Relaxed);
+        CURRENT_COMMAND_ACCEPTS_SHELL_INPUT
+            .store(load_command_accepts_shell_input(config), Ordering::Relaxed);
 
         let runtime_config = ghostty_runtime_config_s {
             userdata: ptr::null_mut(),
@@ -706,6 +726,11 @@ pub fn ghostty_background_opacity() -> f64 {
         .get()
         .map(|state| state.background_opacity)
         .unwrap_or(1.0)
+}
+
+pub fn terminal_command_accepts_shell_input() -> bool {
+    init_ghostty();
+    CURRENT_COMMAND_ACCEPTS_SHELL_INPUT.load(Ordering::Relaxed)
 }
 
 fn load_background_opacity(config: ghostty_config_t) -> f64 {
@@ -1108,6 +1133,8 @@ unsafe extern "C" fn ghostty_action_cb(
         GHOSTTY_ACTION_RELOAD_CONFIG => {
             let config = load_ghostty_config();
             CURRENT_SCROLLBAR_ENABLED.store(load_scrollbar_enabled(config), Ordering::Relaxed);
+            CURRENT_COMMAND_ACCEPTS_SHELL_INPUT
+                .store(load_command_accepts_shell_input(config), Ordering::Relaxed);
             match target.tag {
                 GHOSTTY_TARGET_APP => unsafe {
                     ghostty_app_update_config(app, config);

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -58,6 +58,8 @@ struct Workspace {
     cwd: Rc<RefCell<Option<String>>>,
     /// The folder path this workspace was opened with.
     folder_path: Option<String>,
+    /// Command launched directly in every new terminal for this workspace.
+    autostart_command: Rc<RefCell<Option<String>>>,
     /// Path label shown below workspace name in sidebar.
     path_label: gtk::Label,
 }
@@ -995,6 +997,7 @@ fn snapshot_session_state(state: &State) -> AppSessionState {
                 favorite: workspace.favorite,
                 cwd,
                 folder_path,
+                autostart_command: workspace.autostart_command.borrow().clone(),
                 layout,
             }
         })
@@ -1061,6 +1064,7 @@ fn build_workspace_root(
     shortcuts: &Rc<ResolvedShortcutConfig>,
     ws_id: &str,
     working_directory: Option<&str>,
+    autostart_command: &Rc<RefCell<Option<String>>>,
     layout: &LayoutNodeState,
 ) -> (gtk::Widget, Rc<SplitTreeContainer>) {
     let tree_node = split_tree::build_split_node_from_layout(
@@ -1068,6 +1072,7 @@ fn build_workspace_root(
         shortcuts,
         ws_id,
         working_directory,
+        autostart_command,
         layout,
     );
     let container = SplitTreeContainer::new_from_tree(state, tree_node);
@@ -3110,11 +3115,26 @@ fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::Lis
 
     let rename_btn = gtk::Button::with_label("Rename");
     rename_btn.add_css_class("flat");
+    let has_autostart = {
+        let app_state = state.borrow();
+        app_state
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .is_some_and(|workspace| workspace.autostart_command.borrow().is_some())
+    };
+    let autostart_btn = gtk::Button::with_label(if has_autostart {
+        "Edit Autostart…"
+    } else {
+        "Set Autostart…"
+    });
+    autostart_btn.add_css_class("flat");
     let delete_btn = gtk::Button::with_label("Delete");
     delete_btn.add_css_class("flat");
     delete_btn.add_css_class("destructive-action");
 
     menu_box.append(&rename_btn);
+    menu_box.append(&autostart_btn);
     menu_box.append(&delete_btn);
 
     let popover = gtk::Popover::new();
@@ -3135,6 +3155,15 @@ fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::Lis
         let state = state.clone();
         let ws_id = workspace_id.to_string();
         let pop = popover.clone();
+        autostart_btn.connect_clicked(move |_| {
+            pop.popdown();
+            show_workspace_autostart_dialog(&state, &ws_id);
+        });
+    }
+    {
+        let state = state.clone();
+        let ws_id = workspace_id.to_string();
+        let pop = popover.clone();
         delete_btn.connect_clicked(move |_| {
             pop.popdown();
             close_workspace_by_id(&state, &ws_id);
@@ -3148,6 +3177,114 @@ fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::Lis
     }
 
     popover.popup();
+}
+
+fn normalize_autostart_command(command: &str) -> Option<String> {
+    let command = command.trim();
+    (!command.is_empty()).then(|| command.to_string())
+}
+
+fn show_workspace_autostart_dialog(state: &State, workspace_id: &str) {
+    let (workspace_name, current_command) = {
+        let app_state = state.borrow();
+        let Some(workspace) = app_state
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+        else {
+            return;
+        };
+        let workspace_name = workspace.name.clone();
+        let current_command = workspace.autostart_command.borrow().clone();
+        (workspace_name, current_command)
+    };
+
+    let dialog = gtk::Window::builder()
+        .title("Workspace Autostart")
+        .modal(true)
+        .default_width(520)
+        .resizable(false)
+        .build();
+    if let Some(window) = active_window(state) {
+        dialog.set_transient_for(Some(&window));
+    }
+
+    let description = gtk::Label::builder()
+        .label(format!(
+            "Run a command whenever a new terminal opens in {workspace_name}."
+        ))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .build();
+    let entry = gtk::Entry::builder()
+        .text(current_command.as_deref().unwrap_or_default())
+        .placeholder_text("Command, for example: ssh codex")
+        .hexpand(true)
+        .activates_default(true)
+        .build();
+    let hint = gtk::Label::builder()
+        .label("Leave the command empty to disable autostart for this workspace.")
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .build();
+    hint.add_css_class("dim-label");
+
+    let buttons = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .halign(gtk::Align::End)
+        .spacing(8)
+        .build();
+    let cancel_button = gtk::Button::with_label("Cancel");
+    let save_button = gtk::Button::with_label("Save");
+    save_button.add_css_class("suggested-action");
+    buttons.append(&cancel_button);
+    buttons.append(&save_button);
+
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(12)
+        .margin_top(16)
+        .margin_bottom(16)
+        .margin_start(16)
+        .margin_end(16)
+        .build();
+    content.append(&description);
+    content.append(&entry);
+    content.append(&hint);
+    content.append(&buttons);
+    dialog.set_child(Some(&content));
+    dialog.set_default_widget(Some(&save_button));
+
+    let dialog_for_cancel = dialog.clone();
+    cancel_button.connect_clicked(move |_| dialog_for_cancel.close());
+
+    let state_for_save = state.clone();
+    let workspace_id_for_save = workspace_id.to_string();
+    let dialog_for_save = dialog.clone();
+    let entry_for_save = entry.clone();
+    save_button.connect_clicked(move |_| {
+        let command = normalize_autostart_command(entry_for_save.text().as_str());
+        {
+            let app_state = state_for_save.borrow();
+            let Some(workspace) = app_state
+                .workspaces
+                .iter()
+                .find(|workspace| workspace.id == workspace_id_for_save)
+            else {
+                dialog_for_save.close();
+                return;
+            };
+            *workspace.autostart_command.borrow_mut() = command;
+        }
+        request_session_save(&state_for_save);
+        dialog_for_save.close();
+    });
+
+    let save_button_for_entry = save_button.clone();
+    entry.connect_activate(move |_| save_button_for_entry.emit_clicked());
+    entry.grab_focus();
+    entry.set_position(-1);
+    dialog.present();
 }
 
 fn clamp_workspace_insert_index_for_pinning(
@@ -3518,14 +3655,19 @@ fn create_workspace_for_tab(state: &State, payload: &str) -> bool {
         app_state.shortcuts.clone()
     };
     let new_workspace_id = uuid::Uuid::new_v4().to_string();
+    let autostart_command = Rc::new(RefCell::new(None));
     let stack_name = format!("ws-{new_workspace_id}");
     let pane = create_pane_for_workspace(
         state,
         &shortcuts,
         &new_workspace_id,
         seed.cwd.as_deref(),
-        None,
-        true,
+        autostart_command.clone(),
+        PaneCreationOptions {
+            initial_state: None,
+            skip_default_tab: true,
+            suppress_initial_autostart: false,
+        },
     );
     let split_container = SplitTreeContainer::new(state, pane.clone().upcast());
     let root = split_container.widget().clone();
@@ -3559,6 +3701,7 @@ fn create_workspace_for_tab(state: &State, payload: &str) -> bool {
             favorite: false,
             cwd: Rc::new(RefCell::new(seed.cwd.clone())),
             folder_path: seed.folder_path.clone(),
+            autostart_command,
             path_label,
         });
         app_state.active_idx = app_state.workspaces.len() - 1;
@@ -3998,6 +4141,7 @@ fn workspace_state_with_folder(name: &str, folder_path: &str) -> WorkspaceState 
         favorite: false,
         cwd: Some(folder_path.to_string()),
         folder_path: Some(folder_path.to_string()),
+        autostart_command: None,
         layout: LayoutNodeState::Pane(PaneState::fallback(Some(folder_path))),
     }
 }
@@ -4184,6 +4328,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                     skip_default_tab: false,
                     new_pane_first: resolved.placement.new_pane_first,
                     persist: true,
+                    suppress_initial_autostart: request.command.is_some(),
                 },
             );
             let Some(new_pane) = new_pane else {
@@ -4662,8 +4807,15 @@ fn add_workspace_from_state(state: &State, workspace: &WorkspaceState) {
         .folder_path
         .as_deref()
         .or(workspace.cwd.as_deref());
-    let (root, split_container) =
-        build_workspace_root(state, &shortcuts, &id, working_dir, &workspace.layout);
+    let autostart_command = Rc::new(RefCell::new(workspace.autostart_command.clone()));
+    let (root, split_container) = build_workspace_root(
+        state,
+        &shortcuts,
+        &id,
+        working_dir,
+        &autostart_command,
+        &workspace.layout,
+    );
     stack.add_named(&root, Some(&stack_name));
 
     let show_workspace_path = state
@@ -4696,6 +4848,7 @@ fn add_workspace_from_state(state: &State, workspace: &WorkspaceState) {
         favorite: workspace.favorite,
         cwd,
         folder_path: workspace.folder_path.clone(),
+        autostart_command,
         path_label,
     };
 
@@ -4714,13 +4867,19 @@ fn add_workspace_from_state(state: &State, workspace: &WorkspaceState) {
 }
 
 /// Create a PaneWidget wired up with callbacks for a specific workspace.
+pub(crate) struct PaneCreationOptions<'a> {
+    pub(crate) initial_state: Option<&'a PaneState>,
+    pub(crate) skip_default_tab: bool,
+    pub(crate) suppress_initial_autostart: bool,
+}
+
 pub(crate) fn create_pane_for_workspace(
     state: &State,
     shortcuts: &Rc<ResolvedShortcutConfig>,
     ws_id: &str,
     working_directory: Option<&str>,
-    initial_state: Option<&PaneState>,
-    skip_default_tab: bool,
+    autostart_command: Rc<RefCell<Option<String>>>,
+    options: PaneCreationOptions<'_>,
 ) -> gtk::Box {
     let state_for_split = state.clone();
     let state_for_close = state.clone();
@@ -4749,6 +4908,8 @@ pub(crate) fn create_pane_for_workspace(
 
     let callbacks = Rc::new(PaneCallbacks {
         workspace_id: ws_id.to_string(),
+        autostart_command,
+        suppress_next_autostart: Cell::new(options.suppress_initial_autostart),
         on_split: Box::new(move |pane_widget, orientation| {
             split_pane(
                 &state_for_split,
@@ -4760,6 +4921,7 @@ pub(crate) fn create_pane_for_workspace(
                     skip_default_tab: false,
                     new_pane_first: false,
                     persist: true,
+                    suppress_initial_autostart: false,
                 },
             );
         }),
@@ -4932,8 +5094,8 @@ pub(crate) fn create_pane_for_workspace(
         callbacks,
         shortcuts.clone(),
         working_directory,
-        initial_state,
-        skip_default_tab,
+        options.initial_state,
+        options.skip_default_tab,
     )
 }
 
@@ -5250,6 +5412,7 @@ struct SplitPaneOptions {
     skip_default_tab: bool,
     new_pane_first: bool,
     persist: bool,
+    suppress_initial_autostart: bool,
 }
 
 fn split_pane(
@@ -5259,21 +5422,18 @@ fn split_pane(
     orientation: gtk::Orientation,
     options: SplitPaneOptions,
 ) -> Option<gtk::Widget> {
-    let (shortcuts, wd, container) = {
+    let (shortcuts, wd, autostart_command, container) = {
         let s = state.borrow();
+        let workspace = s.workspaces.iter().find(|w| w.id == ws_id);
         (
             s.shortcuts.clone(),
-            s.workspaces
-                .iter()
-                .find(|w| w.id == ws_id)
-                .and_then(|ws| ws.folder_path.clone().or_else(|| ws.cwd.borrow().clone())),
-            s.workspaces
-                .iter()
-                .find(|w| w.id == ws_id)
-                .map(|ws| ws.split_container.clone()),
+            workspace.and_then(|ws| ws.folder_path.clone().or_else(|| ws.cwd.borrow().clone())),
+            workspace.map(|ws| ws.autostart_command.clone()),
+            workspace.map(|ws| ws.split_container.clone()),
         )
     };
     let container = container?;
+    let autostart_command = autostart_command?;
     if !container.can_split(pane_widget, orientation) {
         return None;
     }
@@ -5283,8 +5443,12 @@ fn split_pane(
         &shortcuts,
         ws_id,
         wd.as_deref(),
-        options.initial_state.as_ref(),
-        options.skip_default_tab,
+        autostart_command,
+        PaneCreationOptions {
+            initial_state: options.initial_state.as_ref(),
+            skip_default_tab: options.skip_default_tab,
+            suppress_initial_autostart: options.suppress_initial_autostart,
+        },
     );
 
     // Mutate the data model and trigger async widget tree rebuild.
@@ -5412,6 +5576,7 @@ fn handle_split_with_tab(
             skip_default_tab: true,
             new_pane_first,
             persist: false,
+            suppress_initial_autostart: false,
         },
     );
     let Some(new_pane) = new_pane else { return };
@@ -5608,6 +5773,7 @@ fn dispatch_browser_command(state: &State, command: ShortcutCommand) -> bool {
                 skip_default_tab: false,
                 new_pane_first: false,
                 persist: true,
+                suppress_initial_autostart: false,
             },
         )
         .is_some();
@@ -5645,6 +5811,7 @@ fn split_focused_pane(state: &State, orientation: gtk::Orientation) {
                 skip_default_tab: false,
                 new_pane_first: false,
                 persist: true,
+                suppress_initial_autostart: false,
             },
         );
     }
@@ -6316,8 +6483,8 @@ mod tests {
         directional_neighbor_score, favorites_prefix_len, find_leaf_pane, font_size_after_delta,
         ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
         initial_workspace_state, keep_workspace_open_after_empty_pane, next_active_workspace_index,
-        pane_create_split_placement, queue_session_save_request, resolve_pane_create_source_id,
-        resolved_system_prefers_dark, sanitize_background_opacity,
+        normalize_autostart_command, pane_create_split_placement, queue_session_save_request,
+        resolve_pane_create_source_id, resolved_system_prefers_dark, sanitize_background_opacity,
         shortcut_allowed_while_browser_find_active, shortcut_blocked_by_editable,
         shortcut_command_from_key_event, shortcut_dispatch_propagation,
         should_emit_desktop_notification, tab_drag_workspace_seed, use_opaque_window_background,
@@ -6356,6 +6523,15 @@ mod tests {
     fn favorites_prefix_len_counts_only_leading_favorites() {
         let flags = [true, true, false, true, false];
         assert_eq!(favorites_prefix_len(&flags), 2);
+    }
+
+    #[test]
+    fn workspace_autostart_normalizes_command_and_empty_input() {
+        assert_eq!(
+            normalize_autostart_command("  ssh codex  ").as_deref(),
+            Some("ssh codex")
+        );
+        assert_eq!(normalize_autostart_command("  \t "), None);
     }
 
     #[test]

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -5485,6 +5485,7 @@ fn open_url_in_browser_tab(state: &State, ws_id: &str, pane_widget: &gtk::Widget
                     skip_default_tab: false,
                     new_pane_first: false,
                     persist: true,
+                    suppress_initial_autostart: false,
                 },
             )
             .is_some()

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3218,7 +3218,7 @@ fn show_workspace_autostart_dialog(state: &State, workspace_id: &str) {
         .build();
     let entry = gtk::Entry::builder()
         .text(current_command.as_deref().unwrap_or_default())
-        .placeholder_text("Command, for example: ssh codex")
+        .placeholder_text("Command, for example: ssh user@server")
         .hexpand(true)
         .activates_default(true)
         .build();
@@ -6528,8 +6528,8 @@ mod tests {
     #[test]
     fn workspace_autostart_normalizes_command_and_empty_input() {
         assert_eq!(
-            normalize_autostart_command("  ssh codex  ").as_deref(),
-            Some("ssh codex")
+            normalize_autostart_command("  ssh user@server  ").as_deref(),
+            Some("ssh user@server")
         );
         assert_eq!(normalize_autostart_command("  \t "), None);
     }

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -544,7 +544,7 @@ if readable:
 time.sleep(30)
 PY
 chmod 700 "$DIRECT_COMMAND"
-printf 'command = direct:%s\n' "$DIRECT_COMMAND" > "$XDG_CONFIG_HOME/ghostty/config"
+printf 'command = direct:%s\n' "$DIRECT_COMMAND" > "$XDG_CONFIG_HOME/ghostty/config.ghostty"
 rm -f "$DEMO_DIR/autostart-proof" "$DEMO_DIR/direct-command-started" \
   "$DEMO_DIR/direct-command-input"
 cat > "$XDG_DATA_HOME/limux/session.json" <<DIRECT_SESSION
@@ -595,7 +595,32 @@ grep -Fq "skipping workspace autostart for non-shell terminal command" \
   "$LOG_DIR/host-direct-command.stderr" \
   || { echo "FAIL: non-shell autostart suppression was not diagnosed"; exit 1; }
 stop_host
-echo "stage 9: OK (direct command started without autostart input)"
+echo "stage 9: OK (config.ghostty direct command started without autostart input)"
+
+# --- 13. Stage 10: shell wrappers with payloads receive no input -----------
+echo
+echo "== stage 10: non-interactive shell wrapper suppresses autostart input =="
+printf "command = shell:/bin/bash -lc 'exec %s'\n" "$DIRECT_COMMAND" \
+  > "$XDG_CONFIG_HOME/ghostty/config.ghostty"
+rm -f "$DEMO_DIR/autostart-proof" "$DEMO_DIR/direct-command-started" \
+  "$DEMO_DIR/direct-command-input"
+start_host host-shell-wrapper
+for _ in $(seq 1 50); do
+  [ -f "$DEMO_DIR/direct-command-started" ] && break
+  sleep 0.1
+done
+[ -f "$DEMO_DIR/direct-command-started" ] \
+  || { echo "FAIL: configured shell wrapper did not start its command"; exit 1; }
+sleep 3
+[ ! -e "$DEMO_DIR/direct-command-input" ] \
+  || { echo "FAIL: shell-wrapped command received injected terminal input"; exit 1; }
+[ ! -e "$DEMO_DIR/autostart-proof" ] \
+  || { echo "FAIL: workspace autostart ran for a non-interactive shell wrapper"; exit 1; }
+grep -Fq "skipping workspace autostart for non-shell terminal command" \
+  "$LOG_DIR/host-shell-wrapper.stderr" \
+  || { echo "FAIL: shell-wrapper autostart suppression was not diagnosed"; exit 1; }
+stop_host
+echo "stage 10: OK (shell-wrapped command started without autostart input)"
 
 kill -TERM -- "-$WESTON_PID"
 for _ in $(seq 1 50); do

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -87,6 +87,7 @@ export XDG_CONFIG_HOME="$DEMO_DIR/config"
 export XDG_RUNTIME_DIR="$DEMO_DIR/runtime"
 mkdir -p "$XDG_DATA_HOME/limux" "$XDG_STATE_HOME" "$XDG_CONFIG_HOME" "$XDG_RUNTIME_DIR"
 chmod 700 "$XDG_RUNTIME_DIR"
+mkdir -p "$DEMO_DIR/autostart-cwd"
 cat > "$XDG_DATA_HOME/limux/session.json" <<SMOKE_SESSION
 {
   "version": 1,
@@ -100,7 +101,7 @@ cat > "$XDG_DATA_HOME/limux/session.json" <<SMOKE_SESSION
       "favorite": false,
       "cwd": "$DEMO_DIR",
       "folder_path": "$DEMO_DIR",
-      "autostart_command": "echo native-autostart-visible; if [ -t 0 ] && [ -t 1 ]; then printf native-autostart-pty > $DEMO_DIR/autostart-proof; fi",
+      "autostart_command": "cd $DEMO_DIR/autostart-cwd; export LIMUX_AUTOSTART_STATE=preserved; echo native-autostart-visible; if [ -t 0 ] && [ -t 1 ]; then printf native-autostart-pty > $DEMO_DIR/autostart-proof; fi",
       "layout": {
         "kind": "pane",
         "pane_id": 1,
@@ -292,6 +293,20 @@ fi
 ! grep -Fq "echo native-autostart-visible" "$LOG_DIR/stage1-autostart-screen.txt" \
   || { echo "FAIL: workspace autostart command was visibly typed into the terminal"; exit 1; }
 echo "native workspace autostart: OK"
+
+SHELL_STATE_COMMAND="printf '%s|%s' \"\$PWD\" \"\$LIMUX_AUTOSTART_STATE\" > '$DEMO_DIR/autostart-shell-state'"
+"$LIMUX_CLI" send --workspace limux "$SHELL_STATE_COMMAND" \
+  >"$LOG_DIR/stage1-autostart-state-send.txt"
+"$LIMUX_CLI" send-key --workspace limux Enter \
+  >"$LOG_DIR/stage1-autostart-state-enter.txt"
+for _ in $(seq 1 50); do
+  [ -f "$DEMO_DIR/autostart-shell-state" ] && break
+  sleep 0.1
+done
+[ "$(cat "$DEMO_DIR/autostart-shell-state" 2>/dev/null)" \
+    = "$DEMO_DIR/autostart-cwd|preserved" ] \
+  || { echo "FAIL: workspace autostart did not preserve parent-shell state"; exit 1; }
+echo "native workspace autostart shell state: OK"
 
 SCREEN_PROOF="limux-screen-proof-$$"
 SCREEN_COMMAND="clear; printf '%s\\n' '$SCREEN_PROOF'; printf screen-ok > '$DEMO_DIR/screen-command-proof'"
@@ -621,6 +636,31 @@ grep -Fq "skipping workspace autostart for non-shell terminal command" \
   || { echo "FAIL: shell-wrapper autostart suppression was not diagnosed"; exit 1; }
 stop_host
 echo "stage 10: OK (shell-wrapped command started without autostart input)"
+
+# --- 14. Stage 11: first-surface initial-command receives no input --------
+echo
+echo "== stage 11: non-shell initial-command suppresses autostart input =="
+printf 'command = direct:/bin/bash\ninitial-command = direct:%s\n' "$DIRECT_COMMAND" \
+  > "$XDG_CONFIG_HOME/ghostty/config.ghostty"
+rm -f "$DEMO_DIR/autostart-proof" "$DEMO_DIR/direct-command-started" \
+  "$DEMO_DIR/direct-command-input"
+start_host host-initial-command
+for _ in $(seq 1 50); do
+  [ -f "$DEMO_DIR/direct-command-started" ] && break
+  sleep 0.1
+done
+[ -f "$DEMO_DIR/direct-command-started" ] \
+  || { echo "FAIL: configured initial-command did not start"; exit 1; }
+sleep 3
+[ ! -e "$DEMO_DIR/direct-command-input" ] \
+  || { echo "FAIL: configured initial-command received injected terminal input"; exit 1; }
+[ ! -e "$DEMO_DIR/autostart-proof" ] \
+  || { echo "FAIL: workspace autostart ran for a configured non-shell initial-command"; exit 1; }
+grep -Fq "skipping workspace autostart for non-shell terminal command" \
+  "$LOG_DIR/host-initial-command.stderr" \
+  || { echo "FAIL: initial-command autostart suppression was not diagnosed"; exit 1; }
+stop_host
+echo "stage 11: OK (initial-command started without autostart input)"
 
 kill -TERM -- "-$WESTON_PID"
 for _ in $(seq 1 50); do

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -99,6 +99,7 @@ cat > "$XDG_DATA_HOME/limux/session.json" <<SMOKE_SESSION
       "favorite": false,
       "cwd": "$DEMO_DIR",
       "folder_path": "$DEMO_DIR",
+      "autostart_command": "echo native-autostart-visible; if [ -t 0 ] && [ -t 1 ]; then printf native-autostart-pty > $DEMO_DIR/autostart-proof; fi",
       "layout": {
         "kind": "pane",
         "pane_id": 1,
@@ -271,6 +272,20 @@ start_host host
 echo
 echo "== stage 1b: terminal surface health and screen I/O =="
 wait_for_healthy_surfaces limux "$LOG_DIR/stage1-health.json"
+
+for _ in $(seq 1 50); do
+  [ -f "$DEMO_DIR/autostart-proof" ] && break
+  sleep 0.1
+done
+[ "$(cat "$DEMO_DIR/autostart-proof" 2>/dev/null)" = "native-autostart-pty" ] \
+  || { echo "FAIL: native workspace autostart did not receive a terminal PTY"; exit 1; }
+"$LIMUX_CLI" read-screen --workspace limux --scrollback \
+  >"$LOG_DIR/stage1-autostart-screen.txt"
+[ "$(grep -Fxc "native-autostart-visible" "$LOG_DIR/stage1-autostart-screen.txt")" -eq 1 ] \
+  || { echo "FAIL: workspace autostart output was missing or duplicated"; exit 1; }
+! grep -Fq "echo native-autostart-visible" "$LOG_DIR/stage1-autostart-screen.txt" \
+  || { echo "FAIL: workspace autostart command was visibly typed into the terminal"; exit 1; }
+echo "native workspace autostart: OK"
 
 SCREEN_PROOF="limux-screen-proof-$$"
 SCREEN_COMMAND="clear; printf '%s\\n' '$SCREEN_PROOF'; printf screen-ok > '$DEMO_DIR/screen-command-proof'"
@@ -488,8 +503,14 @@ start_host host-restart
 "$LIMUX_CLI" list-workspaces >"$LOG_DIR/stage8-workspaces.txt"
 grep -Fq "$RESTORED_WORKSPACE" "$LOG_DIR/stage8-workspaces.txt" \
   || { echo "FAIL: renamed workspace was not restored"; exit 1; }
-"$LIMUX_CLI" --json list-panes --workspace "$RESTORED_WORKSPACE" \
-  >"$LOG_DIR/stage8-panes.json"
+for _ in $(seq 1 50); do
+  "$LIMUX_CLI" --json list-panes --workspace "$RESTORED_WORKSPACE" \
+    >"$LOG_DIR/stage8-panes.json"
+  if jq -e '(.panes | length) == 4' "$LOG_DIR/stage8-panes.json" >/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
 jq -e '(.panes | length) == 4' "$LOG_DIR/stage8-panes.json" >/dev/null \
   || { echo "FAIL: restored workspace did not retain all panes"; exit 1; }
 wait_for_healthy_surfaces "$RESTORED_WORKSPACE" "$LOG_DIR/stage8-health.json"

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -83,8 +83,9 @@ export LIMUX_SOCKET_MODE="runtime"
 unset LIMUX_PANE_ID LIMUX_SURFACE_ID LIMUX_TAB_ID LIMUX_WORKSPACE_ID
 export XDG_DATA_HOME="$DEMO_DIR/data"
 export XDG_STATE_HOME="$DEMO_DIR/state"
+export XDG_CONFIG_HOME="$DEMO_DIR/config"
 export XDG_RUNTIME_DIR="$DEMO_DIR/runtime"
-mkdir -p "$XDG_DATA_HOME/limux" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR"
+mkdir -p "$XDG_DATA_HOME/limux" "$XDG_STATE_HOME" "$XDG_CONFIG_HOME" "$XDG_RUNTIME_DIR"
 chmod 700 "$XDG_RUNTIME_DIR"
 cat > "$XDG_DATA_HOME/limux/session.json" <<SMOKE_SESSION
 {
@@ -520,6 +521,82 @@ jq -e '(.panes | length) == 4' "$LOG_DIR/stage8-panes.json" >/dev/null \
   || { echo "FAIL: restored workspace did not retain all panes"; exit 1; }
 wait_for_healthy_surfaces "$RESTORED_WORKSPACE" "$LOG_DIR/stage8-health.json"
 stop_host
+
+# --- 12. Stage 9: explicit non-shell Ghostty commands receive no input -----
+echo
+echo "== stage 9: non-shell Ghostty command suppresses autostart input =="
+mkdir -p "$XDG_CONFIG_HOME/ghostty"
+DIRECT_COMMAND="$DEMO_DIR/direct-command.py"
+cat > "$DIRECT_COMMAND" <<'PY'
+#!/usr/bin/python3
+import pathlib
+import select
+import sys
+import time
+
+root = pathlib.Path(__file__).parent
+(root / "direct-command-started").write_text("started")
+readable, _, _ = select.select([sys.stdin], [], [], 2.0)
+if readable:
+    data = sys.stdin.buffer.read1(4096)
+    if data:
+        (root / "direct-command-input").write_bytes(data)
+time.sleep(30)
+PY
+chmod 700 "$DIRECT_COMMAND"
+printf 'command = direct:%s\n' "$DIRECT_COMMAND" > "$XDG_CONFIG_HOME/ghostty/config"
+rm -f "$DEMO_DIR/autostart-proof" "$DEMO_DIR/direct-command-started" \
+  "$DEMO_DIR/direct-command-input"
+cat > "$XDG_DATA_HOME/limux/session.json" <<DIRECT_SESSION
+{
+  "version": 1,
+  "active_workspace_index": 0,
+  "top_bar_visible": true,
+  "sidebar": { "visible": true, "width": 220 },
+  "workspaces": [
+    {
+      "id": "00000000-0000-4000-8000-000000000009",
+      "name": "direct-command",
+      "favorite": false,
+      "cwd": "$DEMO_DIR",
+      "folder_path": "$DEMO_DIR",
+      "autostart_command": "printf should-not-run > $DEMO_DIR/autostart-proof",
+      "layout": {
+        "kind": "pane",
+        "pane_id": 1,
+        "active_tab_id": "terminal-direct",
+        "tabs": [
+          {
+            "id": "terminal-direct",
+            "custom_name": null,
+            "pinned": false,
+            "tab_kind": "terminal",
+            "cwd": "$DEMO_DIR"
+          }
+        ]
+      }
+    }
+  ]
+}
+DIRECT_SESSION
+start_host host-direct-command
+for _ in $(seq 1 50); do
+  [ -f "$DEMO_DIR/direct-command-started" ] && break
+  sleep 0.1
+done
+[ -f "$DEMO_DIR/direct-command-started" ] \
+  || { echo "FAIL: configured direct command did not start"; exit 1; }
+sleep 3
+[ ! -e "$DEMO_DIR/direct-command-input" ] \
+  || { echo "FAIL: configured direct command received injected terminal input"; exit 1; }
+[ ! -e "$DEMO_DIR/autostart-proof" ] \
+  || { echo "FAIL: workspace autostart ran for a configured non-shell command"; exit 1; }
+grep -Fq "skipping workspace autostart for non-shell terminal command" \
+  "$LOG_DIR/host-direct-command.stderr" \
+  || { echo "FAIL: non-shell autostart suppression was not diagnosed"; exit 1; }
+stop_host
+echo "stage 9: OK (direct command started without autostart input)"
+
 kill -TERM -- "-$WESTON_PID"
 for _ in $(seq 1 50); do
   if ! kill -0 -- "-$WESTON_PID" 2>/dev/null; then

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -279,6 +279,11 @@ for _ in $(seq 1 50); do
 done
 [ "$(cat "$DEMO_DIR/autostart-proof" 2>/dev/null)" = "native-autostart-pty" ] \
   || { echo "FAIL: native workspace autostart did not receive a terminal PTY"; exit 1; }
+if find "$XDG_RUNTIME_DIR/limux" -maxdepth 1 -name 'workspace-autostart-*.sh' -print -quit \
+  | grep -q .; then
+  echo "FAIL: workspace autostart script was not removed after launch"
+  exit 1
+fi
 "$LIMUX_CLI" read-screen --workspace limux --scrollback \
   >"$LOG_DIR/stage1-autostart-screen.txt"
 [ "$(grep -Fxc "native-autostart-visible" "$LOG_DIR/stage1-autostart-screen.txt")" -eq 1 ] \


### PR DESCRIPTION
## Summary

- add a workspace-level autostart command configurable from the sidebar context menu
- persist autostart commands with session state and share them across every pane in the workspace
- preserve restored agent sessions and explicit `new-pane --command` behavior
- keep short-lived commands inside a usable, Ghostty-integrated shell instead of closing the terminal

## Why

Workspace setup currently has to live outside Limux, typically in shell startup files or wrapper scripts. That makes the behavior global, difficult to manage per workspace, and easy to trigger in unrelated terminals.

This adds the behavior at the workspace boundary where it belongs. Users can right-click a workspace, choose **Set Autostart…**, and use commands such as `ssh user@server`. Saving an empty value disables it again.

## Implementation

- `WorkspaceState` stores an optional, backward-compatible `autostart_command`.
- All panes in a workspace share the live setting, including newly split panes and restored layouts.
- Restored agent commands take precedence, while explicit control-API pane commands suppress the workspace autostart for that terminal.
- Limux writes autostart to a private, self-deleting `/bin/sh` script and sources it with `. <script>` through Ghostty `initial_input`. The command is neither visibly typed nor stored in shell history, while `cd`, `export`, aliases, and functions affect the interactive parent shell.
- Limux classifies `command` and `initial-command` from Ghostty's finalized configuration, including legacy `config`, `config.ghostty`, and recursive `config-file` sources. Autostart runs only when both effective launch paths are POSIX-compatible shells with interactive/login-only arguments.
- Non-shell commands, non-POSIX shells, and non-interactive shell wrappers skip autostart and receive no injected PTY input.
- GTK smoke coverage verifies normal autostart, persisted parent-shell state, session restoration, `config.ghostty` direct commands, shell-wrapped payload commands, and a non-shell first-surface `initial-command`.

## User impact

Autostart is fully managed from Limux and requires no shell startup-file changes. Short commands leave an interactive shell open; stateful setup such as `cd` and `export` remains active, and interactive commands such as SSH retain the terminal PTY. Terminals configured to launch applications, non-POSIX shells, or scripted shell payloads are left untouched.

## Validation

- format and Clippy with `-D warnings`
- all workspace and doc tests
- release-version and AUR source validation
- package SVG/graphics checks: 32/32 under an unprivileged user
- `./scripts/xvfb-smoke-test.sh` (release profile, headless Weston, including parent-shell state and all no-input safety stages)
