### PR TITLE
fix(cli): serialize agent hook session updates

### DIFF
--- a/rust/limux-cli/src/agent_hooks.rs
+++ b/rust/limux-cli/src/agent_hooks.rs
@@ -1,11 +1,14 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
+use std::fs::{self, File, TryLockError};
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const STORE_LOCK_TIMEOUT: Duration = Duration::from_secs(2);
+const STORE_LOCK_RETRY: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -116,7 +119,8 @@ impl AgentHookSessionStore {
         }
     }
 
-    pub(crate) fn lookup(&self, session_id: &str) -> Result<Option<AgentHookSessionRecord>> {
+    #[cfg(test)]
+    fn lookup(&self, session_id: &str) -> Result<Option<AgentHookSessionRecord>> {
         let session_id = normalized(session_id);
         if session_id.is_none() {
             return Ok(None);
@@ -125,11 +129,17 @@ impl AgentHookSessionStore {
         Ok(file.sessions.get(session_id.as_deref().unwrap()).cloned())
     }
 
-    pub(crate) fn upsert(&self, record: AgentHookSessionRecord) -> Result<()> {
-        let Some(session_id) = normalized(&record.session_id) else {
+    pub(crate) fn update(
+        &self,
+        session_id: &str,
+        update: impl FnOnce(Option<&AgentHookSessionRecord>) -> AgentHookSessionRecord,
+    ) -> Result<()> {
+        let Some(session_id) = normalized(session_id) else {
             return Ok(());
         };
+        let _lock = self.lock()?;
         let mut file = self.load()?;
+        let record = update(file.sessions.get(&session_id));
         file.version = 1;
         file.sessions.insert(session_id, record);
         self.save(&file)
@@ -139,9 +149,46 @@ impl AgentHookSessionStore {
         let Some(session_id) = normalized(session_id) else {
             return Ok(());
         };
+        let _lock = self.lock()?;
         let mut file = self.load()?;
         file.sessions.remove(&session_id);
         self.save(&file)
+    }
+
+    fn lock(&self) -> Result<File> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        // Keep a stable sibling inode: the JSON is replaced by rename, and
+        // unlinking the lock file would let another writer lock a different inode.
+        let lock_path = self.path.with_extension("lock");
+        let lock = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("failed to open {}", lock_path.display()))?;
+        let deadline = Instant::now() + STORE_LOCK_TIMEOUT;
+        loop {
+            match lock.try_lock() {
+                Ok(()) => return Ok(lock),
+                Err(TryLockError::WouldBlock) => {
+                    if Instant::now() >= deadline {
+                        bail!(
+                            "timed out acquiring hook store lock {}",
+                            lock_path.display()
+                        );
+                    }
+                    std::thread::sleep(STORE_LOCK_RETRY);
+                }
+                Err(TryLockError::Error(error)) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to lock {}", lock_path.display()));
+                }
+            }
+        }
     }
 
     fn load(&self) -> Result<AgentHookSessionFile> {
@@ -489,12 +536,170 @@ mod tests {
             updated_at: 11.0,
         };
 
-        store.upsert(record.clone()).expect("upsert");
+        store
+            .update(&record.session_id, |_| record.clone())
+            .expect("update");
 
         assert_eq!(
             store.lookup("codex-session-1").expect("lookup"),
             Some(record)
         );
+    }
+
+    fn test_record(session_id: &str) -> AgentHookSessionRecord {
+        AgentHookSessionRecord {
+            session_id: session_id.to_string(),
+            workspace_id: "workspace".to_string(),
+            surface_id: format!("1:{session_id}"),
+            cwd: Some("/fresh-cwd".to_string()),
+            pid: None,
+            launch_command: None,
+            updated_at: now_seconds(),
+        }
+    }
+
+    fn await_marker(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    struct Worker(std::process::Child);
+
+    impl Worker {
+        fn start(dir: &Path, action: &str) -> Self {
+            Self(
+                std::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "agent_hooks::tests::hook_store_process_worker",
+                        "--nocapture",
+                    ])
+                    .env("LIMUX_HOOK_TEST_DIR", dir)
+                    .env("LIMUX_HOOK_TEST_ACTION", action)
+                    .stdout(std::process::Stdio::null())
+                    .spawn()
+                    .unwrap(),
+            )
+        }
+
+        fn finish(&mut self) {
+            assert!(self.0.wait().unwrap().success());
+        }
+    }
+
+    impl Drop for Worker {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    // Run in separate processes so these tests exercise OS lock semantics,
+    // including descriptor release on termination, rather than a thread mutex.
+    #[test]
+    fn hook_store_process_worker() {
+        let Ok(dir) = std::env::var("LIMUX_HOOK_TEST_DIR") else {
+            return;
+        };
+        let dir = Path::new(&dir);
+        let action = std::env::var("LIMUX_HOOK_TEST_ACTION").unwrap();
+        let store = AgentHookSessionStore::new_for_dir("codex", dir);
+        if action == "hold" {
+            store
+                .update("first", |_| {
+                    fs::write(dir.join("held"), "").unwrap();
+                    await_marker(&dir.join("release"));
+                    test_record("first")
+                })
+                .unwrap();
+            return;
+        }
+
+        // The first worker has entered its merge closure. Verify it actually
+        // holds the kernel lock before allowing the parent to release it.
+        let probe = File::options()
+            .read(true)
+            .write(true)
+            .open(store.path.with_extension("lock"))
+            .unwrap();
+        assert!(matches!(probe.try_lock(), Err(TryLockError::WouldBlock)));
+        fs::write(dir.join("contended"), "").unwrap();
+        match action.as_str() {
+            "insert" => store.update("second", |_| test_record("second")).unwrap(),
+            "merge" => store
+                .update("first", |existing| {
+                    let mut record = existing.expect("must see committed first update").clone();
+                    assert_eq!(record.cwd.as_deref(), Some("/fresh-cwd"));
+                    record.pid = Some(42);
+                    record
+                })
+                .unwrap(),
+            "remove" => store.remove("remove-me").unwrap(),
+            _ => panic!("unknown worker action"),
+        }
+    }
+
+    #[test]
+    fn concurrent_process_transactions_preserve_sessions_merges_and_cleanup() {
+        for action in ["insert", "merge", "remove"] {
+            let dir = tempdir().unwrap();
+            let store = AgentHookSessionStore::new_for_dir("codex", dir.path());
+            store
+                .update("remove-me", |_| test_record("remove-me"))
+                .unwrap();
+            let mut first = Worker::start(dir.path(), "hold");
+            await_marker(&dir.path().join("held"));
+            let mut second = Worker::start(dir.path(), action);
+            await_marker(&dir.path().join("contended"));
+            fs::write(dir.path().join("release"), "").unwrap();
+            first.finish();
+            second.finish();
+
+            let first = store.lookup("first").unwrap().unwrap();
+            assert_eq!(first.cwd.as_deref(), Some("/fresh-cwd"));
+            match action {
+                "insert" => assert!(store.lookup("second").unwrap().is_some()),
+                "merge" => assert_eq!(first.pid, Some(42)),
+                "remove" => assert!(store.lookup("remove-me").unwrap().is_none()),
+                _ => unreachable!(),
+            }
+            if action != "remove" {
+                assert!(store.lookup("remove-me").unwrap().is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn killed_writer_releases_lock_without_deleting_lock_file() {
+        let dir = tempdir().unwrap();
+        let store = AgentHookSessionStore::new_for_dir("codex", dir.path());
+        let mut holder = Worker::start(dir.path(), "hold");
+        await_marker(&dir.path().join("held"));
+        holder.0.kill().unwrap();
+        holder.0.wait().unwrap();
+        assert!(store.path.with_extension("lock").exists());
+        store.update("next", |_| test_record("next")).unwrap();
+        assert!(store.lookup("next").unwrap().is_some());
+    }
+
+    #[test]
+    fn lock_timeout_does_not_modify_session_store() {
+        let dir = tempdir().unwrap();
+        let store = AgentHookSessionStore::new_for_dir("codex", dir.path());
+        store.update("saved", |_| test_record("saved")).unwrap();
+        let before = fs::read(&store.path).unwrap();
+        let _holder = Worker::start(dir.path(), "hold");
+        await_marker(&dir.path().join("held"));
+        let result = store.update("blocked", |_| panic!("must not merge without lock"));
+        assert!(result.unwrap_err().to_string().contains("timed out"));
+        assert_eq!(fs::read(&store.path).unwrap(), before);
     }
 
     #[test]

--- a/rust/limux-cli/src/main.rs
+++ b/rust/limux-cli/src/main.rs
@@ -1179,30 +1179,27 @@ fn persist_agent_hook_session(
         return Ok(());
     };
 
-    let existing = store.lookup(&session_id)?;
-    let cwd = hook_str(payload, &["cwd", "working_directory", "directory"])
-        .map(str::to_string)
-        .or_else(|| existing.as_ref().and_then(|record| record.cwd.clone()));
-    let pid = hook_str(payload, &["pid"])
-        .and_then(|value| value.parse::<u32>().ok())
-        .or_else(|| agent_ancestor_pid(agent))
-        .or_else(|| existing.as_ref().and_then(|record| record.pid));
-    let launch_command = agent_hooks::launch_record_from_env(agent, cwd.as_deref()).or_else(|| {
-        existing
-            .as_ref()
-            .and_then(|record| record.launch_command.clone())
-    });
+    let result = store.update(&session_id, |existing| {
+        let cwd = hook_str(payload, &["cwd", "working_directory", "directory"])
+            .map(str::to_string)
+            .or_else(|| existing.and_then(|record| record.cwd.clone()));
+        let pid = hook_str(payload, &["pid"])
+            .and_then(|value| value.parse::<u32>().ok())
+            .or_else(|| agent_ancestor_pid(agent))
+            .or_else(|| existing.and_then(|record| record.pid));
+        let launch_command = agent_hooks::launch_record_from_env(agent, cwd.as_deref())
+            .or_else(|| existing.and_then(|record| record.launch_command.clone()));
 
-    let record = agent_hooks::AgentHookSessionRecord {
-        session_id,
-        workspace_id,
-        surface_id,
-        cwd,
-        pid,
-        launch_command,
-        updated_at: agent_hooks::now_seconds(),
-    };
-    let result = store.upsert(record);
+        agent_hooks::AgentHookSessionRecord {
+            session_id: session_id.clone(),
+            workspace_id,
+            surface_id,
+            cwd,
+            pid,
+            launch_command,
+            updated_at: agent_hooks::now_seconds(),
+        }
+    });
     if result.is_ok() {
         write_agent_hook_debug(
             agent,


### PR DESCRIPTION
Concurrent agent hooks can each read the same session store and then replace it with different snapshots. Both commands succeed, but the last rename drops the other agent's restoration record. On the next layout save/restart, that terminal opens a shell instead of resuming its agent.

Serialize each store's complete read–merge–write transaction with a persistent sibling OS lock. Existing launch metadata is merged inside the lock, and cleanup shares the same transaction boundary. The lock is released automatically when a process exits or is killed.

## Reproduction

Run two `claude-hook` SessionStart commands concurrently with distinct session IDs and the same `LIMUX_AGENT_HOOK_STATE_DIR`. Pause both immediately before their store rename: each pending snapshot contains only its own new record. After both successful commands finish, the original code retains only one. The added subprocess tests deterministically exercise overlapping transactions, updates to the same record, and cleanup.

## Validation

- 34 CLI tests passed, including process contention, metadata preservation, cleanup, killed-writer recovery, and timeout preservation.
- Strict CLI Clippy and formatting passed.
- Actual CLI stress run: 100 successful concurrent hooks, all 100 session records retained.
- The full local workspace gate is blocked by the unavailable Ghostty library in this isolated CLI checkout; native host code is unchanged.

## Downsides

Contending hooks wait up to two seconds for the store lock, then return an explicit error without replacing the store. A small persistent lock file is retained beside each agent's JSON file so all processes lock the same inode.
