### PR TITLE
fix(appimage): use host graphics libraries

### DIFF
--- a/scripts/appimage-webkit.sh
+++ b/scripts/appimage-webkit.sh
@@ -87,6 +87,9 @@ is_appimage_system_library() {
         ld-linux*.so*|libanl.so*|libBrokenLocale.so*|libc.so*|libcidn.so*|libdl.so*|libm.so*|libmvec.so*|libnsl.so*|libnss_*.so*|libpthread.so*|libresolv.so*|librt.so*|libthread_db.so*|libutil.so*)
             return 0
             ;;
+        libEGL.so*|libGL.so*|libGLX.so*|libGLdispatch.so*|libOpenGL.so*|libdrm*.so*|libgbm.so*|libglapi.so*|libwayland-client.so*|libwayland-cursor.so*|libwayland-egl.so*|libwayland-server.so*)
+            return 0
+            ;;
     esac
 
     return 1

--- a/scripts/appimage-webkit.sh
+++ b/scripts/appimage-webkit.sh
@@ -87,7 +87,7 @@ is_appimage_system_library() {
         ld-linux*.so*|libanl.so*|libBrokenLocale.so*|libc.so*|libcidn.so*|libdl.so*|libm.so*|libmvec.so*|libnsl.so*|libnss_*.so*|libpthread.so*|libresolv.so*|librt.so*|libthread_db.so*|libutil.so*)
             return 0
             ;;
-        libEGL.so*|libGL.so*|libGLX.so*|libGLdispatch.so*|libOpenGL.so*|libdrm*.so*|libgbm.so*|libglapi.so*|libwayland-client.so*|libwayland-cursor.so*|libwayland-egl.so*|libwayland-server.so*)
+        libEGL.so*|libGL.so*|libGLESv1_CM.so*|libGLESv2.so*|libGLX.so*|libGLdispatch.so*|libOpenGL.so*|libdrm*.so*|libgbm.so*|libglapi.so*|libwayland-client.so*|libwayland-cursor.so*|libwayland-egl.so*|libwayland-server.so*)
             return 0
             ;;
     esac

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -949,10 +949,9 @@ fi
 export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
 export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS:-/usr/share}"
 
