### PR TITLE
fix(host): restrict session state permissions

### DIFF
--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 pub const SESSION_VERSION: u32 = 1;
@@ -345,13 +345,16 @@ pub fn save_session_atomic_in(dir: &Path, state: &AppSessionState) -> io::Result
     let normalized = normalize_session(state.clone());
     let json = serde_json::to_vec_pretty(&normalized)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    match fs::remove_file(&temp_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
     let mut temp_file = OpenOptions::new()
         .write(true)
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .mode(0o600)
         .open(&temp_path)?;
-    temp_file.set_permissions(fs::Permissions::from_mode(0o600))?;
     temp_file.write_all(&json)?;
     drop(temp_file);
     fs::rename(&temp_path, &path)?;
@@ -915,6 +918,8 @@ fn shell_single_quote(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::Mutex;
     use tempfile::tempdir;
 
@@ -1094,6 +1099,7 @@ mod tests {
         fs::write(&temp_path, "stale session").expect("write stale session");
         fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o644))
             .expect("set stale session permissions");
+        let mut stale_reader = fs::File::open(&temp_path).expect("open stale session");
         let state = AppSessionState {
             workspaces: vec![WorkspaceState {
                 id: Some("22222222-2222-4222-8222-222222222222".to_string()),
@@ -1117,6 +1123,11 @@ mod tests {
                 & 0o777,
             0o600
         );
+        let mut stale_contents = String::new();
+        stale_reader
+            .read_to_string(&mut stale_contents)
+            .expect("read stale session inode");
+        assert_eq!(stale_contents, "stale session");
         let raw = fs::read_to_string(path).expect("read canonical session");
         let decoded: AppSessionState =
             serde_json::from_str(&raw).expect("decode canonical session");

--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -1,8 +1,9 @@
 use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::fs;
-use std::io;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 pub const SESSION_VERSION: u32 = 1;
@@ -344,7 +345,15 @@ pub fn save_session_atomic_in(dir: &Path, state: &AppSessionState) -> io::Result
     let normalized = normalize_session(state.clone());
     let json = serde_json::to_vec_pretty(&normalized)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-    fs::write(&temp_path, json)?;
+    let mut temp_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&temp_path)?;
+    temp_file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    temp_file.write_all(&json)?;
+    drop(temp_file);
     fs::rename(&temp_path, &path)?;
     Ok(path)
 }
@@ -1080,6 +1089,11 @@ mod tests {
     #[test]
     fn save_session_atomic_writes_canonical_file() {
         let dir = tempdir().expect("tempdir");
+        let canonical_path = canonical_session_path_in(dir.path());
+        let temp_path = temp_session_path(&canonical_path);
+        fs::write(&temp_path, "stale session").expect("write stale session");
+        fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o644))
+            .expect("set stale session permissions");
         let state = AppSessionState {
             workspaces: vec![WorkspaceState {
                 id: Some("22222222-2222-4222-8222-222222222222".to_string()),
@@ -1094,7 +1108,15 @@ mod tests {
         };
 
         let path = save_session_atomic_in(dir.path(), &state).expect("save canonical session");
-        assert_eq!(path, canonical_session_path_in(dir.path()));
+        assert_eq!(path, canonical_path);
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("session metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
         let raw = fs::read_to_string(path).expect("read canonical session");
         let decoded: AppSessionState =
             serde_json::from_str(&raw).expect("decode canonical session");


### PR DESCRIPTION
## Summary

- create every atomic session replacement with owner-only 0600 permissions
- repair permissions when reusing a stale per-process temporary file
- keep persisted workspace autostart commands and agent launch metadata private

Follow-up to #150.

## Testing

- focused save_session_atomic_writes_canonical_file regression
- cargo check -p limux-host-linux
- ./scripts/check.sh

## Did this cause any problems?

Revert this commit. Existing session contents and serialization remain unchanged.
