### PR TITLE
fix(host): pair Ghostty display realize with unrealize

### DIFF
--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -2188,6 +2188,15 @@ pub fn create_terminal(
             let Some(surface) = *surface_cell.borrow() else {
                 return;
             };
+            // Deliberately asymmetric with the realize path, which gates on
+            // `gl_area.error()`. GTK destroys this GL context once the
+            // unrealize handlers return, so the teardown must be forwarded
+            // either way. Holding the state realized after a failed
+            // `make_current` would make the next `connect_realize` suppress
+            // its own `display_realized`, leaving the renderer bound to a
+            // swap chain from a dead context. Surface teardown stays safe
+            // regardless: `SwapChain.drainForDeinit` returns early once the
+            // chain is defunct, so `ghostty_surface_free` cannot double-free.
             if display_realized.begin_unrealize() {
                 gl_area.make_current();
                 unsafe { ghostty_surface_display_unrealized(surface) };

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -597,13 +597,11 @@ fn refresh_surface_display(surface: ghostty_surface_t, gl_area: &gtk::GLArea) {
 
 /// Tracks whether Ghostty's renderer is realized for one surface.
 ///
-/// Ghostty guards its own realize path this way in `renderer/Thread.zig`
-/// (`if (self.renderer_realized == value) return;`), but the C export
-/// `ghostty_surface_display_realized` bypasses that guard and calls the
-/// renderer directly. A second realize with no intervening unrealize makes
-/// `Renderer.displayRealized` overwrite `self.swap_chain` without deiniting
-/// it, orphaning a full-size render target and a colour atlas texture. That
-/// is the leak in issue #155, so the host must pair the two calls itself.
+/// `ghostty_surface_display_realized` is not idempotent: a second call with
+/// no intervening unrealize replaces the renderer's swap chain without
+/// freeing the old one, orphaning its render target and colour atlas
+/// texture. The C export does not guard against that, so the host pairs the
+/// two calls itself.
 #[derive(Default)]
 struct DisplayRealizeState {
     realized: Cell<bool>,
@@ -620,9 +618,8 @@ impl DisplayRealizeState {
         self.realized.replace(false)
     }
 
-    /// Adopt the state Ghostty gives a freshly created surface. Its renderer
-    /// thread starts realized (`Thread.renderer_realized` defaults to `true`),
-    /// so the first `unrealize` must still be forwarded.
+    /// Adopt the realized state a freshly created surface already carries,
+    /// so its first unrealize is still forwarded.
     fn adopt_realized(&self) {
         self.realized.set(true);
     }
@@ -2188,15 +2185,11 @@ pub fn create_terminal(
             let Some(surface) = *surface_cell.borrow() else {
                 return;
             };
-            // Deliberately asymmetric with the realize path, which gates on
-            // `gl_area.error()`. GTK destroys this GL context once the
-            // unrealize handlers return, so the teardown must be forwarded
-            // either way. Holding the state realized after a failed
-            // `make_current` would make the next `connect_realize` suppress
-            // its own `display_realized`, leaving the renderer bound to a
-            // swap chain from a dead context. Surface teardown stays safe
-            // regardless: `SwapChain.drainForDeinit` returns early once the
-            // chain is defunct, so `ghostty_surface_free` cannot double-free.
+            // Unlike the realize path, this does not gate on
+            // `gl_area.error()`. GTK destroys the context once these handlers
+            // return, so staying realized after a failed `make_current` would
+            // make the next realize suppress itself and leave the renderer
+            // bound to a dead context.
             if display_realized.begin_unrealize() {
                 gl_area.make_current();
                 unsafe { ghostty_surface_display_unrealized(surface) };
@@ -2934,9 +2927,6 @@ mod tests {
 
     #[test]
     fn display_realize_state_suppresses_a_second_realize() {
-        // Issue #155: Ghostty's `Renderer.displayRealized` overwrites its
-        // swap chain without deiniting it, so a repeated realize orphans a
-        // full-size render target.
         let state = DisplayRealizeState::default();
         assert!(state.begin_realize());
         assert!(!state.begin_realize());
@@ -2963,8 +2953,6 @@ mod tests {
 
     #[test]
     fn display_realize_state_adopts_a_freshly_created_surface() {
-        // `Thread.renderer_realized` defaults to true, so a new surface is
-        // already realized and its first unrealize must be forwarded.
         let state = DisplayRealizeState::default();
         state.adopt_realized();
         assert!(!state.begin_realize());

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -294,7 +294,7 @@ impl TerminalHandle {
             return;
         };
 
-        refresh_realized_surface_display(surface, &self.gl_area);
+        refresh_surface_display(surface, &self.gl_area);
     }
 
     pub fn perform_binding_action(&self, action: &str) -> bool {
@@ -595,10 +595,52 @@ fn refresh_surface_display(surface: ghostty_surface_t, gl_area: &gtk::GLArea) {
     gl_area.queue_render();
 }
 
-fn refresh_realized_surface_display(surface: ghostty_surface_t, gl_area: &gtk::GLArea) {
+/// Tracks whether Ghostty's renderer is realized for one surface.
+///
+/// Ghostty guards its own realize path this way in `renderer/Thread.zig`
+/// (`if (self.renderer_realized == value) return;`), but the C export
+/// `ghostty_surface_display_realized` bypasses that guard and calls the
+/// renderer directly. A second realize with no intervening unrealize makes
+/// `Renderer.displayRealized` overwrite `self.swap_chain` without deiniting
+/// it, orphaning a full-size render target and a colour atlas texture. That
+/// is the leak in issue #155, so the host must pair the two calls itself.
+#[derive(Default)]
+struct DisplayRealizeState {
+    realized: Cell<bool>,
+}
+
+impl DisplayRealizeState {
+    /// True when the caller must invoke `ghostty_surface_display_realized`.
+    fn begin_realize(&self) -> bool {
+        !self.realized.replace(true)
+    }
+
+    /// True when the caller must invoke `ghostty_surface_display_unrealized`.
+    fn begin_unrealize(&self) -> bool {
+        self.realized.replace(false)
+    }
+
+    /// Adopt the state Ghostty gives a freshly created surface. Its renderer
+    /// thread starts realized (`Thread.renderer_realized` defaults to `true`),
+    /// so the first `unrealize` must still be forwarded.
+    fn adopt_realized(&self) {
+        self.realized.set(true);
+    }
+}
+
+/// Realize Ghostty's renderer for a freshly realized `GLArea`, then resize.
+///
+/// Only the `realize` signal may call this. Every other path that needs the
+/// surface to match the widget calls [`refresh_surface_display`], which
+/// resizes without touching renderer lifetime.
+fn refresh_realized_surface_display(
+    surface: ghostty_surface_t,
+    gl_area: &gtk::GLArea,
+    display_realized: &DisplayRealizeState,
+) {
     if gl_area.is_realized() {
         gl_area.make_current();
-        if gl_area.error().is_none() {
+        if gl_area.error().is_none() && display_realized.begin_realize() {
             unsafe { ghostty_surface_display_realized(surface) };
         }
     }
@@ -1464,6 +1506,7 @@ pub fn create_terminal(
     let extra_env = options.extra_env;
     let callbacks = Rc::new(RefCell::new(callbacks));
     let surface_cell: Rc<RefCell<Option<ghostty_surface_t>>> = Rc::new(RefCell::new(None));
+    let display_realized: Rc<DisplayRealizeState> = Rc::new(DisplayRealizeState::default());
     let shutting_down = Rc::new(Cell::new(false));
     let had_focus = Rc::new(Cell::new(false));
     let scrollbar_syncing = Rc::new(Cell::new(false));
@@ -1542,7 +1585,7 @@ pub fn create_terminal(
         let surface_cell = surface_cell.clone();
         let handler = gl_area.connect_map(move |gl_area| {
             if let Some(surface) = *surface_cell.borrow() {
-                refresh_realized_surface_display(surface, gl_area);
+                refresh_surface_display(surface, gl_area);
             } else {
                 gl_area.queue_render();
             }
@@ -1609,6 +1652,7 @@ pub fn create_terminal(
         let scrollbar_syncing = scrollbar_syncing.clone();
         let extra_env = extra_env.clone();
         let shutting_down = shutting_down.clone();
+        let display_realized = display_realized.clone();
         let handler = gl_area.connect_realize(move |gl_area| {
             if shutting_down.get() {
                 return;
@@ -1623,7 +1667,7 @@ pub fn create_terminal(
             // reinitialize the GL renderer with the new GL context while
             // preserving the terminal/pty state.
             if let Some(surface) = *surface_cell.borrow() {
-                refresh_realized_surface_display(surface, gl_area);
+                refresh_realized_surface_display(surface, gl_area, &display_realized);
                 let gl_area = gl_area.clone();
                 glib::idle_add_local_once(move || {
                     gl_area.queue_render();
@@ -1788,6 +1832,7 @@ pub fn create_terminal(
                 );
             });
 
+            display_realized.adopt_realized();
             *surface_cell.borrow_mut() = Some(surface);
 
             unsafe {
@@ -2137,9 +2182,13 @@ pub fn create_terminal(
     {
         let surface_cell = surface_cell.clone();
         let link_popover = link_popover.clone();
+        let display_realized = display_realized.clone();
         let handler = gl_area.connect_unrealize(move |gl_area| {
             link_popover.popdown();
-            if let Some(surface) = *surface_cell.borrow() {
+            let Some(surface) = *surface_cell.borrow() else {
+                return;
+            };
+            if display_realized.begin_unrealize() {
                 gl_area.make_current();
                 unsafe { ghostty_surface_display_unrealized(surface) };
             }
@@ -2872,6 +2921,45 @@ mod tests {
             physical_size_for_allocation(640, 480, 3),
             Some((1920, 1440, 3))
         );
+    }
+
+    #[test]
+    fn display_realize_state_suppresses_a_second_realize() {
+        // Issue #155: Ghostty's `Renderer.displayRealized` overwrites its
+        // swap chain without deiniting it, so a repeated realize orphans a
+        // full-size render target.
+        let state = DisplayRealizeState::default();
+        assert!(state.begin_realize());
+        assert!(!state.begin_realize());
+        assert!(!state.begin_realize());
+    }
+
+    #[test]
+    fn display_realize_state_forwards_every_paired_transition() {
+        let state = DisplayRealizeState::default();
+        for _ in 0..3 {
+            assert!(state.begin_realize());
+            assert!(state.begin_unrealize());
+        }
+    }
+
+    #[test]
+    fn display_realize_state_suppresses_unrealize_when_not_realized() {
+        let state = DisplayRealizeState::default();
+        assert!(!state.begin_unrealize());
+        state.begin_realize();
+        assert!(state.begin_unrealize());
+        assert!(!state.begin_unrealize());
+    }
+
+    #[test]
+    fn display_realize_state_adopts_a_freshly_created_surface() {
+        // `Thread.renderer_realized` defaults to true, so a new surface is
+        // already realized and its first unrealize must be forwarded.
+        let state = DisplayRealizeState::default();
+        state.adopt_realized();
+        assert!(!state.begin_realize());
+        assert!(state.begin_unrealize());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #155.

## Root cause

The host calls `ghostty_surface_display_realized` on ordinary user activity, not only on a GTK realize transition. Ghostty's `Renderer.displayRealized` is not idempotent — it overwrites `self.swap_chain` with a fresh one and relies on a guard that does not survive optimization:

```zig
// ghostty/src/renderer/generic.zig:1210
assert(self.swap_chain.defunct);
...
var swap_chain = try SwapChain.init(self.api, self.has_custom_shaders);
...
self.swap_chain = swap_chain;   // old swap chain overwritten, never deinited
```

That `assert` is `quirks.inlineAssert`, which for every release mode is `if (!ok) unreachable`. Under `ReleaseFast` — what `scripts/package.sh:251` and `rust/limux-ghostty-sys/build.rs` both build with — the optimizer assumes it away, so no check survives. The stale swap chain is dropped with no GL delete.

Each orphaned swap chain holds one `FrameState` (`OpenGL.zig:33` sets `swap_chain_count = 1`) with a full-size `Target` at `.rgba`/`.srgba` plus a colour atlas texture at `.bgra`. Those are exactly the two pixel layouts #155 reports (`282c34ff` and `342c28ff`) from exactly two producers.

Ghostty guards its own path this way in `renderer/Thread.zig:1584`:

```zig
const value = request == .realize;
if (self.renderer_realized == value) return;
```

The C export at `src/apprt/embedded.zig:3190` calls `renderer.displayRealized()` directly and bypasses that guard, so the host has to pair the calls itself.

Before this change, `refresh_realized_surface_display` was reached from four places and only one was a real realize:

| Call site | Trigger | Legitimate |
|---|---|---|
| `connect_realize` | widget realized | yes |
| `connect_map` | widget mapped | no |
| `refresh_display` ← `focus_surface` | pane/tab focus | no |
| `refresh_display` ← `refresh_terminal_displays_in_root` | split-tree rebuild | no |

The rebuild path amplifies it: `split_tree.rs:559` fires `refresh_terminal_displays_in_root` four times per rebuild (immediate, idle, 16 ms, 80 ms), for every terminal in the tree.

## The change

`DisplayRealizeState` mirrors Ghostty's own flag, one per surface. Only `connect_realize` realizes and only `connect_unrealize` unrealizes. `connect_map`, `focus_surface` and `refresh_terminal_displays_in_root` now resize through `refresh_surface_display`, which sets content scale and size and queues a render without touching renderer lifetime.

A freshly created surface calls `adopt_realized()`, because `Thread.renderer_realized` defaults to `true` — without it the first genuine unrealize would be suppressed.

## Verification

Identical workload under Xvfb on both builds: 5 new surfaces, 3 splits, then 60 workspace switches.

| | realize / unrealize | committed memory |
|---|---|---|
| before | 207 / 3 | 404 MB → 1443 MB |
| after | 3 / 3 | 393 MB → 544 MB |

Measured as `VmRSS + VmSwap`. `VmRSS` alone hides this — #155 recorded under 300 MB resident against 15 GB committed.

`limux read-screen` returns live terminal content after the run, so panes still render through splits and workspace switches.

Four unit tests cover the guard in the existing `terminal.rs` test module. `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` exit 0, `cargo test -p limux-host-linux` 240 passed.

`cargo test --workspace` has one failure, `cli_arg_tests::hook_session_id_falls_back_to_transcript_stem`, identical before and after this change. It is unrelated and environment-dependent: `hook_session_id` (`rust/limux-cli/src/main.rs:1219`) prefers `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` over the transcript stem, so the test fails whenever it runs inside a Claude Code session.

## Not addressed

The underlying Ghostty defect is untouched — `displayRealized` stays non-idempotent, and the same trap awaits the next C API caller. The fork's `main` (`b17f1726`) and upstream `ghostty-org/ghostty` HEAD both still carry it, so bumping the submodule would not help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gGsg1isLEq7pwXhY4saiL
