### PR TITLE
feat(host): add embedded link destination

### DIFF
--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -161,6 +161,14 @@ impl LinkOpenDestination {
             _ => Self::DefaultBrowser,
         }
     }
+
+    pub fn effective(self, embedded_browser_available: bool) -> Self {
+        if self == Self::BrowserTab && !embedded_browser_available {
+            Self::DefaultBrowser
+        } else {
+            self
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -879,6 +887,22 @@ mod tests {
         let loaded = load_from_path(&path);
         assert_eq!(
             loaded.config.links.open_destination,
+            LinkOpenDestination::DefaultBrowser
+        );
+    }
+
+    #[test]
+    fn link_destination_matches_embedded_browser_availability() {
+        assert_eq!(
+            LinkOpenDestination::BrowserTab.effective(true),
+            LinkOpenDestination::BrowserTab
+        );
+        assert_eq!(
+            LinkOpenDestination::BrowserTab.effective(false),
+            LinkOpenDestination::DefaultBrowser
+        );
+        assert_eq!(
+            LinkOpenDestination::DefaultBrowser.effective(false),
             LinkOpenDestination::DefaultBrowser
         );
     }

--- a/rust/limux-host-linux/src/app_config.rs
+++ b/rust/limux-host-linux/src/app_config.rs
@@ -52,6 +52,8 @@ pub struct AppConfig {
     #[serde(skip)]
     pub clipboard: ClipboardConfig,
     #[serde(skip)]
+    pub links: LinkConfig,
+    #[serde(skip)]
     pub font_size: Option<f32>,
 }
 
@@ -121,6 +123,49 @@ impl Default for ClipboardConfig {
             copy_selection_to_clipboard: true,
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LinkOpenDestination {
+    #[default]
+    DefaultBrowser,
+    BrowserTab,
+}
+
+impl LinkOpenDestination {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DefaultBrowser => "default_browser",
+            Self::BrowserTab => "browser_tab",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "default_browser" => Some(Self::DefaultBrowser),
+            "browser_tab" => Some(Self::BrowserTab),
+            _ => None,
+        }
+    }
+
+    pub fn dropdown_index(self) -> u32 {
+        match self {
+            Self::DefaultBrowser => 0,
+            Self::BrowserTab => 1,
+        }
+    }
+
+    pub fn from_dropdown_index(index: u32) -> Self {
+        match index {
+            1 => Self::BrowserTab,
+            _ => Self::DefaultBrowser,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LinkConfig {
+    pub open_destination: LinkOpenDestination,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -338,6 +383,14 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         .and_then(Value::as_bool)
         .unwrap_or(clipboard_defaults.copy_selection_to_clipboard);
 
+    let open_destination = root
+        .get("links")
+        .and_then(Value::as_object)
+        .and_then(|links| links.get("open_destination"))
+        .and_then(Value::as_str)
+        .and_then(LinkOpenDestination::from_str)
+        .unwrap_or_default();
+
     let font_size = root
         .get("font_size")
         .and_then(Value::as_f64)
@@ -364,6 +417,7 @@ fn parse_app_config_value(root: &Value) -> AppConfig {
         clipboard: ClipboardConfig {
             copy_selection_to_clipboard,
         },
+        links: LinkConfig { open_destination },
         font_size,
     }
 }
@@ -424,6 +478,10 @@ fn save_to_path(path: &Path, config: &AppConfig) -> Result<(), String> {
         json!({
             "copy_selection_to_clipboard": config.clipboard.copy_selection_to_clipboard,
         }),
+    );
+    root.insert(
+        "links".to_string(),
+        json!({ "open_destination": config.links.open_destination.as_str() }),
     );
 
     if let Some(size) = config.font_size {
@@ -549,6 +607,9 @@ fn ensure_default_config_file(path: &Path) -> std::io::Result<()> {
         },
         "clipboard": {
             "copy_selection_to_clipboard": true
+        },
+        "links": {
+            "open_destination": "default_browser"
         }
     });
     let serialized = serde_json::to_string_pretty(&default_root)
@@ -638,6 +699,10 @@ mod tests {
         assert_eq!(
             parsed["clipboard"]["copy_selection_to_clipboard"],
             Value::Bool(true)
+        );
+        assert_eq!(
+            parsed["links"]["open_destination"],
+            Value::String("default_browser".to_string())
         );
     }
 
@@ -776,6 +841,46 @@ mod tests {
 
         assert!(loaded.warnings.is_empty());
         assert!(!loaded.config.clipboard.copy_selection_to_clipboard);
+    }
+
+    #[test]
+    fn load_from_path_reads_link_destination_and_defaults_invalid_values() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+        fs::write(
+            &path,
+            r#"{
+  "links": {
+    "open_destination": "browser_tab"
+  }
+}
+"#,
+        )
+        .expect("write config");
+
+        let loaded = load_from_path(&path);
+        assert_eq!(
+            loaded.config.links.open_destination,
+            LinkOpenDestination::BrowserTab
+        );
+
+        fs::write(
+            &path,
+            r#"{
+  "links": {
+    "open_destination": "invalid"
+  }
+}
+"#,
+        )
+        .expect("write invalid destination");
+
+        let loaded = load_from_path(&path);
+        assert_eq!(
+            loaded.config.links.open_destination,
+            LinkOpenDestination::DefaultBrowser
+        );
     }
 
     #[test]
