### PR TITLE
fix(host): keep terminal control on one surface

### DIFF
--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -391,6 +391,21 @@ fn parse_opt(args: &[String], name: &str) -> Option<String> {
     })
 }
 
+fn parse_terminal_surface(args: &[String]) -> Result<Option<String>> {
+    let Some(surface) = parse_opt(args, "--surface") else {
+        if parse_flag(args, "--surface") {
+            bail!("--surface requires a non-empty target");
+        }
+        return Ok(None);
+    };
+    let normalized = surface.trim();
+    let normalized = normalized.strip_prefix("surface:").unwrap_or(normalized);
+    if normalized.trim().is_empty() {
+        bail!("--surface requires a non-empty target");
+    }
+    Ok(Some(surface))
+}
+
 fn parse_flag(args: &[String], name: &str) -> bool {
     args.iter().any(|a| a == name)
 }
@@ -804,7 +819,7 @@ async fn run_send(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
         .filter(|s| !s.is_empty());
-    let surface = parse_opt(args, "--surface").filter(|s| !s.is_empty());
+    let surface = parse_terminal_surface(args)?;
 
     let text = trailing_title(args).ok_or_else(|| anyhow!("send requires text"))?;
 
@@ -827,7 +842,7 @@ async fn run_send_key(client: &mut Client, args: &[String]) -> Result<Value> {
     let workspace = parse_opt(args, "--workspace")
         .or_else(|| env::var("LIMUX_WORKSPACE_ID").ok())
         .filter(|s| !s.is_empty());
-    let surface = parse_opt(args, "--surface").filter(|s| !s.is_empty());
+    let surface = parse_terminal_surface(args)?;
     let key = trailing_title(args).ok_or_else(|| anyhow!("send-key requires key"))?;
 
     let mut params = Map::new();
@@ -2518,7 +2533,7 @@ async fn run_read_screen(client: &mut Client, args: &[String]) -> Result<Value> 
     }
 
     let workspace = parse_opt(args, "--workspace");
-    let surface = parse_opt(args, "--surface");
+    let surface = parse_terminal_surface(args)?;
     let mut params = Map::new();
     if let Some(workspace) = workspace {
         params.insert("workspace_id".to_string(), Value::String(workspace));
@@ -3773,6 +3788,42 @@ mod cli_arg_tests {
                 }
                 CommandOutput::Json(_) => panic!("version should be plain text"),
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_commands_reject_empty_explicit_surface_before_connecting() {
+        for command in ["send", "send-key", "read-screen"] {
+            for target in ["", "   ", "surface:", " surface:   "] {
+                let mut client = Client::new(PathBuf::from("/does/not/exist.sock"));
+                let mut command_args = args(&[command, "--surface", target]);
+                if command == "send" {
+                    command_args.push("must not be sent".into());
+                }
+                if command == "send-key" {
+                    command_args.push("Enter".into());
+                }
+                let error = execute_command(&mut client, &default_opts(command_args))
+                    .await
+                    .expect_err("invalid target must fail locally");
+                assert_eq!(
+                    error.to_string(),
+                    "--surface requires a non-empty target",
+                    "{command} {target:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn terminal_surface_option_preserves_omission_and_valid_handles() {
+        assert_eq!(parse_terminal_surface(&args(&["payload"])).unwrap(), None);
+        assert!(parse_terminal_surface(&args(&["--surface"])).is_err());
+        for target in ["tab-id", "4:tab-id", "surface:4:tab-id"] {
+            assert_eq!(
+                parse_terminal_surface(&args(&["--surface", target])).unwrap(),
+                Some(target.to_string())
+            );
         }
     }
 

--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -308,6 +308,25 @@ fn optional_handle(
     Ok(None)
 }
 
+/// A supplied terminal target must remain explicit, including malformed empty
+/// handles. Dropping it would redirect input to the active or first terminal.
+fn optional_surface_handle(
+    params: &Map<String, Value>,
+    keys: &[&str],
+) -> Result<Option<String>, BridgeError> {
+    for key in keys {
+        if params.get(*key).is_none_or(Value::is_null) {
+            continue;
+        }
+        let handle = optional_ref_handle(params, &[*key], "surface:")?;
+        return handle
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| Some(value.trim().to_string()))
+            .ok_or_else(|| BridgeError::invalid_params(format!("{key} must not be empty")));
+    }
+    Ok(None)
+}
+
 fn optional_ref_handle(
     params: &Map<String, Value>,
     keys: &[&str],
@@ -533,8 +552,7 @@ fn handle_method(
                 Ok(target) => target,
                 Err(error) => return error_response(id, error),
             };
-            let surface_hint = match optional_ref_handle(params, &["surface_id", "id"], "surface:")
-            {
+            let surface_hint = match optional_surface_handle(params, &["surface_id", "id"]) {
                 Ok(surface_hint) => surface_hint,
                 Err(error) => return error_response(id, error),
             };
@@ -610,11 +628,15 @@ fn handle_method(
                 Ok(target) => target,
                 Err(error) => return error_response(id, error),
             };
+            let surface_hint = match optional_surface_handle(params, &["surface_id"]) {
+                Ok(surface_hint) => surface_hint,
+                Err(error) => return error_response(id, error),
+            };
             let (reply, rx) = mpsc::channel();
             (
                 ControlCommand::SendText {
                     target,
-                    surface_hint: optional_string(params, &["surface_id"]),
+                    surface_hint,
                     text,
                     reply,
                 },
@@ -632,11 +654,15 @@ fn handle_method(
                 Ok(target) => target,
                 Err(error) => return error_response(id, error),
             };
+            let surface_hint = match optional_surface_handle(params, &["surface_id"]) {
+                Ok(surface_hint) => surface_hint,
+                Err(error) => return error_response(id, error),
+            };
             let (reply, rx) = mpsc::channel();
             (
                 ControlCommand::SendKey {
                     target,
-                    surface_hint: optional_string(params, &["surface_id"]),
+                    surface_hint,
                     key,
                     reply,
                 },
@@ -1051,6 +1077,80 @@ mod tests {
 
         assert_eq!(response.error, None);
         assert!(response.result.is_some());
+    }
+
+    #[test]
+    fn terminal_routes_reject_empty_explicit_targets_before_dispatch() {
+        for method in [
+            "surface.send_text",
+            "send-text",
+            "send",
+            "surface.send_key",
+            "send-key",
+            "surface.read_text",
+            "read-screen",
+            "capture-pane",
+        ] {
+            for target in ["", "   ", "surface:", " surface:   "] {
+                let request = json!({ "id": 1, "method": method, "params": { "surface_id": target, "text": "must not be sent", "key": "Enter" } });
+                let response = dispatch_request(&request.to_string(), &|command| {
+                    panic!("invalid target dispatched: {command:?}")
+                });
+                assert_eq!(
+                    response.error.as_ref().map(|error| error.code),
+                    Some(INVALID_PARAMS_CODE),
+                    "{method} target {target:?}"
+                );
+            }
+        }
+        let response = dispatch_request(
+            r#"{"id":1,"method":"capture-pane","params":{"id":"surface:"}}"#,
+            &|command| panic!("empty alias dispatched: {command:?}"),
+        );
+        assert_eq!(
+            response.error.as_ref().map(|error| error.code),
+            Some(INVALID_PARAMS_CODE)
+        );
+    }
+
+    #[test]
+    fn terminal_routes_preserve_omitted_and_nonempty_explicit_targets() {
+        for method in ["surface.send_text", "surface.send_key", "surface.read_text"] {
+            for (target, expected) in [
+                (None, None),
+                (Some("surface:4:target"), Some("4:target")),
+                (Some("missing-surface"), Some("missing-surface")),
+            ] {
+                let mut params = json!({ "text": "test", "key": "Enter" });
+                if let Some(target) = target {
+                    params["surface_id"] = json!(target);
+                }
+                let request = json!({ "id": 1, "method": method, "params": params });
+                let response = dispatch_request(&request.to_string(), &|command| {
+                    let (surface_hint, reply) = match command {
+                        ControlCommand::SendText {
+                            surface_hint,
+                            reply,
+                            ..
+                        }
+                        | ControlCommand::SendKey {
+                            surface_hint,
+                            reply,
+                            ..
+                        }
+                        | ControlCommand::ReadSurfaceText {
+                            surface_hint,
+                            reply,
+                            ..
+                        } => (surface_hint, reply),
+                        other => panic!("unexpected command: {other:?}"),
+                    };
+                    assert_eq!(surface_hint.as_deref(), expected, "{method}");
+                    let _ = reply.send(Ok(json!({})));
+                });
+                assert_eq!(response.error, None);
+            }
+        }
     }
 
     #[test]

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -865,62 +865,59 @@ fn surface_hint_matches(surface_id: &str, tab_id: &str, surface_hint: &str) -> b
     !requested.is_empty() && (requested == tab_id || requested == surface_id)
 }
 
+fn select_terminal_tab<'a>(
+    pane_id: u32,
+    terminal_tab_ids: impl IntoIterator<Item = &'a str>,
+    active_tab: Option<&str>,
+    surface_hint: Option<&str>,
+) -> Option<&'a str> {
+    let mut fallback = None;
+    for tab_id in terminal_tab_ids {
+        if let Some(surface_hint) = surface_hint {
+            if surface_hint_matches(&composite_surface_id(pane_id, tab_id), tab_id, surface_hint) {
+                return Some(tab_id);
+            }
+            // An explicit target must not fall back to the active tab.
+            continue;
+        }
+        if active_tab == Some(tab_id) {
+            return Some(tab_id);
+        }
+        fallback.get_or_insert(tab_id);
+    }
+    fallback
+}
+
 pub fn terminal_handle_for_surface(
     pane_widget: &gtk::Widget,
     surface_hint: Option<&str>,
 ) -> Option<(String, terminal::TerminalHandle)> {
     let internals = find_pane_internals(pane_widget)?;
-    let pane_id = internals.pane_id;
     let tab_state = internals.tab_state.borrow();
-    let requested = surface_hint
-        .map(normalize_surface_hint)
-        .filter(|value| !value.is_empty());
-    let active_tab = tab_state.active_tab.as_deref();
-    let mut fallback = None;
-
-    for entry in &tab_state.tabs {
-        let TabKind::Terminal { state } = &entry.kind else {
-            continue;
-        };
-
-        let full_surface_id = composite_surface_id(pane_id, &entry.id);
-
-        if requested.is_some_and(|value| value == entry.id || value == full_surface_id) {
-            return Some((full_surface_id, state.handle.clone()));
-        }
-
-        if active_tab == Some(entry.id.as_str()) {
-            return Some((full_surface_id, state.handle.clone()));
-        }
-
-        if fallback.is_none() {
-            fallback = Some((full_surface_id, state.handle.clone()));
-        }
-    }
-
-    fallback
+    let terminal_tab_ids = tab_state.tabs.iter().filter_map(|entry| {
+        matches!(entry.kind, TabKind::Terminal { .. }).then_some(entry.id.as_str())
+    });
+    let tab_id = select_terminal_tab(
+        internals.pane_id,
+        terminal_tab_ids,
+        tab_state.active_tab.as_deref(),
+        surface_hint,
+    )?;
+    let entry = tab_state.tabs.iter().find(|entry| entry.id == tab_id)?;
+    let TabKind::Terminal { state } = &entry.kind else {
+        return None;
+    };
+    Some((
+        composite_surface_id(internals.pane_id, tab_id),
+        state.handle.clone(),
+    ))
 }
 
 pub fn exact_terminal_handle_for_surface(
     pane_widget: &gtk::Widget,
     surface_hint: &str,
 ) -> Option<(String, terminal::TerminalHandle)> {
-    let internals = find_pane_internals(pane_widget)?;
-    let pane_id = internals.pane_id;
-    let tab_state = internals.tab_state.borrow();
-
-    for entry in &tab_state.tabs {
-        let TabKind::Terminal { state } = &entry.kind else {
-            continue;
-        };
-
-        let full_surface_id = composite_surface_id(pane_id, &entry.id);
-        if surface_hint_matches(&full_surface_id, &entry.id, surface_hint) {
-            return Some((full_surface_id, state.handle.clone()));
-        }
-    }
-
-    None
+    terminal_handle_for_surface(pane_widget, Some(surface_hint))
 }
 
 // ---------------------------------------------------------------------------
@@ -2232,16 +2229,8 @@ pub fn terminal_handle_for_root(
     if let Some(requested) = requested {
         for internals in pane_internals_for_root(root) {
             let pane_widget: gtk::Widget = internals.pane_outer.clone().upcast();
-            if let Some((surface_id, handle)) =
-                terminal_handle_for_surface(&pane_widget, Some(requested))
-            {
-                if surface_id == requested
-                    || surface_id
-                        .strip_prefix("surface:")
-                        .is_some_and(|value| value == requested)
-                {
-                    return Some((surface_id, handle));
-                }
+            if let Some(target) = exact_terminal_handle_for_surface(&pane_widget, requested) {
+                return Some(target);
             }
         }
         return None;
@@ -4118,11 +4107,12 @@ mod tests {
         classify_content_drop_zone, content_drop_preview_rect, display_terminal_title,
         effective_drop_target_dimensions, is_localhost_input, next_active_after_tab_removal,
         normalize_browser_entry_input, normalize_reorder_insert_index, pane_action_tooltip,
-        resolved_link_destination, select_terminal_commands, surface_hint_matches,
-        workspace_autostart_initial_input, workspace_autostart_script, ContentDropZone,
-        TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS, BROWSER_SEARCH_ENTRY_CSS_CLASSES,
-        BROWSER_URL_ENTRY_CSS_CLASS, BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS,
-        TAB_RENAME_ENTRY_CSS_CLASS, TAB_RENAME_ENTRY_CSS_CLASSES,
+        resolved_link_destination, select_terminal_commands, select_terminal_tab,
+        surface_hint_matches, workspace_autostart_initial_input, workspace_autostart_script,
+        ContentDropZone, TabDragPayload, BROWSER_SEARCH_ENTRY_CSS_CLASS,
+        BROWSER_SEARCH_ENTRY_CSS_CLASSES, BROWSER_URL_ENTRY_CSS_CLASS,
+        BROWSER_URL_ENTRY_CSS_CLASSES, HOST_ENTRY_CSS_CLASS, PANE_CSS, TAB_RENAME_ENTRY_CSS_CLASS,
+        TAB_RENAME_ENTRY_CSS_CLASSES,
     };
     #[cfg(feature = "webkit")]
     use super::{
@@ -4130,6 +4120,39 @@ mod tests {
     };
     use crate::shortcut_config::{default_shortcuts, resolve_shortcuts_from_str, ShortcutId};
     use crate::{app_config::LinkOpenDestination, terminal::LinkOpenRequest};
+
+    #[test]
+    fn explicit_terminal_target_can_follow_the_active_tab() {
+        for target in ["agent", "4:agent", "surface:4:agent"] {
+            assert_eq!(
+                select_terminal_tab(4, ["shell", "agent"], Some("shell"), Some(target)),
+                Some("agent"),
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_missing_terminal_does_not_fall_back_to_active_tab() {
+        for target in ["missing", "5:agent", ""] {
+            assert_eq!(
+                select_terminal_tab(4, ["shell", "agent"], Some("shell"), Some(target)),
+                None,
+            );
+        }
+    }
+
+    #[test]
+    fn implicit_terminal_target_prefers_active_terminal_then_first_terminal() {
+        assert_eq!(
+            select_terminal_tab(4, ["shell", "agent"], Some("agent"), None),
+            Some("agent"),
+        );
+        assert_eq!(
+            select_terminal_tab(4, ["shell", "agent"], Some("browser"), None),
+            Some("shell"),
+        );
+        assert_eq!(select_terminal_tab(4, [], None, None), None);
+    }
 
     #[test]
     fn explicit_terminal_command_can_suppress_workspace_autostart() {

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -2222,9 +2222,7 @@ pub fn terminal_handle_for_root(
     root: &gtk::Widget,
     surface_hint: Option<&str>,
 ) -> Option<(String, terminal::TerminalHandle)> {
-    let requested = surface_hint
-        .map(normalize_surface_hint)
-        .filter(|value| !value.is_empty());
+    let requested = surface_hint.map(normalize_surface_hint);
 
     if let Some(requested) = requested {
         for internals in pane_internals_for_root(root) {
@@ -4133,7 +4131,7 @@ mod tests {
 
     #[test]
     fn explicit_missing_terminal_does_not_fall_back_to_active_tab() {
-        for target in ["missing", "5:agent", ""] {
+        for target in ["missing", "5:agent", "", "   ", "surface:", " surface:   "] {
             assert_eq!(
                 select_terminal_tab(4, ["shell", "agent"], Some("shell"), Some(target)),
                 None,

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -334,6 +334,30 @@ fn focused_ids_for_workspace(state: &State, workspace_id: &str) -> (Option<u32>,
     (Some(surface.pane_id), Some(surface.surface_id))
 }
 
+/// Resolve all terminal control operations through the same workspace-local target.
+/// Explicit surfaces must resolve exactly; otherwise use focus only within the
+/// requested workspace before falling back to that workspace's first terminal.
+fn control_terminal_target(
+    state: &State,
+    workspace_index: usize,
+    surface_hint: Option<&str>,
+) -> Option<(serde_json::Value, crate::terminal::TerminalHandle)> {
+    let app_state = state.borrow();
+    let workspace = &app_state.workspaces[workspace_index];
+    let (_, focused_surface_id) = focused_ids_for_workspace(state, &workspace.id);
+    let surface_hint = surface_hint.or(focused_surface_id.as_deref());
+    let (surface_id, handle) = pane::terminal_handle_for_root(&workspace.root, surface_hint)?;
+    Some((
+        serde_json::json!({
+            "workspace_id": workspace.id.as_str(),
+            "workspace_ref": workspace_ref(&workspace.id),
+            "surface_id": surface_id.as_str(),
+            "surface_ref": surface_ref(&surface_id),
+        }),
+        handle,
+    ))
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[allow(dead_code)]
 pub(crate) enum PaneCreateDirection {
@@ -4598,27 +4622,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 return;
             };
 
-            let target = {
-                let app_state = state.borrow();
-                let workspace = &app_state.workspaces[index];
-                let (_focused_pane_id, focused_surface_id) =
-                    focused_ids_for_workspace(state, &workspace.id);
-                let resolved_surface_hint =
-                    surface_hint.as_deref().or(focused_surface_id.as_deref());
-                pane::terminal_handle_for_root(&workspace.root, resolved_surface_hint).map(
-                    |(surface_id, handle)| {
-                        (
-                            serde_json::json!({
-                                "workspace_id": workspace.id.as_str(),
-                                "workspace_ref": workspace_ref(&workspace.id),
-                                "surface_id": surface_id.as_str(),
-                                "surface_ref": surface_ref(&surface_id),
-                            }),
-                            handle,
-                        )
-                    },
-                )
-            };
+            let target = control_terminal_target(state, index, surface_hint.as_deref());
 
             let Some((mut payload, handle)) = target else {
                 let _ = reply.send(Err(crate::control_bridge::BridgeError::not_found(
@@ -4650,23 +4654,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 return;
             };
 
-            let target = {
-                let app_state = state.borrow();
-                let workspace = &app_state.workspaces[index];
-                pane::terminal_handle_for_root(&workspace.root, surface_hint.as_deref()).map(
-                    |(surface_id, handle)| {
-                        (
-                            serde_json::json!({
-                                "workspace_id": workspace.id.as_str(),
-                                "workspace_ref": workspace_ref(&workspace.id),
-                                "surface_id": surface_id.as_str(),
-                                "surface_ref": surface_ref(&surface_id),
-                            }),
-                            handle,
-                        )
-                    },
-                )
-            };
+            let target = control_terminal_target(state, index, surface_hint.as_deref());
 
             let Some((mut payload, handle)) = target else {
                 let _ = reply.send(Err(crate::control_bridge::BridgeError::not_found(
@@ -4704,23 +4692,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 return;
             };
 
-            let target = {
-                let app_state = state.borrow();
-                let workspace = &app_state.workspaces[index];
-                pane::terminal_handle_for_root(&workspace.root, surface_hint.as_deref()).map(
-                    |(surface_id, handle)| {
-                        (
-                            serde_json::json!({
-                                "workspace_id": workspace.id.as_str(),
-                                "workspace_ref": workspace_ref(&workspace.id),
-                                "surface_id": surface_id.as_str(),
-                                "surface_ref": surface_ref(&surface_id),
-                            }),
-                            handle,
-                        )
-                    },
-                )
-            };
+            let target = control_terminal_target(state, index, surface_hint.as_deref());
 
             let Some((mut payload, handle)) = target else {
                 let _ = reply.send(Err(crate::control_bridge::BridgeError::not_found(

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -335,8 +335,9 @@ fn focused_ids_for_workspace(state: &State, workspace_id: &str) -> (Option<u32>,
 }
 
 /// Resolve all terminal control operations through the same workspace-local target.
-/// Explicit surfaces must resolve exactly; otherwise use focus only within the
-/// requested workspace before falling back to that workspace's first terminal.
+/// Explicit surfaces must resolve exactly. With no explicit surface, use the
+/// requested workspace's focused surface; a focused browser is not a terminal
+/// target. Fall back to the first terminal only when no surface has focus.
 fn control_terminal_target(
     state: &State,
     workspace_index: usize,

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -493,6 +493,68 @@ ENV_SURFACE="$(sed -n '3p' "$SELF_SPLIT_ENV")"
 }
 echo "stage 6: OK (self-split command ran with fresh LIMUX_* env)"
 
+# Keep text, key, and screen operations on the newly focused split, even when
+# the caller has no explicit surface. The first pane must not receive Enter.
+echo
+echo "== stage 6b: consistent terminal control targets =="
+ROUTING_PROOF="$DEMO_DIR/routing-proof"
+ROUTING_COMMAND="printf '%s' \"\$LIMUX_SURFACE_ID\" > '$ROUTING_PROOF'; printf 'routing-visible\\n'"
+"$LIMUX_CLI" --json --id-format both send --workspace limux "$ROUTING_COMMAND" >"$LOG_DIR/stage6b-send.json"
+"$LIMUX_CLI" --json --id-format both send-key --workspace limux Enter >"$LOG_DIR/stage6b-key.json"
+for _ in $(seq 1 50); do
+  [ -f "$ROUTING_PROOF" ] && break
+  sleep 0.1
+done
+[ -f "$ROUTING_PROOF" ] && [ "$(cat "$ROUTING_PROOF")" = "$RESPONSE_SURFACE" ] \
+  || { echo "FAIL: implicit send and Enter did not execute in the focused split"; exit 1; }
+for _ in $(seq 1 50); do
+  "$LIMUX_CLI" --json --id-format both read-screen --workspace limux >"$LOG_DIR/stage6b-read.json"
+  jq -e '.text | contains("routing-visible")' "$LOG_DIR/stage6b-read.json" >/dev/null && break
+  sleep 0.1
+done
+for operation in send key read; do
+  jq -e --arg surface "$RESPONSE_SURFACE" '.surface_id == $surface' \
+    "$LOG_DIR/stage6b-$operation.json" >/dev/null \
+    || { echo "FAIL: $operation targeted a different surface from the focused split"; exit 1; }
+done
+jq -e '.text | contains("routing-visible")' "$LOG_DIR/stage6b-read.json" >/dev/null \
+  || { echo "FAIL: focused terminal output was not readable"; exit 1; }
+
+# An explicit invalid target must fail instead of falling back to focus.
+for operation in send send-key read-screen; do
+  case "$operation" in
+    send) routing_args=("should-not-be-sent") ;;
+    send-key) routing_args=(Enter) ;;
+    read-screen) routing_args=() ;;
+  esac
+  if "$LIMUX_CLI" "$operation" --workspace limux --surface missing-surface \
+      "${routing_args[@]}" >"$LOG_DIR/stage6b-invalid-$operation.txt" 2>&1; then
+    echo "FAIL: $operation accepted a missing explicit surface"
+    exit 1
+  fi
+done
+# Focusing another workspace must not redirect an explicitly scoped request.
+"$LIMUX_CLI" --json --id-format both new-workspace --cwd "$DEMO_DIR" >"$LOG_DIR/stage6b-other-workspace.json"
+OTHER_WORKSPACE="$(jq -r '.workspace_id' "$LOG_DIR/stage6b-other-workspace.json")"
+"$LIMUX_CLI" select-workspace --workspace "$OTHER_WORKSPACE" >"$LOG_DIR/stage6b-other-select.txt"
+"$LIMUX_CLI" --json --id-format both send --workspace limux : >"$LOG_DIR/stage6b-background-send.json"
+"$LIMUX_CLI" --json --id-format both send-key --workspace limux Enter >"$LOG_DIR/stage6b-background-key.json"
+"$LIMUX_CLI" --json --id-format both read-screen --workspace limux >"$LOG_DIR/stage6b-background-read.json"
+BACKGROUND_SURFACE="$(jq -r '.surface_id' "$LOG_DIR/stage6b-background-send.json")"
+for operation in send key read; do
+  jq -e --arg workspace "$WORKSPACE_ID" --arg surface "$BACKGROUND_SURFACE" \
+    '.workspace_id == $workspace and .surface_id == $surface' \
+    "$LOG_DIR/stage6b-background-$operation.json" >/dev/null \
+    || { echo "FAIL: background $operation escaped the requested workspace"; exit 1; }
+done
+if "$LIMUX_CLI" send-key --workspace "$OTHER_WORKSPACE" --surface "$BACKGROUND_SURFACE" Enter \
+    >"$LOG_DIR/stage6b-foreign-surface.txt" 2>&1; then
+  echo "FAIL: explicit surface from another workspace was accepted"
+  exit 1
+fi
+"$LIMUX_CLI" close-workspace --workspace "$OTHER_WORKSPACE" >"$LOG_DIR/stage6b-other-close.txt"
+echo "stage 6b: OK (text, Enter, and screen read share the focused target)"
+
 # --- 10. Stage 7: hook translators end-to-end -----------------------------
 echo
 echo "== stage 7: claude-hook event translation =="


### PR DESCRIPTION
With two terminal panes and the second focused, `send` currently targets that pane while `send-key Enter` and `read-screen` fall back to the first pane. This can execute unrelated pending input or interrupt the wrong process. All three operations now use one workspace-scoped resolver: explicit surface, then focus within that workspace, then its existing first-terminal fallback.

Exact targeting also searches past an earlier active tab, so a valid inactive agent surface remains reachable. Missing, foreign, blank, and prefix-only surface IDs do not fall back to another terminal. The CLI also rejects an explicitly empty --surface before connecting, including an unset shell variable expanded as an empty argument.

## Validation

- Added three selector regressions covering inactive tabs, surface aliases, missing targets, active selection, and fallback.
- Extended the maintained GTK smoke harness to check actual command execution and matching text/key/read response IDs, plus background workspace isolation and invalid-target rejection.
- All 252 host unit tests and 32 CLI tests passed in the no-WebKit build, as did strict host test-target Clippy, formatting, shell syntax, and diff checks.
- The complete maintained GTK smoke harness passed, including the new routing assertions, using the exact pinned Ghostty library and a temporary Weston installation. A local cargo wrapper selected `--no-default-features` because the WebKit development package is unavailable.
- All-target no-WebKit Clippy still reports six existing unused browser helpers/constants; the default-feature quality gate remains covered by upstream CI.

The follow-up live test rejected all 12 malformed-target requests without delivering input to either test terminal. Valid explicit targets continued to work.

## Reproduction

Create two terminal panes in one workspace and focus the second. From a separate CLI client targeting that active workspace, run:

```bash
limux --json send 'printf routing-ok'
limux --json send-key Enter
limux --json read-screen
```

All responses should name the second pane's surface, and that pane should execute the command. Previously the key and read responses named the first pane.

## Downsides

When a nonterminal tab is focused, all three operations now consistently fail instead of sending keystrokes to another terminal. Callers wanting another surface should specify `--surface`. Inactive workspaces retain their existing first-terminal fallback.
