### PR TITLE
fix(host): honor Caps Lock Escape remaps

### DIFF
--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -2591,6 +2591,7 @@ fn translate_key_event(
     let consumed = key_event
         .map(translate_consumed_mods)
         .unwrap_or_else(|| fallback_consumed_mods(keyval, modifier));
+    let keycode = ghostty_keycode_with_caps_escape_remap(keyval, keycode);
 
     ghostty_input_key_s {
         action,
@@ -2600,6 +2601,20 @@ fn translate_key_event(
         text: ptr::null(),
         unshifted_codepoint: unshifted,
         composing: false,
+    }
+}
+
+fn ghostty_keycode_with_caps_escape_remap(keyval: gtk::gdk::Key, keycode: u32) -> u32 {
+    const XKB_KEYCODE_ESCAPE: u32 = 9;
+    const XKB_KEYCODE_CAPS_LOCK: u32 = 66;
+
+    // Embedded Ghostty derives its key from the XKB keycode and cannot see GTK's remapped keyval.
+    if keyval == gtk::gdk::Key::Escape {
+        XKB_KEYCODE_ESCAPE
+    } else if keyval == gtk::gdk::Key::Caps_Lock {
+        XKB_KEYCODE_CAPS_LOCK
+    } else {
+        keycode
     }
 }
 
@@ -2974,6 +2989,39 @@ mod tests {
             '-' as u32
         );
         assert_eq!(fallback_unshifted_codepoint(gtk::gdk::Key::A), 'a' as u32);
+    }
+
+    #[test]
+    fn key_translation_honors_caps_lock_escape_remaps() {
+        let modifiers = gtk::gdk::ModifierType::empty();
+        let caps_as_escape = translate_key_event(
+            GHOSTTY_ACTION_PRESS,
+            None,
+            None,
+            gtk::gdk::Key::Escape,
+            66,
+            modifiers,
+        );
+        let escape_as_caps = translate_key_event(
+            GHOSTTY_ACTION_PRESS,
+            None,
+            None,
+            gtk::gdk::Key::Caps_Lock,
+            9,
+            modifiers,
+        );
+        let writing_key = translate_key_event(
+            GHOSTTY_ACTION_PRESS,
+            None,
+            None,
+            gtk::gdk::Key::a,
+            38,
+            modifiers,
+        );
+
+        assert_eq!(caps_as_escape.keycode, 9);
+        assert_eq!(escape_as_caps.keycode, 66);
+        assert_eq!(writing_key.keycode, 38);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Honor Caps Lock-to-Escape XKB remaps in embedded terminal input.

Closes #152.

## Repro

1. Configure `caps:escape` or `caps:swapescape`.
2. Open Neovim in Limux and enter insert mode.
3. Press Caps Lock.

Before this change, Neovim stays in insert mode because embedded Ghostty receives physical Caps Lock keycode. After this change, it receives Escape.

## Changes

- normalize logical Escape and Caps Lock keyvals to canonical Linux XKB keycodes before Ghostty FFI call
- preserve physical keycodes for writing-system keys and all unrelated input
- cover both Caps-to-Escape and Escape-to-Caps directions with regression test

## Testing

- regression test fails before fix with Caps keycode 66 instead of Escape keycode 9
- `./scripts/check.sh`

## Did this cause any problems?

No known regressions. Revert this commit to restore previous key translation.
