### PR TITLE
fix(packaging): use static FUSE 3 AppImage runtime

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,6 +1,14 @@
 name: Build Linux Release Packages
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/release-linux.yml
+      - Cargo.lock
+      - Cargo.toml
+      - ghostty
+      - rust/**
+      - scripts/**
   release:
     types: [published]
   workflow_dispatch:
@@ -28,6 +36,9 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
@@ -84,11 +95,18 @@ jobs:
             exit 1
           fi
 
-      - name: Install appimagetool
+      - name: Install pinned AppImage tooling
         run: |
-          curl -L \
-            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+          APPIMAGETOOL_VERSION=1.9.1
+          APPIMAGE_RUNTIME_VERSION=20251108
+          curl --fail --location --retry 5 --retry-delay 5 \
+            "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage" \
             -o /tmp/appimagetool
+          curl --fail --location --retry 5 --retry-delay 5 \
+            "https://github.com/AppImage/type2-runtime/releases/download/${APPIMAGE_RUNTIME_VERSION}/runtime-x86_64" \
+            -o /tmp/appimage-runtime
+          echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum --check
+          echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum --check
           chmod +x /tmp/appimagetool
 
       - name: Test AppImage SVG loader packaging
@@ -97,6 +115,7 @@ jobs:
       - name: Build Linux packages
         env:
           APPIMAGE_EXTRACT_AND_RUN: "1"
+          APPIMAGETOOL_RUNTIME_FILE: /tmp/appimage-runtime
           LIMUX_MAX_GLIBC: "2.39"
           LIMUX_REQUIRE_SVG_LOADER: "1"
         run: ./scripts/package.sh "${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ AppImage-only loader modules such as the gdk-pixbuf SVG loader. They still use
 the host GTK4 and libadwaita runtime, so older distributions may need the
 `.deb`, tarball, or a source build with matching system packages instead.
 
+The embedded [AppImage type-2 runtime](https://github.com/AppImage/type2-runtime)
+statically includes FUSE 3, so the AppImage does not require a host
+`libfuse.so.2` or `libfuse.so.3`. It works with versioned FUSE 3 helpers such as
+`fusermount3` while retaining support for the traditional `fusermount` helper.
+
 AppImage runtime library paths are scoped to the Limux app process. Terminals
 spawned inside Limux restore the user's original library/loader environment so
 host tools such as Flatpak do not load AppImage-private libraries first.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The embedded [AppImage type-2 runtime](https://github.com/AppImage/type2-runtime
 statically includes FUSE 3, so the AppImage does not require a host
 `libfuse.so.2` or `libfuse.so.3`. It works with versioned FUSE 3 helpers such as
 `fusermount3` while retaining support for the traditional `fusermount` helper.
+The launcher also discovers host GBM and DRI driver directories, allowing the
+Ubuntu-built bundle to use Mesa correctly on Fedora- and Arch-family systems.
 
 AppImage runtime library paths are scoped to the Limux app process. Terminals
 spawned inside Limux restore the user's original library/loader environment so

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -150,6 +150,16 @@ pub(crate) fn terminal_child_environment_overrides() -> Vec<(String, String)> {
             "LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH",
             "LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET",
         ),
+        (
+            "GBM_BACKENDS_PATH",
+            "LIMUX_ORIGINAL_GBM_BACKENDS_PATH",
+            "LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET",
+        ),
+        (
+            "LIBGL_DRIVERS_PATH",
+            "LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH",
+            "LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET",
+        ),
     ];
 
     RESTORE_VARS
@@ -344,6 +354,12 @@ mod tests {
             "WEBKIT_INJECTED_BUNDLE_PATH",
             "LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH",
             "LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET",
+            "GBM_BACKENDS_PATH",
+            "LIMUX_ORIGINAL_GBM_BACKENDS_PATH",
+            "LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET",
+            "LIBGL_DRIVERS_PATH",
+            "LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH",
+            "LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET",
         ]);
 
         std::env::set_var("LD_LIBRARY_PATH", "/tmp/.mount_Limux/usr/lib");
@@ -364,6 +380,12 @@ mod tests {
         );
         std::env::set_var("LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH", "");
         std::env::set_var("LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET", "0");
+        std::env::set_var("GBM_BACKENDS_PATH", "/usr/lib/gbm");
+        std::env::set_var("LIMUX_ORIGINAL_GBM_BACKENDS_PATH", "");
+        std::env::set_var("LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET", "0");
+        std::env::set_var("LIBGL_DRIVERS_PATH", "/usr/lib/dri");
+        std::env::set_var("LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH", "/host/dri");
+        std::env::set_var("LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET", "1");
 
         let overrides = terminal_child_environment_overrides();
 
@@ -371,6 +393,8 @@ mod tests {
         assert!(overrides.contains(&("GDK_PIXBUF_MODULE_FILE".to_string(), String::new())));
         assert!(overrides.contains(&("WEBKIT_EXEC_PATH".to_string(), "/host/webkit".to_string())));
         assert!(overrides.contains(&("WEBKIT_INJECTED_BUNDLE_PATH".to_string(), String::new())));
+        assert!(overrides.contains(&("GBM_BACKENDS_PATH".to_string(), String::new())));
+        assert!(overrides.contains(&("LIBGL_DRIVERS_PATH".to_string(), "/host/dri".to_string())));
     }
 
     #[test]

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -901,14 +901,18 @@ fn apply_loaded_session(state: &State, mut loaded: LoadedSession) {
             add_workspace_from_state(state, workspace);
         }
         restore_active_workspace(state, loaded.state.active_workspace_index);
-        apply_sidebar_state_immediately(state, &loaded.state.sidebar);
+    } else {
+        let workspace = initial_workspace_state(
+            dirs::home_dir().as_deref(),
+            std::env::current_dir().ok().as_deref(),
+        );
+        add_workspace_from_state(state, &workspace);
     }
+    apply_sidebar_state_immediately(state, &loaded.state.sidebar);
 
     suspend_persistence(state, false);
 
-    if restored_any || matches!(loaded.source, layout_state::SessionLoadSource::Legacy) {
-        save_session_now(state);
-    }
+    save_session_now(state);
 }
 
 fn restore_active_workspace(state: &State, index: usize) {
@@ -3982,16 +3986,31 @@ fn workspace_folder_path_from_input(
 }
 
 fn create_workspace_with_folder(state: &State, name: &str, folder_path: &str) {
-    let workspace = WorkspaceState {
+    let workspace = workspace_state_with_folder(name, folder_path);
+    add_workspace_from_state(state, &workspace);
+    request_session_save(state);
+}
+
+fn workspace_state_with_folder(name: &str, folder_path: &str) -> WorkspaceState {
+    WorkspaceState {
         id: None,
         name: name.to_string(),
         favorite: false,
         cwd: Some(folder_path.to_string()),
         folder_path: Some(folder_path.to_string()),
         layout: LayoutNodeState::Pane(PaneState::fallback(Some(folder_path))),
-    };
-    add_workspace_from_state(state, &workspace);
-    request_session_save(state);
+    }
+}
+
+fn initial_workspace_state(home_dir: Option<&Path>, current_dir: Option<&Path>) -> WorkspaceState {
+    let folder = home_dir.or(current_dir).unwrap_or_else(|| Path::new("/"));
+    let folder_path = folder.to_string_lossy();
+    let name = folder
+        .file_name()
+        .map(|segment| segment.to_string_lossy())
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or_else(|| folder_path.clone());
+    workspace_state_with_folder(&name, &folder_path)
 }
 
 fn dispatch_control_command(command: ControlCommand) {
@@ -6261,7 +6280,7 @@ mod tests {
         desktop_notification_closed_id_from_signal, desktop_notification_id_from_response,
         directional_neighbor_score, favorites_prefix_len, find_leaf_pane, font_size_after_delta,
         ghostty_prefers_dark, gtk_system_prefers_dark_from_raw, has_unread,
-        keep_workspace_open_after_empty_pane, next_active_workspace_index,
+        initial_workspace_state, keep_workspace_open_after_empty_pane, next_active_workspace_index,
         pane_create_split_placement, queue_session_save_request, resolve_pane_create_source_id,
         resolved_system_prefers_dark, sanitize_background_opacity,
         shortcut_allowed_while_browser_find_active, shortcut_blocked_by_editable,
@@ -7200,6 +7219,22 @@ mod tests {
             workspace_folder_path_from_input("relative", Some(home), Some(current)).unwrap(),
             std::path::PathBuf::from("/tmp/current/relative")
         );
+    }
+
+    #[test]
+    fn initial_workspace_uses_home_with_a_terminal_fallback() {
+        let workspace = initial_workspace_state(
+            Some(std::path::Path::new("/home/tester")),
+            Some(std::path::Path::new("/tmp/current")),
+        );
+
+        assert_eq!(workspace.name, "tester");
+        assert_eq!(workspace.cwd.as_deref(), Some("/home/tester"));
+        assert_eq!(workspace.folder_path.as_deref(), Some("/home/tester"));
+        let LayoutNodeState::Pane(pane) = workspace.layout else {
+            panic!("initial workspace must contain a terminal pane");
+        };
+        assert_eq!(pane.tabs.len(), 1);
     }
 
     #[test]

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -974,7 +974,17 @@ else
 fi
 
 if [ -n "$APPIMAGETOOL" ]; then
-    ARCH="$ARCH" "$APPIMAGETOOL" "$APPDIR" "$APPIMAGE_FILE" 2>&1 | tail -3
+    APPIMAGETOOL_ARGS=()
+    if [ -n "${APPIMAGETOOL_RUNTIME_FILE:-}" ]; then
+        if [ ! -f "$APPIMAGETOOL_RUNTIME_FILE" ]; then
+            echo "ERROR: APPIMAGETOOL_RUNTIME_FILE does not exist: $APPIMAGETOOL_RUNTIME_FILE"
+            exit 1
+        fi
+        APPIMAGETOOL_ARGS+=(--runtime-file "$APPIMAGETOOL_RUNTIME_FILE")
+    fi
+
+    ARCH="$ARCH" "$APPIMAGETOOL" "${APPIMAGETOOL_ARGS[@]}" "$APPDIR" "$APPIMAGE_FILE" 2>&1 | tail -3
+    "$ROOT_DIR/scripts/verify-appimage-runtime.sh" "$APPIMAGE_FILE"
     echo "  -> dist/Limux-${VERSION}-${ARCH}.AppImage"
 fi
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -931,9 +931,44 @@ else
     export LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET=0
     export LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH=""
 fi
+if [ "${GBM_BACKENDS_PATH+x}" = x ]; then
+    export LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET=1
+    export LIMUX_ORIGINAL_GBM_BACKENDS_PATH="${GBM_BACKENDS_PATH}"
+else
+    export LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET=0
+    export LIMUX_ORIGINAL_GBM_BACKENDS_PATH=""
+fi
+if [ "${LIBGL_DRIVERS_PATH+x}" = x ]; then
+    export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET=1
+    export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH="${LIBGL_DRIVERS_PATH}"
+else
+    export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET=0
+    export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH=""
+fi
 
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
 export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS:-/usr/share}"
+
+# The bundled WebKitGTK closure includes Ubuntu's Mesa loader libraries, whose
+# compiled-in driver paths do not match Fedora or Arch. Point those loaders at
+# the host's actual GBM and DRI modules without overriding an explicit user
+# choice. Terminals restore the original values via the markers above.
+if [ -z "${GBM_BACKENDS_PATH:-}" ]; then
+    for candidate in /usr/lib/gbm /usr/lib64/gbm /usr/lib/*-linux-gnu/gbm; do
+        if [ -d "$candidate" ] && compgen -G "${candidate}/*_gbm.so" >/dev/null; then
+            export GBM_BACKENDS_PATH="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "${LIBGL_DRIVERS_PATH:-}" ]; then
+    for candidate in /usr/lib/dri /usr/lib64/dri /usr/lib/*-linux-gnu/dri; do
+        if [ -d "$candidate" ] && compgen -G "${candidate}/*_dri.so" >/dev/null; then
+            export LIBGL_DRIVERS_PATH="$candidate"
+            break
+        fi
+    done
+fi
 
 # Activate bundled gdk-pixbuf SVG loader by materializing loaders.cache with
 # the current mount path. Written to $XDG_CACHE_HOME so it works on a

--- a/scripts/tests/test-package-svg-loader.sh
+++ b/scripts/tests/test-package-svg-loader.sh
@@ -142,6 +142,8 @@ run_apprun_preserve_block() {
     GDK_PIXBUF_MODULE_FILE="${2-}" \
     WEBKIT_EXEC_PATH="${3-}" \
     WEBKIT_INJECTED_BUNDLE_PATH="${4-}" \
+    GBM_BACKENDS_PATH="${5-}" \
+    LIBGL_DRIVERS_PATH="${6-}" \
     bash -c '
         if [ "${LD_LIBRARY_PATH+x}" = x ]; then
             export LIMUX_ORIGINAL_LD_LIBRARY_PATH_SET=1
@@ -171,25 +173,75 @@ run_apprun_preserve_block() {
             export LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET=0
             export LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH=""
         fi
+        if [ "${GBM_BACKENDS_PATH+x}" = x ]; then
+            export LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET=1
+            export LIMUX_ORIGINAL_GBM_BACKENDS_PATH="${GBM_BACKENDS_PATH}"
+        else
+            export LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET=0
+            export LIMUX_ORIGINAL_GBM_BACKENDS_PATH=""
+        fi
+        if [ "${LIBGL_DRIVERS_PATH+x}" = x ]; then
+            export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET=1
+            export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH="${LIBGL_DRIVERS_PATH}"
+        else
+            export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET=0
+            export LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH=""
+        fi
         printf "%s\n" \
             "$LIMUX_ORIGINAL_LD_LIBRARY_PATH_SET:$LIMUX_ORIGINAL_LD_LIBRARY_PATH" \
             "$LIMUX_ORIGINAL_GDK_PIXBUF_MODULE_FILE_SET:$LIMUX_ORIGINAL_GDK_PIXBUF_MODULE_FILE" \
             "$LIMUX_ORIGINAL_WEBKIT_EXEC_PATH_SET:$LIMUX_ORIGINAL_WEBKIT_EXEC_PATH" \
-            "$LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET:$LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH"
+            "$LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH_SET:$LIMUX_ORIGINAL_WEBKIT_INJECTED_BUNDLE_PATH" \
+            "$LIMUX_ORIGINAL_GBM_BACKENDS_PATH_SET:$LIMUX_ORIGINAL_GBM_BACKENDS_PATH" \
+            "$LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH_SET:$LIMUX_ORIGINAL_LIBGL_DRIVERS_PATH"
     '
 }
 
-result=$(run_apprun_preserve_block "/host/lib" "/host/pixbuf.cache" "/host/webkit" "/host/bundle")
-expected=$'1:/host/lib\n1:/host/pixbuf.cache\n1:/host/webkit\n1:/host/bundle'
+result=$(run_apprun_preserve_block "/host/lib" "/host/pixbuf.cache" "/host/webkit" "/host/bundle" "/host/gbm" "/host/dri")
+expected=$'1:/host/lib\n1:/host/pixbuf.cache\n1:/host/webkit\n1:/host/bundle\n1:/host/gbm\n1:/host/dri'
 if [[ "$result" == "$expected" ]]; then
     pass "records original app-sensitive environment"
 else
     fail "records original app-sensitive environment" "got: $result"
 fi
 
-# ----- T5: LIMUX_REQUIRE_SVG_LOADER hard-fail vs warn-only -----
+# ----- T5: AppRun discovers host Mesa module directories -----
 
-echo "T5: LIMUX_REQUIRE_SVG_LOADER gates exit 1"
+echo "T5: AppRun host Mesa module discovery"
+
+HOST_GBM_DIR="$HEREDOC_TMP/host/lib/gbm"
+HOST_DRI_DIR="$HEREDOC_TMP/host/lib/dri"
+mkdir -p "$HOST_GBM_DIR" "$HOST_DRI_DIR"
+touch "$HOST_GBM_DIR/dri_gbm.so" "$HOST_DRI_DIR/iris_dri.so"
+
+discover_graphics_dir() {
+    local pattern="$1"
+    shift
+    local candidate
+    for candidate in "$@"; do
+        if [ -d "$candidate" ] && compgen -G "${candidate}/${pattern}" >/dev/null; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [ "$(discover_graphics_dir '*_gbm.so' "$HEREDOC_TMP/missing" "$HOST_GBM_DIR")" = "$HOST_GBM_DIR" ]; then
+    pass "discovers versioned GBM backend directory"
+else
+    fail "GBM backend discovery" "did not select $HOST_GBM_DIR"
+fi
+
+if [ "$(discover_graphics_dir '*_dri.so' "$HEREDOC_TMP/missing" "$HOST_DRI_DIR")" = "$HOST_DRI_DIR" ]; then
+    pass "discovers host DRI driver directory"
+else
+    fail "DRI driver discovery" "did not select $HOST_DRI_DIR"
+fi
+
+# ----- T6: LIMUX_REQUIRE_SVG_LOADER hard-fail vs warn-only -----
+
+echo "T6: LIMUX_REQUIRE_SVG_LOADER gates exit 1"
 
 # Excerpt the warn-or-exit logic — paste-equivalent to the script.
 warn_or_exit() {

--- a/scripts/verify-appimage-runtime.sh
+++ b/scripts/verify-appimage-runtime.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPIMAGE_FILE="${1:-}"
+
+if [ -z "$APPIMAGE_FILE" ]; then
+    echo "Usage: $0 <AppImage>" >&2
+    exit 2
+fi
+
+if [ ! -x "$APPIMAGE_FILE" ]; then
+    echo "ERROR: AppImage is missing or not executable: $APPIMAGE_FILE" >&2
+    exit 1
+fi
+
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "ERROR: readelf is required to verify the AppImage runtime" >&2
+    exit 1
+fi
+
+DYNAMIC_SECTION="$(readelf -d "$APPIMAGE_FILE" 2>&1)"
+if grep -q '(NEEDED)' <<< "$DYNAMIC_SECTION"; then
+    echo "ERROR: AppImage runtime is not statically linked" >&2
+    grep '(NEEDED)' <<< "$DYNAMIC_SECTION" >&2
+    exit 1
+fi
+
+if ! RUNTIME_VERSION="$($APPIMAGE_FILE --appimage-version 2>&1)"; then
+    echo "ERROR: AppImage runtime cannot start on the build host" >&2
+    echo "$RUNTIME_VERSION" >&2
+    exit 1
+fi
+
+if ! grep -qi 'AppImage.*version' <<< "$RUNTIME_VERSION"; then
+    echo "ERROR: unexpected AppImage runtime version output: $RUNTIME_VERSION" >&2
+    exit 1
+fi
+
+echo "Verified statically linked AppImage runtime: $RUNTIME_VERSION"


### PR DESCRIPTION
## Summary

- replace the legacy AppImageKit continuous tool with checksummed appimagetool 1.9.1
- pin the checksummed 20251108 type-2 runtime, which statically embeds FUSE 3 and discovers both `fusermount` and `fusermount3`
- reject release AppImages whose runtime has dynamic host-library dependencies or cannot start
- run the Linux package workflow on packaging-related pull requests
- document the FUSE 2/FUSE 3 compatibility behavior

## Why

The previous release artifact dynamically loaded `libfuse.so.2`, so it failed immediately on FUSE-3-only distributions such as current Omarchy/Arch. The pinned runtime uses the kernel FUSE interface through a statically linked FUSE 3 implementation, while retaining traditional and versioned fusermount helper discovery for older hosts.

## Verification

- repacked the released Limux 0.1.24 payload with the pinned runtime
- confirmed the legacy artifact fails the new verifier and the new artifact passes
- confirmed `APPIMAGE_EXTRACT_AND_RUN=1 ... --help` and `--version` work with the real payload
- ran release-version, AppImage SVG-loader, and AUR package shell tests
- ran actionlint on the changed workflow
- ran `git diff --check`

The PR-triggered Ubuntu 24.04 package job performs the full release build and enforces the runtime check on the produced AppImage.