### PR TITLE
chore: bump version to 0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "limux-cli"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "limux-control"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "limux-core"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "limux-protocol",
@@ -779,11 +779,11 @@ dependencies = [
 
 [[package]]
 name = "limux-ghostty-sys"
-version = "0.1.25"
+version = "0.1.26"
 
 [[package]]
 name = "limux-host-linux"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "cc",
  "dirs",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "limux-protocol"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 authors = ["limux contributors"]
 edition = "2021"
 license = "MIT"
-version = "0.1.25"
+version = "0.1.26"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

- bump workspace version from 0.1.25 to 0.1.26
- refresh workspace crate versions in Cargo.lock

## Testing

- cargo check -p limux-protocol
- ./scripts/check.sh
- cargo audit
- cargo fmt --check
- ./scripts/validate-release-version.sh 0.1.26

## Did this cause any problems?

Revert this commit before publishing v0.1.26.