@@ -989,6 +1094,24 @@ mod tests {
         assert_eq!(
             parsed["clipboard"]["copy_selection_to_clipboard"],
             Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn save_to_path_writes_link_destination() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = settings_path_in(dir.path());
+        fs::create_dir_all(path.parent().expect("config dir")).expect("create config dir");
+
+        let mut config = AppConfig::default();
+        config.links.open_destination = LinkOpenDestination::BrowserTab;
+        save_to_path(&path, &config).expect("save link destination");
+
+        let raw = fs::read_to_string(&path).expect("read config");
+        let parsed: Value = serde_json::from_str(&raw).expect("parse config");
+        assert_eq!(
+            parsed["links"]["open_destination"],
+            Value::String("browser_tab".to_string())
         );
     }
 

--- a/rust/limux-host-linux/src/browser_link.rs
+++ b/rust/limux-host-linux/src/browser_link.rs
@@ -1,0 +1,110 @@
+pub fn open_in_right_pane<Pane>(
+    source: &Pane,
+    right: Option<&Pane>,
+    split_right: impl FnOnce() -> bool,
+    mut append_browser_tab: impl FnMut(&Pane),
+) {
+    if let Some(right) = right {
+        append_browser_tab(right);
+    } else if !split_right() {
+        append_browser_tab(source);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+
+    use super::open_in_right_pane;
+
+    #[derive(Default)]
+    struct TestPane {
+        pages: RefCell<Vec<&'static str>>,
+        save_requests: Cell<usize>,
+    }
+
+    impl TestPane {
+        fn with_pages(pages: &[&'static str]) -> Self {
+            Self {
+                pages: RefCell::new(pages.to_vec()),
+                save_requests: Cell::new(0),
+            }
+        }
+
+        fn append_page(&self, url: &'static str) {
+            self.pages.borrow_mut().push(url);
+            self.save_requests.set(self.save_requests.get() + 1);
+        }
+    }
+
+    #[test]
+    fn existing_right_pane_gets_a_fresh_tab_and_preserves_existing_pages() {
+        let source = TestPane::default();
+        let right = TestPane::with_pages(&["https://existing.example"]);
+        let split_attempted = Cell::new(false);
+
+        open_in_right_pane(
+            &source,
+            Some(&right),
+            || {
+                split_attempted.set(true);
+                true
+            },
+            |pane| pane.append_page("https://new.example"),
+        );
+
+        assert_eq!(
+            right.pages.borrow().as_slice(),
+            ["https://existing.example", "https://new.example"]
+        );
+        assert_eq!(right.save_requests.get(), 1);
+        assert!(source.pages.borrow().is_empty());
+        assert!(!split_attempted.get());
+    }
+
+    #[test]
+    fn missing_right_pane_creates_and_persists_a_browser_split() {
+        let source = TestPane::default();
+        let created_pages = RefCell::new(Vec::new());
+        let save_requests = Cell::new(0);
+
+        open_in_right_pane(
+            &source,
+            None,
+            || {
+                created_pages.borrow_mut().push("https://new.example");
+                save_requests.set(save_requests.get() + 1);
+                true
+            },
+            |pane| pane.append_page("https://new.example"),
+        );
+
+        assert_eq!(created_pages.borrow().as_slice(), ["https://new.example"]);
+        assert_eq!(save_requests.get(), 1);
+        assert!(source.pages.borrow().is_empty());
+        assert_eq!(source.save_requests.get(), 0);
+    }
+
+    #[test]
+    fn unavailable_split_falls_back_to_a_persisted_source_pane_tab() {
+        let source = TestPane::with_pages(&["https://existing.example"]);
+        let split_attempted = Cell::new(false);
+
+        open_in_right_pane(
+            &source,
+            None,
+            || {
+                split_attempted.set(true);
+                false
+            },
+            |pane| pane.append_page("https://new.example"),
+        );
+
+        assert!(split_attempted.get());
+        assert_eq!(
+            source.pages.borrow().as_slice(),
+            ["https://existing.example", "https://new.example"]
+        );
+        assert_eq!(source.save_requests.get(), 1);
+    }
+}

--- a/rust/limux-host-linux/src/link_uri.rs
+++ b/rust/limux-host-linux/src/link_uri.rs
@@ -1,0 +1,83 @@
+fn scheme_and_rest(url: &str) -> Option<(String, &str)> {
+    let colon = url.find(':')?;
+    Some((url[..colon].to_ascii_lowercase(), &url[colon..]))
+}
+
+pub fn is_safe_external_url(url: &str) -> bool {
+    let Some((scheme, rest)) = scheme_and_rest(url) else {
+        return false;
+    };
+
+    match scheme.as_str() {
+        "http" | "https" => rest.starts_with("://"),
+        "mailto" => rest.starts_with(':'),
+        _ => false,
+    }
+}
+
+pub fn is_embedded_browser_url(url: &str) -> bool {
+    let Some((scheme, rest)) = scheme_and_rest(url) else {
+        return false;
+    };
+
+    matches!(scheme.as_str(), "http" | "https") && rest.starts_with("://")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_urls_allow_web_and_email_schemes() {
+        for url in [
+            "https://example.com",
+            "HTTP://localhost:8080/path",
+            "mailto:user@example.com",
+            "MAILTO:user@example.com?subject=hi",
+        ] {
+            assert!(is_safe_external_url(url), "should accept {url}");
+        }
+    }
+
+    #[test]
+    fn embedded_urls_allow_web_schemes_only() {
+        for url in ["https://example.com", "HTTP://localhost:8080/path"] {
+            assert!(is_embedded_browser_url(url), "should accept {url}");
+        }
+        assert!(!is_embedded_browser_url("mailto:user@example.com"));
+    }
+
+    #[test]
+    fn link_urls_reject_unsafe_schemes_and_malformed_values() {
+        for url in [
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "data:text/html,hello",
+            "vbscript:msgbox(1)",
+            "file:///etc/passwd",
+            "ftp://ftp.example.com/file",
+            "ftps://ftp.example.com/file",
+            "smb://host/share",
+            "nfs://host/export",
+            "dav://host/path",
+            "davs://host/path",
+            "sftp://host/path",
+            "ssh://host/path",
+            "magnet:?xt=urn:btih:abc",
+            "chrome://settings",
+            "about:blank",
+            "vscode://file/etc/passwd",
+            "slack://open?team=T",
+            " example.com",
+            "/etc/passwd",
+            "example.com",
+            "",
+            "https:",
+            "https:example.com",
+            "http:/example.com",
+        ] {
+            assert!(!is_safe_external_url(url), "should reject {url}");
+            assert!(!is_embedded_browser_url(url), "should reject {url}");
+        }
+    }
+}

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -4,6 +4,7 @@ mod ghostty_config;
 mod ime;
 mod keybind_editor;
 mod layout_state;
+mod link_uri;
 mod pane;
 mod settings_editor;
 mod shortcut_config;

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -1,4 +1,5 @@
 mod app_config;
+mod browser_link;
 mod control_bridge;
 mod ghostty_config;
 mod ime;

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1724,66 +1724,6 @@ pub fn add_browser_tab_to_pane_with_uri(pane_widget: &gtk::Widget, uri: Option<&
     }
 }
 
-pub fn open_url_in_existing_browser_tab(pane_widget: &gtk::Widget, url: &str) -> bool {
-    let Some(internals) = find_pane_internals(pane_widget) else {
-        return false;
-    };
-
-    let target = {
-        let tab_state = internals.tab_state.borrow();
-        let target_id = preferred_browser_tab_id(
-            tab_state.active_tab.as_deref(),
-            tab_state.tabs.iter().map(|entry| {
-                (
-                    entry.id.as_str(),
-                    matches!(entry.kind, TabKind::Browser { .. }),
-                )
-            }),
-        );
-        target_id
-            .and_then(|target_id| tab_state.tabs.iter().find(|entry| entry.id == target_id))
-            .and_then(|entry| match &entry.kind {
-                TabKind::Browser { state } => {
-                    Some((entry.id.clone(), state.uri.clone(), state.handles.clone()))
-                }
-                _ => None,
-            })
-    };
-
-    let Some((tab_id, saved_uri, handles)) = target else {
-        return false;
-    };
-    if !handles.load_uri(url) {
-        return false;
-    }
-    *saved_uri.borrow_mut() = Some(url.to_string());
-    activate_tab(
-        &internals.tab_strip,
-        &internals.content_stack,
-        &internals.tab_state,
-        &tab_id,
-    );
-    (internals.callbacks.on_state_changed)();
-    true
-}
-
-fn preferred_browser_tab_id<'a>(
-    active_tab_id: Option<&str>,
-    tabs: impl IntoIterator<Item = (&'a str, bool)>,
-) -> Option<&'a str> {
-    let mut first_browser = None;
-    for (tab_id, is_browser) in tabs {
-        if !is_browser {
-            continue;
-        }
-        if Some(tab_id) == active_tab_id {
-            return Some(tab_id);
-        }
-        first_browser.get_or_insert(tab_id);
-    }
-    first_browser
-}
-
 pub fn add_keybind_editor_tab_to_pane(
     pane_widget: &gtk::Widget,
     shortcuts: Rc<ResolvedShortcutConfig>,
@@ -3437,11 +3377,6 @@ impl BrowserShortcutTarget {
 
 #[cfg(feature = "webkit")]
 impl BrowserHandles {
-    fn load_uri(&self, uri: &str) -> bool {
-        self.webview.load_uri(uri);
-        true
-    }
-
     fn prepare_for_removal(&self) {
         self.find_controller.search_finish();
         self.search_bar.set_search_mode(false);
@@ -3597,10 +3532,6 @@ fn search_for_browser_text(find_controller: &webkit6::FindController, query: &st
 
 #[cfg(not(feature = "webkit"))]
 impl BrowserHandles {
-    fn load_uri(&self, _uri: &str) -> bool {
-        false
-    }
-
     fn prepare_for_removal(&self) {}
 
     fn is_find_active(&self) -> bool {
@@ -4061,8 +3992,8 @@ mod tests {
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
         effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
         normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
-        preferred_browser_tab_id, resolved_link_destination, surface_hint_matches, ContentDropZone,
-        TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
+        resolved_link_destination, surface_hint_matches, ContentDropZone, TabDragPayload,
+        BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
         TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
     };
@@ -4370,25 +4301,6 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(normalize_browser_entry_input(input), expected, "{input}");
         }
-    }
-
-    #[test]
-    fn preferred_browser_tab_uses_active_browser_then_first_browser() {
-        let tabs = [
-            ("terminal", false),
-            ("browser-1", true),
-            ("browser-2", true),
-        ];
-
-        assert_eq!(
-            preferred_browser_tab_id(Some("browser-2"), tabs),
-            Some("browser-2")
-        );
-        assert_eq!(
-            preferred_browser_tab_id(Some("terminal"), tabs),
-            Some("browser-1")
-        );
-        assert_eq!(preferred_browser_tab_id(None, [("terminal", false)]), None);
     }
 
     #[test]

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -1347,10 +1347,9 @@ fn resolved_link_destination(
     let destination = match request {
         LinkOpenRequest::Configured => configured,
         LinkOpenRequest::Destination(destination) => destination,
-    };
-    if destination == LinkOpenDestination::BrowserTab
-        && (!cfg!(feature = "webkit") || !link_uri::is_embedded_browser_url(url))
-    {
+    }
+    .effective(cfg!(feature = "webkit"));
+    if destination == LinkOpenDestination::BrowserTab && !link_uri::is_embedded_browser_url(url) {
         return Some(LinkOpenDestination::DefaultBrowser);
     }
     Some(destination)

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -15,14 +15,15 @@ use gtk4 as gtk;
 #[cfg(feature = "webkit")]
 use webkit6::prelude::*;
 
-use crate::app_config::AppConfig;
+use crate::app_config::{AppConfig, LinkOpenDestination};
 use crate::keybind_editor;
 use crate::layout_state::{
     PaneState, RestorableAgentState, TabContentState, TabState as SavedTabState,
 };
+use crate::link_uri;
 use crate::settings_editor;
 use crate::shortcut_config::{NormalizedShortcut, ResolvedShortcutConfig, ShortcutId};
-use crate::terminal::{self, TerminalCallbacks};
+use crate::terminal::{self, LinkOpenRequest, TerminalCallbacks};
 
 static NEXT_PANE_ID: AtomicU32 = AtomicU32::new(1);
 
@@ -218,6 +219,7 @@ type PanePathCallback = dyn Fn(&str);
 type PaneDesktopNotificationCallback = dyn Fn(&str, &str, bool, u32, &str);
 type PaneEmptyCallback = dyn Fn(&gtk::Widget, PaneEmptyReason);
 type PaneOpenBrowserHereCallback = dyn Fn(&gtk::Widget);
+type PaneOpenUrlInBrowserCallback = dyn Fn(&gtk::Widget, &str);
 type PaneVisibilityCallback = dyn Fn(&gtk::Widget) -> bool;
 type PaneShortcutStateCallback = dyn Fn() -> Rc<ResolvedShortcutConfig>;
 type PaneShortcutCaptureCallback =
@@ -237,6 +239,7 @@ pub struct PaneCallbacks {
     pub on_bell: Box<PaneBellCallback>,
     pub on_desktop_notification: Box<PaneDesktopNotificationCallback>,
     pub on_open_browser_here: Box<PaneOpenBrowserHereCallback>,
+    pub on_open_url_in_browser: Box<PaneOpenUrlInBrowserCallback>,
     pub on_open_keybinds: Box<PaneWidgetCallback>,
     pub current_shortcuts: Box<PaneShortcutStateCallback>,
     pub on_capture_shortcut: Rc<PaneShortcutCaptureCallback>,
@@ -1194,6 +1197,7 @@ fn make_terminal_callbacks(
     let callbacks_for_pwd = internals.callbacks.clone();
     let callbacks_for_close = internals.callbacks.clone();
     let callbacks_for_browser_here = internals.callbacks.clone();
+    let callbacks_for_open_url = internals.callbacks.clone();
     let callbacks_for_split_right = internals.callbacks.clone();
     let callbacks_for_split_down = internals.callbacks.clone();
     let callbacks_for_keybinds = internals.callbacks.clone();
@@ -1259,14 +1263,23 @@ fn make_terminal_callbacks(
         }),
         on_open_url: Box::new({
             let pane_outer = internals.pane_outer.clone();
-            move |url, external| {
-                if external {
-                    open_url_in_external_browser(url);
+            move |url, request| {
+                let configured_destination = (callbacks_for_open_url.current_config)()
+                    .borrow()
+                    .links
+                    .open_destination;
+                let Some(destination) =
+                    resolved_link_destination(configured_destination, request, url)
+                else {
+                    eprintln!("limux: refusing to open URL with unrecognized scheme: {url}");
                     return;
-                }
-
+                };
                 let pane_widget: gtk::Widget = pane_outer.clone().upcast();
-                add_browser_tab_to_pane_with_uri(&pane_widget, Some(url));
+                if destination == LinkOpenDestination::BrowserTab {
+                    (callbacks_for_open_url.on_open_url_in_browser)(&pane_widget, url);
+                } else {
+                    open_url_in_external_browser(url);
+                }
             }
         }),
         on_open_browser_here: Box::new({
@@ -1322,39 +1335,29 @@ fn display_terminal_title(title: &str) -> String {
     format!("{}…", &title[..truncate_at])
 }
 
-fn is_safe_browser_url(url: &str) -> bool {
-    // Minimal allow-list of URI schemes that may be handed to the system
-    // browser on Ctrl+click. The threat model is hostile terminal output:
-    // anything that ends up in a pane's scrollback can craft an OSC 8
-    // hyperlink, and clicking it must not lead to code execution.
-    //
-    // Why only http/https/mailto?
-    // - `javascript:`, `vbscript:`, `data:` are classic XSS sinks (Gitea
-    //   blocks these unconditionally — github.com/go-gitea/gitea#25960).
-    // - `file://` directly opens local files via the registered handler;
-    //   a hostile `cat` of a crafted .desktop file would be RCE.
-    // - `ftp://`, `ftps://`, `smb://`, `nfs://`, `dav://`, `sftp://` all
-    //   auto-mount via gvfs and can execute binaries on the mounted share
-    //   (positive.security/blog/url-open-rce).
-    // - Custom schemes (`vscode://`, `slack://`, `obsidian://`, ...) have
-    //   historically had RCE CVEs in their handlers; we don't second-guess
-    //   that surface area here.
-    //
-    // RFC 3986 §3.1: scheme matching is case-insensitive.
-    let Some(colon) = url.find(':') else {
-        return false;
-    };
-    let scheme = url[..colon].to_ascii_lowercase();
-    let rest = &url[colon..];
-    match scheme.as_str() {
-        "https" | "http" => rest.starts_with("://"),
-        "mailto" => rest.starts_with(':'),
-        _ => false,
+fn resolved_link_destination(
+    configured: LinkOpenDestination,
+    request: LinkOpenRequest,
+    url: &str,
+) -> Option<LinkOpenDestination> {
+    if !link_uri::is_safe_external_url(url) {
+        return None;
     }
+
+    let destination = match request {
+        LinkOpenRequest::Configured => configured,
+        LinkOpenRequest::Destination(destination) => destination,
+    };
+    if destination == LinkOpenDestination::BrowserTab
+        && (!cfg!(feature = "webkit") || !link_uri::is_embedded_browser_url(url))
+    {
+        return Some(LinkOpenDestination::DefaultBrowser);
+    }
+    Some(destination)
 }
 
 fn open_url_in_external_browser(url: &str) {
-    if !is_safe_browser_url(url) {
+    if !link_uri::is_safe_external_url(url) {
         eprintln!("limux: refusing to open URL with unrecognized scheme: {url}");
         return;
     }
@@ -1715,7 +1718,70 @@ pub fn add_browser_tab_to_pane_with_uri(pane_widget: &gtk::Widget, uri: Option<&
             uri: Some(uri),
         });
         add_browser_tab_inner(&internals, options);
+        if uri.is_some() {
+            (internals.callbacks.on_state_changed)();
+        }
     }
+}
+
+pub fn open_url_in_existing_browser_tab(pane_widget: &gtk::Widget, url: &str) -> bool {
+    let Some(internals) = find_pane_internals(pane_widget) else {
+        return false;
+    };
+
+    let target = {
+        let tab_state = internals.tab_state.borrow();
+        let target_id = preferred_browser_tab_id(
+            tab_state.active_tab.as_deref(),
+            tab_state.tabs.iter().map(|entry| {
+                (
+                    entry.id.as_str(),
+                    matches!(entry.kind, TabKind::Browser { .. }),
+                )
+            }),
+        );
+        target_id
+            .and_then(|target_id| tab_state.tabs.iter().find(|entry| entry.id == target_id))
+            .and_then(|entry| match &entry.kind {
+                TabKind::Browser { state } => {
+                    Some((entry.id.clone(), state.uri.clone(), state.handles.clone()))
+                }
+                _ => None,
+            })
+    };
+
+    let Some((tab_id, saved_uri, handles)) = target else {
+        return false;
+    };
+    if !handles.load_uri(url) {
+        return false;
+    }
+    *saved_uri.borrow_mut() = Some(url.to_string());
+    activate_tab(
+        &internals.tab_strip,
+        &internals.content_stack,
+        &internals.tab_state,
+        &tab_id,
+    );
+    (internals.callbacks.on_state_changed)();
+    true
+}
+
+fn preferred_browser_tab_id<'a>(
+    active_tab_id: Option<&str>,
+    tabs: impl IntoIterator<Item = (&'a str, bool)>,
+) -> Option<&'a str> {
+    let mut first_browser = None;
+    for (tab_id, is_browser) in tabs {
+        if !is_browser {
+            continue;
+        }
+        if Some(tab_id) == active_tab_id {
+            return Some(tab_id);
+        }
+        first_browser.get_or_insert(tab_id);
+    }
+    first_browser
 }
 
 pub fn add_keybind_editor_tab_to_pane(
@@ -3371,6 +3437,11 @@ impl BrowserShortcutTarget {
 
 #[cfg(feature = "webkit")]
 impl BrowserHandles {
+    fn load_uri(&self, uri: &str) -> bool {
+        self.webview.load_uri(uri);
+        true
+    }
+
     fn prepare_for_removal(&self) {
         self.find_controller.search_finish();
         self.search_bar.set_search_mode(false);
@@ -3526,6 +3597,10 @@ fn search_for_browser_text(find_controller: &webkit6::FindController, query: &st
 
 #[cfg(not(feature = "webkit"))]
 impl BrowserHandles {
+    fn load_uri(&self, _uri: &str) -> bool {
+        false
+    }
+
     fn prepare_for_removal(&self) {}
 
     fn is_find_active(&self) -> bool {
@@ -3984,9 +4059,9 @@ fn create_browser_widget(
 mod tests {
     use super::{
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
-        effective_drop_target_dimensions, is_localhost_input, is_safe_browser_url,
-        next_active_after_tab_removal, normalize_browser_entry_input,
-        normalize_reorder_insert_index, pane_action_tooltip, surface_hint_matches, ContentDropZone,
+        effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
+        normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
+        preferred_browser_tab_id, resolved_link_destination, surface_hint_matches, ContentDropZone,
         TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
         BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
         TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
@@ -3996,6 +4071,7 @@ mod tests {
         env_value_contains_token, is_kde_wayland_session_from_env, BROWSER_WEB_VIEW_CSS_CLASS,
     };
     use crate::shortcut_config::{default_shortcuts, resolve_shortcuts_from_str, ShortcutId};
+    use crate::{app_config::LinkOpenDestination, terminal::LinkOpenRequest};
 
     #[test]
     fn terminal_title_truncation_preserves_utf8_boundaries() {
@@ -4297,72 +4373,53 @@ mod tests {
     }
 
     #[test]
-    fn is_safe_browser_url_accepts_navigable_schemes() {
-        // Web + email only — see the rationale on `is_safe_browser_url`.
-        for url in [
-            "https://example.com",
-            "https://example.com/path?x=1&y=2",
-            "http://example.com",
-            "http://localhost:8080/foo",
-            "mailto:user@example.com",
-            "mailto:user@example.com?subject=hi",
-        ] {
-            assert!(is_safe_browser_url(url), "should accept {url}");
-        }
+    fn preferred_browser_tab_uses_active_browser_then_first_browser() {
+        let tabs = [
+            ("terminal", false),
+            ("browser-1", true),
+            ("browser-2", true),
+        ];
+
+        assert_eq!(
+            preferred_browser_tab_id(Some("browser-2"), tabs),
+            Some("browser-2")
+        );
+        assert_eq!(
+            preferred_browser_tab_id(Some("terminal"), tabs),
+            Some("browser-1")
+        );
+        assert_eq!(preferred_browser_tab_id(None, [("terminal", false)]), None);
     }
 
     #[test]
-    fn is_safe_browser_url_is_scheme_case_insensitive() {
-        // RFC 3986 §3.1: scheme matching is case-insensitive. OSC 8 hyperlinks
-        // sometimes preserve the original case from upstream sources, so we
-        // must not reject syntactically valid uppercase/mixed-case schemes.
-        for url in [
-            "HTTPS://example.com",
-            "Https://example.com",
-            "HTTP://example.com",
-            "MAILTO:user@example.com",
-        ] {
-            assert!(is_safe_browser_url(url), "should accept {url}");
-        }
-    }
-
-    #[test]
-    fn is_safe_browser_url_rejects_unsupported_or_dangerous_schemes() {
-        // Threat model: hostile terminal output can craft any OSC 8 hyperlink.
-        // The schemes below are either classic XSS sinks (`javascript:`,
-        // `data:`, `vbscript:`), gvfs auto-mount + exec vectors
-        // (`smb:`, `nfs:`, `dav:`, `davs:`, `sftp:`, `ftp:`, `ftps:`), local
-        // RCE via the file handler (`file:`), or app-specific URIs whose
-        // handlers have a history of RCE CVEs (`vscode:`, `slack:`, etc.).
-        // Leading whitespace and bare paths are also rejected as malformed.
-        for url in [
-            "javascript:alert(1)",
-            "JavaScript:alert(1)",
-            "data:text/html,<script>alert(1)</script>",
-            "vbscript:msgbox(1)",
-            "file:///etc/passwd",
-            "File:///home/manu/notes.md",
-            "ftp://ftp.example.com/pub/file",
-            "ftps://ftp.example.com/pub/file",
-            "smb://server/share",
-            "nfs://server/export",
-            "dav://server/path",
-            "davs://server/path",
-            "sftp://user@host/path",
-            "ssh://user@host",
-            "magnet:?xt=urn:btih:abc",
-            "chrome://settings",
-            "about:blank",
-            "vscode://file/path",
-            "slack://open?team=T",
-            "  https://example.com",
-            "/etc/passwd",
-            "example.com",
-            "",
-            "https:",
-            "http:/example.com",
-        ] {
-            assert!(!is_safe_browser_url(url), "should reject {url:?}");
-        }
+    fn resolved_link_destination_honors_config_and_keeps_mailto_external() {
+        assert_eq!(
+            resolved_link_destination(
+                LinkOpenDestination::BrowserTab,
+                LinkOpenRequest::Configured,
+                "https://example.com",
+            ),
+            Some(if cfg!(feature = "webkit") {
+                LinkOpenDestination::BrowserTab
+            } else {
+                LinkOpenDestination::DefaultBrowser
+            })
+        );
+        assert_eq!(
+            resolved_link_destination(
+                LinkOpenDestination::DefaultBrowser,
+                LinkOpenRequest::Destination(LinkOpenDestination::BrowserTab),
+                "mailto:user@example.com",
+            ),
+            Some(LinkOpenDestination::DefaultBrowser)
+        );
+        assert_eq!(
+            resolved_link_destination(
+                LinkOpenDestination::DefaultBrowser,
+                LinkOpenRequest::Configured,
+                "file:///etc/passwd",
+            ),
+            None
+        );
     }
 }

--- a/rust/limux-host-linux/src/settings_editor.rs
+++ b/rust/limux-host-linux/src/settings_editor.rs
@@ -333,6 +333,7 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
             .borrow()
             .links
             .open_destination
+            .effective(cfg!(feature = "webkit"))
             .dropdown_index(),
     );
     link_destination_dropdown.set_sensitive(cfg!(feature = "webkit"));

--- a/rust/limux-host-linux/src/settings_editor.rs
+++ b/rust/limux-host-linux/src/settings_editor.rs
@@ -5,7 +5,9 @@ use adw::prelude::*;
 use gtk4 as gtk;
 use libadwaita as adw;
 
-use crate::app_config::{AppConfig, ColorScheme, NotificationSound, UiScale, DEFAULT_UI_SCALE};
+use crate::app_config::{
+    AppConfig, ColorScheme, LinkOpenDestination, NotificationSound, UiScale, DEFAULT_UI_SCALE,
+};
 use crate::keybind_editor;
 use crate::shortcut_config::{NormalizedShortcut, ResolvedShortcutConfig, ShortcutId};
 
@@ -317,6 +319,28 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
     auto_copy_row.set_activatable_widget(Some(&auto_copy_switch));
     group.add(&auto_copy_row);
 
+    let link_destination_row = adw::ActionRow::builder()
+        .title("Open links in")
+        .subtitle("Choose whether terminal links open outside Limux or in a browser tab")
+        .build();
+    link_destination_row.set_title_lines(1);
+    link_destination_row.set_subtitle_lines(2);
+    let link_destination_dropdown =
+        gtk::DropDown::from_strings(&["Default browser", "Browser tab"]);
+    link_destination_dropdown.set_selected(
+        input
+            .config
+            .borrow()
+            .links
+            .open_destination
+            .dropdown_index(),
+    );
+    link_destination_dropdown.set_sensitive(cfg!(feature = "webkit"));
+    link_destination_dropdown.set_valign(gtk::Align::Center);
+    link_destination_row.add_suffix(&link_destination_dropdown);
+    link_destination_row.set_activatable_widget(Some(&link_destination_dropdown));
+    group.add(&link_destination_row);
+
     let scale_row = adw::ActionRow::builder()
         .title("Interface scale")
         .subtitle("Scale Limux sidebar, pane header, and settings text")
@@ -428,6 +452,28 @@ fn build_general_page(input: &SettingsEditorInput) -> gtk::Widget {
             apply_config_change(&config, &*on_changed, move |c| {
                 c.clipboard.copy_selection_to_clipboard = copy_selection_to_clipboard;
             });
+        });
+    }
+    {
+        let config = input.config.clone();
+        let on_changed = input.on_config_changed.clone();
+        let syncing = Rc::new(Cell::new(false));
+        link_destination_dropdown.connect_selected_notify(move |dropdown| {
+            if syncing.get() {
+                return;
+            }
+            let destination = LinkOpenDestination::from_dropdown_index(dropdown.selected());
+            let effective = apply_config_change(&config, &*on_changed, move |c| {
+                c.links.open_destination = destination;
+            })
+            .links
+            .open_destination
+            .dropdown_index();
+            if dropdown.selected() != effective {
+                syncing.set(true);
+                dropdown.set_selected(effective);
+                syncing.set(false);
+            }
         });
     }
     {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -446,7 +446,7 @@ impl TerminalHandle {
             return Some(String::new());
         }
 
-        let bytes = unsafe { std::slice::from_raw_parts(text.text as *const u8, text.text_len) };
+        let bytes = unsafe { std::slice::from_raw_parts(text.text.cast::<u8>(), text.text_len) };
         let output = String::from_utf8_lossy(bytes).into_owned();
         unsafe { ghostty_surface_free_text(surface, &mut text) };
         Some(output)
@@ -518,7 +518,7 @@ impl TerminalHandle {
             return String::new();
         }
 
-        let bytes = unsafe { std::slice::from_raw_parts(text.text as *const u8, text.text_len) };
+        let bytes = unsafe { std::slice::from_raw_parts(text.text.cast::<u8>(), text.text_len) };
         let selection = String::from_utf8_lossy(bytes).into_owned();
         unsafe { ghostty_surface_free_text(surface, &mut text) };
         selection

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 
 use limux_ghostty_sys::*;
 
+use crate::app_config::LinkOpenDestination;
+use crate::link_uri;
 use crate::shortcut_config::NormalizedShortcut;
 
 // ---------------------------------------------------------------------------
@@ -41,10 +43,16 @@ type TitleChangedCallback = dyn Fn(&str);
 type PwdChangedCallback = dyn Fn(&str);
 type DesktopNotificationCallback = dyn Fn(&str, &str, bool);
 type BellCallback = dyn Fn(bool);
-type OpenUrlCallback = dyn Fn(&str, bool);
+type OpenUrlCallback = dyn Fn(&str, LinkOpenRequest);
 type VoidCallback = dyn Fn();
 type WidgetCallback = dyn Fn(&gtk::Widget);
 type IdentityCallback = dyn Fn() -> TerminalIdentity;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinkOpenRequest {
+    Configured,
+    Destination(LinkOpenDestination),
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TerminalIdentity {
@@ -70,9 +78,8 @@ struct SurfaceEntry {
     on_pwd_changed: Option<Box<PwdChangedCallback>>,
     on_desktop_notification: Option<Box<DesktopNotificationCallback>>,
     on_bell: Option<Box<BellCallback>>,
-    on_open_url: Option<Box<OpenUrlCallback>>,
+    on_open_url: Option<Rc<OpenUrlCallback>>,
     on_close: Option<Box<VoidCallback>>,
-    open_url_external: Rc<Cell<bool>>,
     clipboard_context: *mut ClipboardContext,
     // Hover URL preview for OSC 8 hyperlinks. The popover is a child of
     // `gl_area` so it inherits libadwaita's popover styling — matching the
@@ -1014,21 +1021,19 @@ unsafe extern "C" fn ghostty_action_cb(
                 let surface_key = unsafe { target.target.surface } as usize;
                 let open_url = unsafe { action.action.open_url };
                 if let Some(url) = ghostty_open_url_to_string(open_url) {
-                    let external = SURFACE_MAP.with(|map| {
-                        map.borrow()
-                            .get(&surface_key)
-                            .map(|entry| entry.open_url_external.get())
-                            .unwrap_or(false)
-                    });
-                    glib::idle_add_local_once(move || {
-                        SURFACE_MAP.with(|map| {
-                            if let Some(entry) = map.borrow().get(&surface_key) {
-                                if let Some(cb) = &entry.on_open_url {
-                                    cb(&url, external);
-                                }
+                    if let Some(identity) = current_surface_identity(surface_key) {
+                        glib::idle_add_local_once(move || {
+                            let callback = SURFACE_MAP.with(|map| {
+                                let map = map.borrow();
+                                map.get(&surface_key)
+                                    .filter(|entry| entry.identity == identity)
+                                    .and_then(|entry| entry.on_open_url.clone())
+                            });
+                            if let Some(callback) = callback {
+                                callback(&url, LinkOpenRequest::Configured);
                             }
                         });
-                    });
+                    }
                 }
             }
             true
@@ -1462,7 +1467,6 @@ pub fn create_terminal(
     let shutting_down = Rc::new(Cell::new(false));
     let had_focus = Rc::new(Cell::new(false));
     let scrollbar_syncing = Rc::new(Cell::new(false));
-    let open_url_external = Rc::new(Cell::new(false));
     let clipboard_context_cell: Rc<Cell<*mut ClipboardContext>> =
         Rc::new(Cell::new(ptr::null_mut()));
     let cursor_pos: Rc<Cell<(f64, f64)>> = Rc::new(Cell::new((0.0, 0.0)));
@@ -1603,7 +1607,6 @@ pub fn create_terminal(
         let had_focus = had_focus.clone();
         let clipboard_context_cell = clipboard_context_cell.clone();
         let scrollbar_syncing = scrollbar_syncing.clone();
-        let open_url_external_for_map = open_url_external.clone();
         let extra_env = extra_env.clone();
         let shutting_down = shutting_down.clone();
         let handler = gl_area.connect_realize(move |gl_area| {
@@ -1762,11 +1765,11 @@ pub fn create_terminal(
                                 (callbacks.on_bell)(source_focused);
                             }
                         })),
-                        on_open_url: Some(Box::new({
+                        on_open_url: Some(Rc::new({
                             let cb = callbacks.clone();
-                            move |url, external| {
+                            move |url, destination| {
                                 let callbacks = cb.borrow();
-                                (callbacks.on_open_url)(url, external);
+                                (callbacks.on_open_url)(url, destination);
                             }
                         })),
                         on_close: Some(Box::new({
@@ -1776,7 +1779,6 @@ pub fn create_terminal(
                                 (callbacks.on_close)();
                             }
                         })),
-                        open_url_external: open_url_external_for_map.clone(),
                         clipboard_context,
                         link_popover: link_popover_for_map.clone(),
                         link_label: link_label_for_map.clone(),
@@ -1937,8 +1939,6 @@ pub fn create_terminal(
     // Mouse buttons (also handles click-to-focus) — skip right-click (handled below)
     {
         let surface_cell = surface_cell.clone();
-        let open_url_external_for_press = open_url_external.clone();
-        let open_url_external_for_release = open_url_external.clone();
         let click = gtk::GestureClick::new();
         click.set_button(0); // all buttons
         let sc = surface_cell.clone();
@@ -1961,9 +1961,7 @@ pub fn create_terminal(
                 let mods = translate_mouse_mods(gesture.current_event_state());
                 unsafe {
                     ghostty_surface_mouse_pos(surface, x, y, mods);
-                    open_url_external_for_press.set(mods & GHOSTTY_MODS_CTRL != 0);
                     ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, button, mods);
-                    open_url_external_for_press.set(false);
                 }
             }
         });
@@ -1982,9 +1980,7 @@ pub fn create_terminal(
                 let mods = translate_mouse_mods(gesture.current_event_state());
                 unsafe {
                     ghostty_surface_mouse_pos(surface, x, y, mods);
-                    open_url_external_for_release.set(mods & GHOSTTY_MODS_CTRL != 0);
                     ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, button, mods);
-                    open_url_external_for_release.set(false);
                 }
             }
         });
@@ -2281,6 +2277,31 @@ fn build_popover_inner_box() -> gtk::Box {
     menu_box
 }
 
+fn build_submenu_button(label: &str, popover: &gtk::Popover) -> gtk::MenuButton {
+    let button = gtk::MenuButton::new();
+    button.set_label(label);
+    button.set_direction(gtk::ArrowType::Right);
+    button.set_has_frame(false);
+    button.set_halign(gtk::Align::Fill);
+    button.set_popover(Some(popover));
+    button.add_css_class("flat");
+
+    let weak_button = button.downgrade();
+    let motion = gtk::EventControllerMotion::new();
+    motion.connect_enter(move |motion, _, _| {
+        if motion
+            .widget()
+            .is_some_and(|widget| widget_has_native_surface(&widget))
+        {
+            if let Some(button) = weak_button.upgrade() {
+                button.popup();
+            }
+        }
+    });
+    button.add_controller(motion);
+    button
+}
+
 fn show_terminal_context_menu(
     gl_area: &gtk::GLArea,
     overlay: &gtk::Overlay,
@@ -2290,6 +2311,10 @@ fn show_terminal_context_menu(
     y: f64,
     mods: c_int,
 ) {
+    if !widget_has_native_surface(gl_area) {
+        return;
+    }
+
     let menu_box = build_popover_inner_box();
     let url = url_at_position(surface, x, y, mods);
 
@@ -2300,6 +2325,9 @@ fn show_terminal_context_menu(
     let mut items: Vec<(&str, bool)> = vec![("Copy", has_selection)];
     if url.is_some() {
         items.push(("Copy URL", true));
+    }
+    if url.as_deref().is_some_and(link_uri::is_safe_external_url) {
+        items.push(("Open in", true));
     }
     items.extend([
         ("Paste", true),
@@ -2336,6 +2364,33 @@ fn show_terminal_context_menu(
         ids_box.append(btn);
     }
     ids_popover.set_child(Some(&ids_box));
+    let ids_menu_button = build_submenu_button("IDs", &ids_popover);
+
+    let open_in_popover = gtk::Popover::new();
+    open_in_popover.set_has_arrow(false);
+    open_in_popover.set_position(gtk::PositionType::Right);
+    let open_in_box = build_popover_inner_box();
+    let open_default_browser_btn = gtk::Button::with_label("Default browser");
+    let open_browser_tab_btn = gtk::Button::with_label("Browser tab");
+    open_browser_tab_btn.set_sensitive(
+        cfg!(feature = "webkit")
+            && url
+                .as_deref()
+                .is_some_and(link_uri::is_embedded_browser_url),
+    );
+    for btn in [&open_default_browser_btn, &open_browser_tab_btn] {
+        btn.add_css_class("flat");
+        btn.set_halign(gtk::Align::Fill);
+        if let Some(label) = btn
+            .child()
+            .and_then(|child| child.downcast::<gtk::Label>().ok())
+        {
+            label.set_xalign(0.0);
+        }
+        open_in_box.append(btn);
+    }
+    open_in_popover.set_child(Some(&open_in_box));
+    let open_in_menu_button = build_submenu_button("Open in…", &open_in_popover);
 
     for (label, enabled) in &items {
         if *label == "---" {
@@ -2346,32 +2401,21 @@ fn show_terminal_context_menu(
             continue;
         }
 
-        let btn = gtk::Button::with_label(if *label == "IDs" { "IDs >" } else { label });
+        if *label == "IDs" {
+            menu_box.append(&ids_menu_button);
+            continue;
+        }
+        if *label == "Open in" {
+            menu_box.append(&open_in_menu_button);
+            continue;
+        }
+
+        let btn = gtk::Button::with_label(label);
         btn.add_css_class("flat");
         btn.set_sensitive(*enabled);
         btn.set_halign(gtk::Align::Fill);
         if let Some(lbl) = btn.child().and_then(|c| c.downcast::<gtk::Label>().ok()) {
             lbl.set_xalign(0.0);
-        }
-        if *label == "IDs" {
-            ids_popover.set_parent(&btn);
-            let ids_popover_for_motion = ids_popover.clone();
-            let motion = gtk::EventControllerMotion::new();
-            motion.connect_enter(move |motion, _, _| {
-                if motion
-                    .widget()
-                    .is_some_and(|widget| widget_has_native_surface(&widget))
-                {
-                    ids_popover_for_motion.popup();
-                }
-            });
-            btn.add_controller(motion);
-            let ids_popover_for_click = ids_popover.clone();
-            btn.connect_clicked(move |btn| {
-                if widget_has_native_surface(btn) {
-                    ids_popover_for_click.popup();
-                }
-            });
         }
         menu_box.append(&btn);
     }
@@ -2384,16 +2428,16 @@ fn show_terminal_context_menu(
     while let Some(widget) = child {
         if let Some(btn) = widget.downcast_ref::<gtk::Button>() {
             let label = btn.label().unwrap_or_default().to_string();
-            let pop = popover.clone();
+            let pop = popover.downgrade();
             let cb = callbacks.clone();
             let gl_area = gl_area.clone();
             let url = url.clone();
             let overlay = overlay.clone();
 
             btn.connect_clicked(move |_| {
-                if label == "IDs >" {
+                let Some(pop) = pop.upgrade() else {
                     return;
-                }
+                };
                 pop.popdown();
                 match label.as_str() {
                     "Copy" => surface_action(surface, "copy_to_clipboard"),
@@ -2432,9 +2476,33 @@ fn show_terminal_context_menu(
         child = widget.next_sibling();
     }
 
+    for (button, destination) in [
+        (
+            open_default_browser_btn,
+            LinkOpenDestination::DefaultBrowser,
+        ),
+        (open_browser_tab_btn, LinkOpenDestination::BrowserTab),
+    ] {
+        let pop = popover.downgrade();
+        let open_in_pop = open_in_popover.downgrade();
+        let callbacks = callbacks.clone();
+        let url = url.clone();
+        button.connect_clicked(move |_| {
+            if let Some(open_in_pop) = open_in_pop.upgrade() {
+                open_in_pop.popdown();
+            }
+            if let Some(pop) = pop.upgrade() {
+                pop.popdown();
+            }
+            if let Some(url) = url.as_deref() {
+                (callbacks.borrow().on_open_url)(url, LinkOpenRequest::Destination(destination));
+            }
+        });
+    }
+
     {
-        let pop = popover.clone();
-        let ids_pop = ids_popover.clone();
+        let pop = popover.downgrade();
+        let ids_pop = ids_popover.downgrade();
         let overlay = overlay.clone();
         let workspace_id = identity.workspace_id.clone();
         copy_workspace_btn.connect_clicked(move |_| {
@@ -2442,33 +2510,51 @@ fn show_terminal_context_menu(
                 copy_text_to_clipboards(workspace_id);
                 show_clipboard_toast(&overlay);
             }
-            ids_pop.popdown();
-            pop.popdown();
+            if let Some(ids_pop) = ids_pop.upgrade() {
+                ids_pop.popdown();
+            }
+            if let Some(pop) = pop.upgrade() {
+                pop.popdown();
+            }
         });
     }
 
     {
-        let pop = popover.clone();
-        let ids_pop = ids_popover.clone();
+        let pop = popover.downgrade();
+        let ids_pop = ids_popover.downgrade();
         let overlay = overlay.clone();
         let surface_id = identity.surface_id.clone();
         copy_surface_btn.connect_clicked(move |_| {
             copy_text_to_clipboards(&surface_id);
             show_clipboard_toast(&overlay);
-            ids_pop.popdown();
-            pop.popdown();
+            if let Some(ids_pop) = ids_pop.upgrade() {
+                ids_pop.popdown();
+            }
+            if let Some(pop) = pop.upgrade() {
+                pop.popdown();
+            }
         });
     }
 
     {
-        let ids_popover = ids_popover.clone();
+        let ids_menu_button = ids_menu_button.clone();
+        let open_in_menu_button = open_in_menu_button.clone();
         popover.connect_closed(move |p| {
-            ids_popover.popdown();
+            ids_menu_button.popdown();
+            ids_menu_button.set_popover(None::<&gtk::Popover>);
+            open_in_menu_button.popdown();
+            open_in_menu_button.set_popover(None::<&gtk::Popover>);
             p.unparent();
         });
     }
 
-    popover.popup();
+    if widget_has_native_surface(gl_area) {
+        popover.popup();
+    } else {
+        ids_menu_button.set_popover(None::<&gtk::Popover>);
+        open_in_menu_button.set_popover(None::<&gtk::Popover>);
+        popover.unparent();
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -5288,9 +5288,7 @@ fn split_pane(
 
 fn open_url_in_browser_tab(state: &State, ws_id: &str, pane_widget: &gtk::Widget, url: &str) {
     if let Some(right_pane) = pane_in_direction(state, pane_widget, Direction::Right) {
-        if !pane::open_url_in_existing_browser_tab(&right_pane, url) {
-            pane::add_browser_tab_to_pane_with_uri(&right_pane, Some(url));
-        }
+        pane::add_browser_tab_to_pane_with_uri(&right_pane, Some(url));
         return;
     }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -4707,6 +4707,7 @@ pub(crate) fn create_pane_for_workspace(
     let state_for_close = state.clone();
     let state_for_bell = state.clone();
     let state_for_desktop_notification = state.clone();
+    let state_for_open_url = state.clone();
     let state_for_keybinds = state.clone();
     let state_for_pwd = state.clone();
     let state_for_empty = state.clone();
@@ -4716,6 +4717,7 @@ pub(crate) fn create_pane_for_workspace(
     let ws_id_close = ws_id.to_string();
     let ws_id_bell = ws_id.to_string();
     let ws_id_desktop_notification = ws_id.to_string();
+    let ws_id_open_url = ws_id.to_string();
     let ws_id_pwd = ws_id.to_string();
     let ws_id_empty = ws_id.to_string();
     let ws_id_unread = ws_id.to_string();
@@ -4788,6 +4790,9 @@ pub(crate) fn create_pane_for_workspace(
         ),
         on_open_browser_here: Box::new(move |pane_widget| {
             pane::add_browser_tab_to_pane(pane_widget);
+        }),
+        on_open_url_in_browser: Box::new(move |pane_widget, url| {
+            open_url_in_browser_tab(&state_for_open_url, &ws_id_open_url, pane_widget, url);
         }),
         on_open_keybinds: Box::new(move |anchor| {
             open_keybind_editor_tab(&state_for_keybinds, anchor);
@@ -5281,6 +5286,32 @@ fn split_pane(
     Some(new_pane.upcast())
 }
 
+fn open_url_in_browser_tab(state: &State, ws_id: &str, pane_widget: &gtk::Widget, url: &str) {
+    if let Some(right_pane) = pane_in_direction(state, pane_widget, Direction::Right) {
+        if !pane::open_url_in_existing_browser_tab(&right_pane, url) {
+            pane::add_browser_tab_to_pane_with_uri(&right_pane, Some(url));
+        }
+        return;
+    }
+
+    if split_pane(
+        state,
+        ws_id,
+        pane_widget,
+        gtk::Orientation::Horizontal,
+        SplitPaneOptions {
+            initial_state: Some(PaneState::browser_only(Some(url))),
+            skip_default_tab: false,
+            new_pane_first: false,
+            persist: true,
+        },
+    )
+    .is_none()
+    {
+        pane::add_browser_tab_to_pane_with_uri(pane_widget, Some(url));
+    }
+}
+
 fn remove_pane(state: &State, ws_id: &str, pane_widget: &gtk::Widget) {
     remove_pane_internal(state, ws_id, pane_widget, true);
 }
@@ -5702,6 +5733,20 @@ fn focus_pane_in_direction(state: &State, direction: Direction) {
         Some(v) => v,
         None => return,
     };
+
+    let Some(leaf) = pane_in_direction(state, &pane_widget, direction) else {
+        return;
+    };
+    if let Some(gl) = find_gl_area(&leaf) {
+        gl.grab_focus();
+    }
+}
+
+fn pane_in_direction(
+    state: &State,
+    pane_widget: &gtk::Widget,
+    direction: Direction,
+) -> Option<gtk::Widget> {
     let root = state.borrow().window.clone().upcast::<gtk::Widget>();
 
     // Determine which axis and sides we care about.
@@ -5716,10 +5761,7 @@ fn focus_pane_in_direction(state: &State, direction: Direction) {
     // orientation where the current subtree is on the correct side.
     let mut current: gtk::Widget = pane_widget.clone();
     loop {
-        let parent = match current.parent() {
-            Some(p) => p,
-            None => return, // reached the top without finding a valid split
-        };
+        let parent = current.parent()?;
         if let Some(paned) = parent.downcast_ref::<gtk::Paned>() {
             if paned.orientation() == target_orientation {
                 let is_start = paned.start_child().map(|c| c == current).unwrap_or(false);
@@ -5731,20 +5773,15 @@ fn focus_pane_in_direction(state: &State, direction: Direction) {
                         paned.start_child()
                     };
                     if let Some(sibling) = sibling {
-                        let leaf =
-                            best_directional_leaf_pane(&pane_widget, &sibling, &root, direction)
+                        return Some(
+                            best_directional_leaf_pane(pane_widget, &sibling, &root, direction)
                                 .unwrap_or_else(|| {
-                                    // Fall back to the old edge-based heuristic if bounds
-                                    // are unavailable for some reason.
                                     let prefer_start = !must_be_start;
                                     find_leaf_pane(&sibling, target_orientation, prefer_start)
-                                });
-                        // Find the GLArea inside the pane and focus it directly
-                        if let Some(gl) = find_gl_area(&leaf) {
-                            gl.grab_focus();
-                        }
+                                }),
+                        );
                     }
-                    return;
+                    return None;
                 }
             }
         }

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -5287,27 +5287,27 @@ fn split_pane(
 }
 
 fn open_url_in_browser_tab(state: &State, ws_id: &str, pane_widget: &gtk::Widget, url: &str) {
-    if let Some(right_pane) = pane_in_direction(state, pane_widget, Direction::Right) {
-        pane::add_browser_tab_to_pane_with_uri(&right_pane, Some(url));
-        return;
-    }
-
-    if split_pane(
-        state,
-        ws_id,
+    let right_pane = pane_in_direction(state, pane_widget, Direction::Right);
+    crate::browser_link::open_in_right_pane(
         pane_widget,
-        gtk::Orientation::Horizontal,
-        SplitPaneOptions {
-            initial_state: Some(PaneState::browser_only(Some(url))),
-            skip_default_tab: false,
-            new_pane_first: false,
-            persist: true,
+        right_pane.as_ref(),
+        || {
+            split_pane(
+                state,
+                ws_id,
+                pane_widget,
+                gtk::Orientation::Horizontal,
+                SplitPaneOptions {
+                    initial_state: Some(PaneState::browser_only(Some(url))),
+                    skip_default_tab: false,
+                    new_pane_first: false,
+                    persist: true,
+                },
+            )
+            .is_some()
         },
-    )
-    .is_none()
-    {
-        pane::add_browser_tab_to_pane_with_uri(pane_widget, Some(url));
-    }
+        |target| pane::add_browser_tab_to_pane_with_uri(target, Some(url)),
+    );
 }
 
 fn remove_pane(state: &State, ws_id: &str, pane_widget: &gtk::Widget) {


### PR DESCRIPTION
## Summary

- add a persisted "Open links in" setting with Default browser as the default and Browser tab as the embedded option
- add an "Open in…" URL context submenu for explicit Default browser and Browser tab choices
- open embedded links in a fresh Limux browser tab in the pane to the right, creating that pane when needed and preserving existing pages
- preserve the HTTP/HTTPS/mailto allowlist, keep mailto external, and harden popover and queued-callback lifecycles

## Testing

- `./scripts/check.sh`
- `LD_LIBRARY_PATH="$PWD/ghostty/zig-out/lib" cargo test -p limux-host-linux --no-default-features resolved_link_destination_honors_config_and_keeps_mailto_external`
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`
