### PR TITLE
fix(host): overlay terminal scrollbar to stop text jitter

### DIFF
--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -1496,12 +1496,21 @@ pub fn create_terminal(
     let scrollbar = gtk::Scrollbar::new(gtk::Orientation::Vertical, Some(&scrollbar_adjustment));
     scrollbar.set_visible(false);
     scrollbar.set_vexpand(true);
+    // The scrollbar must be an overlay child, not a sibling in the box below.
+    // Ghostty emits a SCROLLBAR action whenever `total > len` flips, and we
+    // toggle visibility in response. As a Box sibling that consumes layout
+    // width, showing/hiding it reallocated the GLArea, changed the terminal
+    // grid columns, and reflowed the text left/right — the "window bounces"
+    // flicker in issue #136. Overlaid, the terminal keeps its full width and
+    // the scrollbar just draws (or stops drawing) on top of it.
+    scrollbar.set_halign(gtk::Align::End);
+    scrollbar.set_valign(gtk::Align::Fill);
+    overlay.add_overlay(&scrollbar);
 
     let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     root.set_hexpand(true);
     root.set_vexpand(true);
     root.append(&overlay);
-    root.append(&scrollbar);
 
     let search_entry = gtk::SearchEntry::builder()
         .hexpand(true)


### PR DESCRIPTION
## Problem

Fixes #136 — intermittent window/text "bounce" jitter.

The terminal scrollbar was a **space-consuming sibling in a horizontal `gtk::Box`** in `create_terminal`. Ghostty emits a `GHOSTTY_ACTION_SCROLLBAR` callback whenever `total > len` flips, and the handler toggles the scrollbar's visibility. Because the scrollbar consumed layout width:

1. showing/hiding it reallocated the `Box`
2. the `GLArea` shrank/grew by the scrollbar width
3. `connect_resize` fired → `ghostty_surface_set_size` → terminal grid **columns** changed
4. Ghostty reflowed the grid and the text shifted left/right

When scrollback sat right at the `total == len` boundary, typing/scrolling/outputs kept flipping it, so the scrollbar (and text, effectively the window) bounced by the scrollbar width each frame. It's intermittent because it only triggers while content hovers at the boundary; interacting perturbs the buffer and restarts it.

The other editor/sidebar pages are unaffected because GTK4 `ScrolledWindow` defaults to overlay scrolling.

## Fix

Move the scrollbar into the `gtk::Overlay` (`halign End`, `valign Fill`) so toggling visibility draws over the terminal without changing its allocation — no resize, no grid reflow, no bounce. This matches how Ghostty's embedded-surface scrollbar is meant to be rendered by the host.

## Verification

- `cargo build -p limux-host-linux` (GTK4 + libadwaita + WebKitGTK + built Ghostty) — compiles and links clean.
- Host launched headfully; no GL/surface errors.