### PR TITLE
fix(appimage): relocate WebKitGTK process path

### DIFF
--- a/scripts/appimage-webkit.sh
+++ b/scripts/appimage-webkit.sh
@@ -106,7 +106,7 @@ shared_library_dependencies() {
         | sort -u
 }
 
-binary_replace_string() {
+binary_replace_c_string() {
     local file="$1"
     local old="$2"
     local new="$3"
@@ -127,10 +127,12 @@ old = sys.argv[2].encode()
 new = sys.argv[3].encode()
 
 data = path.read_bytes()
-replacement = new + (b"\0" * (len(old) - len(new)))
-patched = data.replace(old, replacement)
-if patched != data:
-    path.write_bytes(patched)
+needle = old + b"\0"
+replacement = new + (b"\0" * (len(needle) - len(new)))
+count = data.count(needle)
+if count:
+    path.write_bytes(data.replace(needle, replacement))
+print(count)
 PY
 }
 
@@ -182,14 +184,28 @@ patch_appimage_webkit_paths() {
     local relative_runtime="usr/lib/webkitgtk-6.0/"
     local relative_bundle="usr/lib/webkitgtk-6.0/injected-bundle/"
     local file
+    local replacements
+    local process_path_patched=0
 
     while IFS= read -r file; do
         # Distro WebKitGTK embeds absolute paths and does not reliably honor
         # WEBKIT_EXEC_PATH outside developer builds.
-        binary_replace_string "$file" "${WEBKITGTK_RUNTIME_DIR%/}/injected-bundle/" "$relative_bundle"
-        binary_replace_string "$file" "${WEBKITGTK_PROCESS_DIR%/}/" "$relative_runtime"
-        binary_replace_string "$file" "${WEBKITGTK_RUNTIME_DIR%/}/" "$relative_runtime"
+        binary_replace_c_string "$file" "${WEBKITGTK_RUNTIME_DIR%/}/injected-bundle/" "$relative_bundle" >/dev/null
+
+        replacements="$(binary_replace_c_string "$file" "${WEBKITGTK_PROCESS_DIR%/}" "${relative_runtime%/}")"
+        if [ "$replacements" -gt 0 ]; then
+            process_path_patched=1
+        fi
+
+        if [ "$WEBKITGTK_RUNTIME_DIR" != "$WEBKITGTK_PROCESS_DIR" ]; then
+            binary_replace_c_string "$file" "${WEBKITGTK_RUNTIME_DIR%/}" "${relative_runtime%/}" >/dev/null
+        fi
     done < <(find "$appdir/usr/lib" -type f \( -perm -0100 -o -name '*.so*' \) | sort)
+
+    if [ "$process_path_patched" != 1 ]; then
+        echo "ERROR: bundled WebKitGTK process path was not found: ${WEBKITGTK_PROCESS_DIR%/}" >&2
+        exit 1
+    fi
 }
 
 copy_appimage_webkit_runtime() {

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -113,6 +113,35 @@ verify_appimage_library_boundary() {
     done < <(find "$library_dir" -maxdepth 1 \( -type f -o -type l \) -print0)
 }
 
+verify_appimage_webkit_paths() {
+    local app_root="$1"
+    local compiled_runtime
+    local library
+    local found=0
+
+    if ! compiled_runtime="$(resolve_webkitgtk_runtime_dir)"; then
+        echo "ERROR: WebKitGTK runtime directory is unavailable during AppImage verification" >&2
+        exit 1
+    fi
+
+    while IFS= read -r -d '' library; do
+        found=1
+        if grep -aFq "${compiled_runtime%/}" "$library"; then
+            echo "ERROR: AppImage WebKitGTK library retains host process path: $library" >&2
+            exit 1
+        fi
+        if ! grep -aFq "usr/lib/webkitgtk-6.0" "$library"; then
+            echo "ERROR: AppImage WebKitGTK library lacks relocated process path: $library" >&2
+            exit 1
+        fi
+    done < <(find "$app_root/usr/lib" -maxdepth 1 -type f -name 'libwebkitgtk-6.0.so*' -print0)
+
+    if [ "$found" != 1 ]; then
+        echo "ERROR: AppImage does not contain bundled WebKitGTK library" >&2
+        exit 1
+    fi
+}
+
 smoke_linux() {
     local tarball="$DIST_DIR/limux-$VERSION-linux-$ARCH.tar.gz"
     local deb="$DIST_DIR/limux_${VERSION}_${DEB_ARCH}.deb"
@@ -161,6 +190,7 @@ smoke_linux() {
         "$appimage" --appimage-extract >/dev/null
     )
     verify_appimage_library_boundary "$appimage_root/usr/lib"
+    verify_appimage_webkit_paths "$appimage_root"
     verify_tree "$appimage_root/usr" "$appimage_root/usr/bin/limux" "$appimage_root/usr/lib" "AppImage"
 
     echo "Linux release artifact smoke: OK"

--- a/scripts/tests/test-package-svg-loader.sh
+++ b/scripts/tests/test-package-svg-loader.sh
@@ -306,6 +306,31 @@ else
     fail "application runtime closure" "libwebkitgtk-6.0.so.4 would be excluded"
 fi
 
+# ----- T8: WebKitGTK process path is made relative to AppRun cwd -----
+
+echo "T8: AppImage relocates WebKitGTK process path"
+
+WEBKIT_APPDIR="$HEREDOC_TMP/webkit-appdir"
+WEBKIT_LIBRARY="$WEBKIT_APPDIR/usr/lib/libwebkitgtk-6.0.so.4"
+WEBKITGTK_RUNTIME_DIR="/usr/lib/x86_64-linux-gnu/webkitgtk-6.0"
+WEBKITGTK_PROCESS_DIR="$WEBKITGTK_RUNTIME_DIR"
+mkdir -p "$(dirname "$WEBKIT_LIBRARY")"
+printf '%s\0%s\0' \
+    "$WEBKITGTK_PROCESS_DIR" \
+    "$WEBKITGTK_RUNTIME_DIR/injected-bundle/" \
+    > "$WEBKIT_LIBRARY"
+chmod 755 "$WEBKIT_LIBRARY"
+
+patch_appimage_webkit_paths "$WEBKIT_APPDIR"
+
+if grep -aFq "$WEBKITGTK_PROCESS_DIR" "$WEBKIT_LIBRARY"; then
+    fail "WebKitGTK path relocation" "compiled-in process path remains"
+elif ! grep -aFq "usr/lib/webkitgtk-6.0" "$WEBKIT_LIBRARY"; then
+    fail "WebKitGTK path relocation" "relative process path is missing"
+else
+    pass "rewrites compiled-in process and injected-bundle paths"
+fi
+
 # ----- Summary -----
 
 echo ""


### PR DESCRIPTION
## Summary

Fix embedded browser startup from AppImage on hosts without Debian's compiled WebKitGTK libexec path.

Follow-up to #161 and #87. Reporter confirmed graphics fix, then exposed this helper-process path failure on NixOS.

## Repro

1. Launch #161 AppImage on NixOS.
2. Open embedded browser.
3. WebKitGTK tries `/usr/lib/x86_64-linux-gnu/webkitgtk-6.0/WebKitNetworkProcess` and aborts because path does not exist.

## Changes

- rewrite exact NUL-terminated WebKitGTK process-directory string to AppRun-relative path
- fail packaging when compiled process path is not found instead of silently producing broken artifact
- verify synthetic relocation and extracted AppImage payload

## Testing

- `./scripts/check.sh`
- `shellcheck scripts/appimage-webkit.sh scripts/tests/test-package-svg-loader.sh scripts/smoke-release-artifacts.sh`
- `./scripts/tests/test-package-svg-loader.sh` (33 passed)
- full package build with pinned Zig 0.16.0
- `APPIMAGE_EXTRACT_AND_RUN=1 ./scripts/smoke-release-artifacts.sh 0.1.25 linux`
- real local `libwebkitgtk-6.0.so.4` relocation probe

NixOS embedded-browser validation remains reporter-side after CI publishes candidate artifact.

## Did this cause any problems?

Revert this commit. AppImage packaging returns to prior WebKitGTK path rewriting behavior.