### PR TITLE
ci: harden release builds and validation

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -18,12 +18,14 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   packages:
     name: Build tarball, deb, and AppImage on Ubuntu 24.04
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Check out repository
@@ -33,18 +35,29 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
             version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
-            echo "version=${version}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            version="${REF_NAME#v}"
           fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release version: $version"
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Validate release version
-        run: ./scripts/validate-release-version.sh "${{ steps.version.outputs.version }}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/validate-release-version.sh "$VERSION"
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2
@@ -118,17 +131,13 @@ jobs:
           APPIMAGETOOL_RUNTIME_FILE: /tmp/appimage-runtime
           LIMUX_MAX_GLIBC: "2.39"
           LIMUX_REQUIRE_SVG_LOADER: "1"
-        run: ./scripts/package.sh "${{ steps.version.outputs.version }}"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/package.sh "$VERSION"
 
-      - name: Upload packages to release
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          files: |
-            dist/*
+      - name: Smoke exact Linux artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/smoke-release-artifacts.sh "$VERSION" linux
 
       - name: Upload packages as artifact
         uses: actions/upload-artifact@v7
@@ -136,3 +145,26 @@ jobs:
           name: limux-linux-packages-${{ steps.version.outputs.version }}
           path: dist/*
           retention-days: 30
+
+  publish:
+    name: Upload Linux packages to release
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Linux packages
+        uses: actions/download-artifact@v8
+        with:
+          name: limux-linux-packages-${{ needs.packages.outputs.version }}
+          path: dist
+
+      - name: Upload packages to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ needs.packages.outputs.version }}
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,6 +1,14 @@
 name: Build RPM Package
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/release-rpm.yml
+      - Cargo.lock
+      - Cargo.toml
+      - ghostty
+      - rust/**
+      - scripts/**
   release:
     types: [published]
   workflow_dispatch:
@@ -10,11 +18,13 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   rpm:
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Check out repository
@@ -29,15 +39,29 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            version="${REF_NAME#v}"
           fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release version: $version"
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Validate release version
-        run: ./scripts/validate-release-version.sh "${{ steps.version.outputs.version }}"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/validate-release-version.sh "$VERSION"
 
       - name: Install stable Rust
         run: |
@@ -51,6 +75,7 @@ jobs:
             appstream \
             binutils \
             build-essential \
+            cpio \
             desktop-file-utils \
             gettext \
             libadwaita-1-dev \
@@ -81,13 +106,20 @@ jobs:
         env:
           LIMUX_MAX_GLIBC: "2.39"
           LIMUX_REQUIRE_SVG_LOADER: "1"
-        run: ./scripts/package.sh "${{ steps.version.outputs.version }}"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/package.sh "$VERSION"
+
+      - name: Smoke exact RPM artifact
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./scripts/smoke-release-artifacts.sh "$VERSION" rpm
 
       - name: Resolve RPM path
         id: rpm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
           ARCH="$(uname -m)"
           RPM_ARCH="x86_64"
           [ "$ARCH" = "aarch64" ] && RPM_ARCH="aarch64"
@@ -96,18 +128,32 @@ jobs:
           echo "rpm_path=$RPM_OUTPUT" >> "$GITHUB_OUTPUT"
           echo "rpm_arch=$RPM_ARCH" >> "$GITHUB_OUTPUT"
 
-      - name: Upload RPM to release
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          files: ${{ steps.rpm.outputs.rpm_path }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload RPM as artifact
         uses: actions/upload-artifact@v7
         with:
           name: limux-rpm-${{ steps.version.outputs.version }}
           path: ${{ steps.rpm.outputs.rpm_path }}
           retention-days: 30
+
+  publish:
+    name: Upload RPM to release
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: rpm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download RPM package
+        uses: actions/download-artifact@v8
+        with:
+          name: limux-rpm-${{ needs.rpm.outputs.version }}
+          path: dist
+
+      - name: Upload RPM to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ needs.rpm.outputs.version }}
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -5,9 +5,45 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "17 9 * * *"
+
+permissions:
+  contents: read
 
 jobs:
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install pinned cargo-audit
+        env:
+          CARGO_AUDIT_VERSION: 0.22.2
+          CARGO_AUDIT_SHA256: 7fb9497f8594b389e5fce5ef9b92db08432996895b2e0c5a0167a69ed445c428
+        run: |
+          set -euo pipefail
+          asset="cargo-audit-x86_64-unknown-linux-musl-v${CARGO_AUDIT_VERSION}.tgz"
+          archive="$RUNNER_TEMP/$asset"
+          install_dir="$RUNNER_TEMP/cargo-audit"
+          bin_dir="$RUNNER_TEMP/bin"
+          curl --fail --location --retry 5 --retry-delay 5 \
+            "https://github.com/rustsec/rustsec/releases/download/cargo-audit/v${CARGO_AUDIT_VERSION}/${asset}" \
+            -o "$archive"
+          printf '%s  %s\n' "$CARGO_AUDIT_SHA256" "$archive" | sha256sum --check
+          mkdir -p "$install_dir" "$bin_dir"
+          tar -xzf "$archive" -C "$install_dir" --strip-components=1
+          install -m755 "$install_dir/cargo-audit" "$bin_dir/cargo-audit"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+
+      - name: Audit locked dependencies
+        run: cargo audit --deny warnings
+
   quality:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     steps:
@@ -49,6 +85,7 @@ jobs:
 
   gtk-host-smoke:
     name: GTK host smoke
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-24.04
 
     steps:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -16,8 +16,8 @@ export LD_LIBRARY_PATH="$GHOSTTY_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 cd "$ROOT_DIR"
 
 cargo fmt --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace -- --test-threads=1
+cargo clippy --locked --workspace --all-targets -- -D warnings
+cargo test --locked --workspace -- --test-threads=1
 ./scripts/tests/test-release-version.sh
 ./scripts/tests/test-package-svg-loader.sh
 ./scripts/tests/test-aur-source-package.sh

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -290,7 +290,7 @@ fi
 
 # Build release binary
 echo "Building release binary..."
-cargo build --release --manifest-path "${ROOT_DIR}/Cargo.toml"
+cargo build --release --locked --manifest-path "${ROOT_DIR}/Cargo.toml"
 
 CLI_BINARY="${ROOT_DIR}/target/release/limux-cli"
 HOST_BINARY="${ROOT_DIR}/target/release/limux"

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -104,6 +104,8 @@ smoke_linux() {
     local appimage="$DIST_DIR/Limux-${VERSION}-${ARCH}.AppImage"
     local tar_root="$SMOKE_ROOT/tar/limux-$VERSION-linux-$ARCH"
     local deb_root="$SMOKE_ROOT/deb"
+    local appimage_extract_root="$SMOKE_ROOT/appimage"
+    local appimage_root="$appimage_extract_root/squashfs-root"
     local actual
     local help
 
@@ -137,6 +139,13 @@ smoke_linux() {
         echo "ERROR: AppImage does not contain the Limux CLI entrypoint" >&2
         exit 1
     fi
+
+    mkdir -p "$appimage_extract_root"
+    (
+        cd "$appimage_extract_root"
+        "$appimage" --appimage-extract >/dev/null
+    )
+    verify_tree "$appimage_root/usr" "$appimage_root/usr/bin/limux" "$appimage_root/usr/lib" "AppImage"
 
     echo "Linux release artifact smoke: OK"
 }

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${1:-}"
+MODE="${2:-all}"
+DIST_DIR="${3:-$ROOT_DIR/dist}"
+
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version> [linux|rpm|all] [dist-dir]" >&2
+    exit 1
+fi
+"$ROOT_DIR/scripts/validate-release-version.sh" "$VERSION" >/dev/null
+
+case "$MODE" in
+    linux | rpm | all) ;;
+    *)
+        echo "ERROR: mode must be linux, rpm, or all: $MODE" >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -d "$DIST_DIR" ]; then
+    echo "ERROR: artifact directory does not exist: $DIST_DIR" >&2
+    exit 1
+fi
+DIST_DIR="$(cd "$DIST_DIR" && pwd)"
+
+ARCH="$(uname -m)"
+DEB_ARCH="amd64"
+[ "$ARCH" = "aarch64" ] && DEB_ARCH="arm64"
+RPM_ARCH="x86_64"
+[ "$ARCH" = "aarch64" ] && RPM_ARCH="aarch64"
+EXPECTED_VERSION="limux $VERSION"
+SMOKE_ROOT="$(mktemp -d -t limux-release-smoke-XXXXXX)"
+trap 'find "$SMOKE_ROOT" -depth -delete' EXIT
+
+require_artifact() {
+    local path="$1"
+
+    if [ ! -f "$path" ]; then
+        echo "ERROR: release artifact is missing: $path" >&2
+        exit 1
+    fi
+}
+
+verify_cli() {
+    local cli="$1"
+    local label="$2"
+    local actual
+    local help
+
+    if [ ! -x "$cli" ]; then
+        echo "ERROR: $label CLI is missing or not executable: $cli" >&2
+        exit 1
+    fi
+    actual="$("$cli" --version)"
+    if [ "$actual" != "$EXPECTED_VERSION" ]; then
+        echo "ERROR: $label reports '$actual', expected '$EXPECTED_VERSION'" >&2
+        exit 1
+    fi
+    help="$("$cli" --help 2>&1)"
+    if ! grep -q "limux CLI" <<< "$help"; then
+        echo "ERROR: $label does not contain the Limux CLI entrypoint" >&2
+        exit 1
+    fi
+}
+
+verify_tree() {
+    local prefix="$1"
+    local cli="$2"
+    local library_dir="$3"
+    local label="$4"
+    local host="$prefix/libexec/limux/limux-host"
+    local ghostty="$library_dir/libghostty-internal.so"
+    local dynamic
+
+    verify_cli "$cli" "$label"
+    if [ ! -x "$host" ]; then
+        echo "ERROR: $label host is missing or not executable: $host" >&2
+        exit 1
+    fi
+    if [ ! -f "$ghostty" ]; then
+        echo "ERROR: $label Ghostty library is missing: $ghostty" >&2
+        exit 1
+    fi
+    if [ -e "$prefix/libexec/limux/limux" ]; then
+        echo "ERROR: $label contains the legacy host entrypoint" >&2
+        exit 1
+    fi
+    if ! dynamic="$(LD_LIBRARY_PATH="$library_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd -r "$host" 2>&1)"; then
+        printf '%s\n' "$dynamic" >&2
+        exit 1
+    fi
+    if printf '%s\n' "$dynamic" | grep -Eq "not found|undefined symbol"; then
+        printf '%s\n' "$dynamic" >&2
+        exit 1
+    fi
+}
+
+smoke_linux() {
+    local tarball="$DIST_DIR/limux-$VERSION-linux-$ARCH.tar.gz"
+    local deb="$DIST_DIR/limux_${VERSION}_${DEB_ARCH}.deb"
+    local appimage="$DIST_DIR/Limux-${VERSION}-${ARCH}.AppImage"
+    local tar_root="$SMOKE_ROOT/tar/limux-$VERSION-linux-$ARCH"
+    local deb_root="$SMOKE_ROOT/deb"
+    local actual
+    local help
+
+    require_artifact "$tarball"
+    require_artifact "$deb"
+    require_artifact "$appimage"
+
+    mkdir -p "$SMOKE_ROOT/tar" "$deb_root"
+    tar -xzf "$tarball" -C "$SMOKE_ROOT/tar"
+    verify_tree "$tar_root" "$tar_root/limux" "$tar_root/lib" "tarball"
+
+    dpkg-deb -x "$deb" "$deb_root"
+    actual="$(dpkg-deb -f "$deb" Version)"
+    if [ "$actual" != "$VERSION" ]; then
+        echo "ERROR: Debian package metadata reports '$actual', expected '$VERSION'" >&2
+        exit 1
+    fi
+    verify_tree "$deb_root/usr" "$deb_root/usr/bin/limux" "$deb_root/usr/lib/limux" "Debian package"
+
+    if [ ! -x "$appimage" ]; then
+        echo "ERROR: AppImage is not executable: $appimage" >&2
+        exit 1
+    fi
+    actual="$(APPIMAGE_EXTRACT_AND_RUN=1 "$appimage" --version)"
+    if [ "$actual" != "$EXPECTED_VERSION" ]; then
+        echo "ERROR: AppImage reports '$actual', expected '$EXPECTED_VERSION'" >&2
+        exit 1
+    fi
+    help="$(APPIMAGE_EXTRACT_AND_RUN=1 "$appimage" --help 2>&1)"
+    if ! grep -q "limux CLI" <<< "$help"; then
+        echo "ERROR: AppImage does not contain the Limux CLI entrypoint" >&2
+        exit 1
+    fi
+
+    echo "Linux release artifact smoke: OK"
+}
+
+smoke_rpm() {
+    local rpm="$DIST_DIR/limux-${VERSION}-1.${RPM_ARCH}.rpm"
+    local rpm_root="$SMOKE_ROOT/rpm"
+    local metadata_version
+
+    require_artifact "$rpm"
+    if ! command -v rpm >/dev/null 2>&1 || ! command -v rpm2cpio >/dev/null 2>&1 || ! command -v cpio >/dev/null 2>&1; then
+        echo "ERROR: rpm, rpm2cpio, and cpio are required for RPM smoke checks" >&2
+        exit 1
+    fi
+    metadata_version="$(rpm -qp --qf '%{VERSION}' "$rpm")"
+    if [ "$metadata_version" != "$VERSION" ]; then
+        echo "ERROR: RPM metadata reports '$metadata_version', expected '$VERSION'" >&2
+        exit 1
+    fi
+
+    mkdir -p "$rpm_root"
+    (
+        cd "$rpm_root"
+        rpm2cpio "$rpm" | cpio -idm --quiet
+    )
+    verify_tree "$rpm_root/usr" "$rpm_root/usr/bin/limux" "$rpm_root/usr/lib/limux" "RPM package"
+
+    echo "RPM release artifact smoke: OK"
+}
+
+case "$MODE" in
+    linux) smoke_linux ;;
+    rpm) smoke_rpm ;;
+    all)
+        smoke_linux
+        smoke_rpm
+        ;;
+esac

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -43,10 +43,10 @@ else
 fi
 
 echo "-- building limux-cli ($PROFILE)..."
-cargo build $CARGO_FLAGS -p limux-cli --bin limux-cli 2>&1 | tail -3
+cargo build --locked $CARGO_FLAGS -p limux-cli --bin limux-cli 2>&1 | tail -3
 
 echo "-- building limux-host-linux ($PROFILE)..."
-cargo build $CARGO_FLAGS -p limux-host-linux 2>&1 | tail -3
+cargo build --locked $CARGO_FLAGS -p limux-host-linux 2>&1 | tail -3
 
 LIMUX_HOST="$ROOT_DIR/$BIN_DIR/limux"
 LIMUX_CLI="$ROOT_DIR/$BIN_DIR/limux-cli"


### PR DESCRIPTION
## Summary

- lock Cargo resolution across quality, GTK smoke, and package builds
- run a checksum-pinned `cargo-audit` scan on every change and daily
- smoke exact tarball, deb, RPM, and AppImage outputs, including CLI version, package metadata, layout, and host linkage
- pass release inputs through environment variables and keep build jobs read-only
- isolate release write permission in publish-only jobs

## Testing

- `./scripts/check.sh`
- `cargo audit --deny warnings`
- `shellcheck scripts/smoke-release-artifacts.sh scripts/check.sh scripts/xvfb-smoke-test.sh`
- `actionlint` 1.7.12 against all changed workflows
- `./scripts/smoke-release-artifacts.sh 0.1.25 all <downloaded-v0.1.25-assets>`

Published v0.1.25 tarball, deb, RPM, and AppImage all passed the new harness.

## Did this cause any problems?

No runtime behavior changes. Revert this commit to restore the previous workflow and packaging validation behavior.