-# The bundled WebKitGTK closure includes Ubuntu's Mesa loader libraries, whose
-# compiled-in driver paths do not match Fedora or Arch. Point those loaders at
-# the host's actual GBM and DRI modules without overriding an explicit user
-# choice. Terminals restore the original values via the markers above.
+# Host Mesa loaders use distro-specific GBM and DRI module paths. Discover
+# common locations without overriding an explicit user choice. Terminals
+# restore the original values via the markers above.
 if [ -z "${GBM_BACKENDS_PATH:-}" ]; then
     for candidate in /usr/lib/gbm /usr/lib64/gbm /usr/lib/*-linux-gnu/gbm; do
         if [ -d "$candidate" ] && compgen -G "${candidate}/*_gbm.so" >/dev/null; then

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/appimage-webkit.sh"
+
 VERSION="${1:-}"
 MODE="${2:-all}"
 DIST_DIR="${3:-$ROOT_DIR/dist}"
@@ -98,6 +101,18 @@ verify_tree() {
     fi
 }
 
+verify_appimage_library_boundary() {
+    local library_dir="$1"
+    local library
+
+    while IFS= read -r -d '' library; do
+        if is_appimage_system_library "$library"; then
+            echo "ERROR: AppImage bundles host library: $(basename "$library")" >&2
+            exit 1
+        fi
+    done < <(find "$library_dir" -maxdepth 1 \( -type f -o -type l \) -print0)
+}
+
 smoke_linux() {
     local tarball="$DIST_DIR/limux-$VERSION-linux-$ARCH.tar.gz"
     local deb="$DIST_DIR/limux_${VERSION}_${DEB_ARCH}.deb"
@@ -145,6 +160,7 @@ smoke_linux() {
         cd "$appimage_extract_root"
         "$appimage" --appimage-extract >/dev/null
     )
+    verify_appimage_library_boundary "$appimage_root/usr/lib"
     verify_tree "$appimage_root/usr" "$appimage_root/usr/bin/limux" "$appimage_root/usr/lib" "AppImage"
 
     echo "Linux release artifact smoke: OK"

--- a/scripts/tests/test-package-svg-loader.sh
+++ b/scripts/tests/test-package-svg-loader.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Unit tests for the AppImage SVG-loader bundling logic in scripts/package.sh.
+# Regression tests for AppImage packaging logic.
 #
 # Tests are pure-shell. They isolate the relevant blocks so they can be
 # exercised without running a full package build.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PACKAGE_SH="$SCRIPT_DIR/../package.sh"
+APPIMAGE_WEBKIT_SH="$SCRIPT_DIR/../appimage-webkit.sh"
+
+# shellcheck disable=SC1090,SC1091
+source "$APPIMAGE_WEBKIT_SH"
 
 PASS=0
 FAIL=0
@@ -267,6 +270,38 @@ if [ "$ec" = "99" ]; then
     pass "LIMUX_REQUIRE_SVG_LOADER=1 -> hard fail (exit 99)"
 else
     fail "hard-fail path" "expected exit 99, got $ec"
+fi
+
+# ----- T7: host graphics libraries stay outside the AppImage -----
+
+echo "T7: AppImage uses host graphics libraries"
+
+for library in \
+    libEGL.so.1 \
+    libGL.so.1 \
+    libGLX.so.0 \
+    libGLdispatch.so.0 \
+    libOpenGL.so.0 \
+    libdrm.so.2 \
+    libdrm_amdgpu.so.1 \
+    libgbm.so.1 \
+    libglapi.so.0 \
+    libwayland-client.so.0 \
+    libwayland-cursor.so.0 \
+    libwayland-egl.so.1 \
+    libwayland-server.so.0
+do
+    if is_appimage_system_library "/usr/lib/$library"; then
+        pass "excludes $library"
+    else
+        fail "host graphics exclusion" "$library would be bundled"
+    fi
+done
+
+if ! is_appimage_system_library "/usr/lib/libwebkitgtk-6.0.so.4"; then
+    pass "keeps application runtime libraries bundled"
+else
+    fail "application runtime closure" "libwebkitgtk-6.0.so.4 would be excluded"
 fi
 
 # ----- Summary -----

--- a/scripts/tests/test-package-svg-loader.sh
+++ b/scripts/tests/test-package-svg-loader.sh
@@ -279,6 +279,8 @@ echo "T7: AppImage uses host graphics libraries"
 for library in \
     libEGL.so.1 \
     libGL.so.1 \
+    libGLESv1_CM.so.1 \
+    libGLESv2.so.2 \
     libGLX.so.0 \
     libGLdispatch.so.0 \
     libOpenGL.so.0 \


### PR DESCRIPTION
## Summary

- keep GLVND, Mesa, DRM, and Wayland libraries host-owned instead of bundling Ubuntu copies in AppImage
- reject host graphics libraries during exact-artifact smoke validation
- cover graphics library classification with focused shell regression checks

## Why

v0.1.25 prepends bundled libraries to LD_LIBRARY_PATH. On NixOS, bundled GLVND dispatcher cannot find host vendor manifests. Loading newer host Mesa against bundled older Wayland can also fail on missing symbols. Using host graphics stack keeps loaders, drivers, manifests, and Wayland ABI aligned.

## Testing

- ./scripts/check.sh
- shellcheck scripts/appimage-webkit.sh scripts/package.sh scripts/smoke-release-artifacts.sh scripts/tests/test-package-svg-loader.sh
- full 0.1.25 tarball, deb, RPM, and AppImage build with Zig 0.16.0
- ./scripts/smoke-release-artifacts.sh 0.1.25 linux dist
- confirmed old v0.1.25 artifact fails new boundary check on bundled libgbm.so.1
- confirmed intermediate artifact fails on bundled libdrm.so.2

NixOS Wayland behavior still needs reporter validation against candidate artifact.

Refs #87

## Did this cause any problems?

Minimal X11-only systems without Wayland runtime libraries may no longer launch AppImage. Documented Ubuntu 24.04-era desktop baseline provides required graphics libraries. Revert this PR to restore previous bundling policy.
