### PR TITLE
Document the CPU-only Rust formatting workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Rust formatting
+
+Run rustfmt before submitting Rust changes:
+
+```bash
+cargo fmt --all
+```
+
+To validate formatting without compiling or requiring GPU tooling, run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+The repository quality gate also checks formatting as part of `./scripts/check.sh`.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Run the canonical local quality gate before committing:
 ```
 
 Repository maintainability rules live in [`docs/maintainability.md`](docs/maintainability.md).
+The [contributing guide](CONTRIBUTING.md) documents the CPU-only Rust formatting workflow.
 Release procedure lives in [`docs/releasing.md`](docs/releasing.md).
 
 ## Workspace autostart


### PR DESCRIPTION
## Summary
- add a short `CONTRIBUTING.md` describing the existing Rust formatting workflow
- document `cargo fmt --all -- --check` as the CPU-only validation command
- link the contributing guide from the README development section

## Validation
- validated local Markdown links in the changed files
- ran `cargo fmt --all -- --check`
- ran `git diff --check`

<!-- repo-agent-case:1c7881bf-ead6-4070-99bb-f1ca03377d13 -->