### PR TITLE
chore: add ESC key handler to close dialog in window.rs. Closes #159

### DIFF
--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3911,6 +3911,19 @@ fn show_workspace_path_dialog(state: &State) {
         dialog_for_cancel.close();
     });
 
+    // ESC key handler to close the dialog
+    let dialog_for_key = dialog.clone();
+    let key_controller = gtk::EventControllerKey::new();
+    key_controller.connect_key_pressed(move |_controller, keyval, _keycode, _modifier| {
+        if keyval == gtk::gdk::Key::Escape {
+            dialog_for_key.close();
+            glib::Propagation::Stop
+        } else {
+            glib::Propagation::Proceed
+        }
+    });
+    dialog.add_controller(key_controller);
+
     dialog.present();
 }
 


### PR DESCRIPTION
Adds support for closing the GTK "new workspace" window. Tested in CachyOS (GNOME 50.4, Mutter (Wayland)) and worked perfectly. Also tested to make sure the original fields and buttons kept working too.

I think it would be good to have this for the settings as well. Including a key combo to open the settings