### PR TITLE
fix(host): preserve terminal input whitespace

### DIFF
--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -598,7 +598,11 @@ fn handle_method(
             (ControlCommand::CloseWorkspace { target, reply }, rx)
         }
         "surface.send_text" | "send-text" | "send" => {
-            let Some(text) = optional_string(params, &["text"]) else {
+            let Some(text) = params
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            else {
                 return error_response(
                     id,
                     BridgeError::invalid_params("surface.send_text requires text"),
@@ -615,7 +619,7 @@ fn handle_method(
                 ControlCommand::SendText {
                     target,
                     surface_hint: optional_string(params, &["surface_id"]),
-                    text,
+                    text: text.to_string(),
                     reply,
                 },
                 rx,
@@ -851,6 +855,43 @@ mod tests {
             .expect("v1 request should parse");
         assert_eq!(request.method, "workspace.create");
         assert_eq!(request.params["cwd"], "/tmp");
+    }
+
+    #[test]
+    fn send_text_preserves_whitespace_for_every_alias() {
+        for method in ["surface.send_text", "send-text", "send"] {
+            for text in ["  alpha\nbeta\t \n", "\n\t  ", "  λ 🦀 \n"] {
+                let response = dispatch_request(
+                    &json!({ "id": 1, "method": method, "params": { "text": text } }).to_string(),
+                    &|command| match command {
+                        ControlCommand::SendText {
+                            text: actual,
+                            reply,
+                            ..
+                        } => {
+                            assert_eq!(actual, text);
+                            reply.send(Ok(json!({}))).unwrap();
+                        }
+                        other => panic!("unexpected command: {other:?}"),
+                    },
+                );
+                assert_eq!(response.error, None);
+            }
+        }
+    }
+
+    #[test]
+    fn send_text_rejects_missing_empty_and_non_string_text() {
+        for params in [json!({}), json!({ "text": "" }), json!({ "text": 1 })] {
+            let response = dispatch_request(
+                &json!({ "method": "surface.send_text", "params": params }).to_string(),
+                &|command| panic!("invalid text should not dispatch: {command:?}"),
+            );
+            assert_eq!(
+                response.error.as_ref().map(|error| error.code),
+                Some(INVALID_PARAMS_CODE)
+            );
+        }
     }
 
     #[test]

--- a/rust/limux-host-linux/src/control_bridge.rs
+++ b/rust/limux-host-linux/src/control_bridge.rs
@@ -602,6 +602,7 @@ fn handle_method(
                 .get("text")
                 .and_then(Value::as_str)
                 .filter(|text| !text.is_empty())
+                .map(str::to_owned)
             else {
                 return error_response(
                     id,
@@ -619,7 +620,7 @@ fn handle_method(
                 ControlCommand::SendText {
                     target,
                     surface_hint: optional_string(params, &["surface_id"]),
-                    text: text.to_string(),
+                    text,
                     reply,
                 },
                 rx,


### PR DESCRIPTION
The GTK control bridge trims `surface.send_text` through the generic identifier parser. Leading spaces, trailing tabs, and final newlines disappear; whitespace-only input is rejected. This changes pasted terminal text and the agent message envelopes generated by the CLI.

Read the text payload without trimming it. Keep rejecting missing, empty, and non-string values. Add dispatcher regressions for all three command aliases, whitespace-only text, Unicode, and invalid payloads.

## Reproduction

Send `"  alpha\nbeta\t \n"` to a terminal running a raw PTY capture. Before the fix it receives `"alpha\rbeta"`; afterward it receives `"  alpha\rbeta\t \r"`. LF-to-CR conversion is Ghostty's normal terminal behavior. The bridge now preserves the surrounding whitespace and final terminator. Shell execution still depends on the shell's paste handling.

## Validation

- 249 native host tests passed under private Xvfb, including the new dispatcher regressions.
- Strict host test-target Clippy and formatting passed with default WebKit features disabled locally.
- Live GTK/raw-PTY checks passed for surrounding whitespace, a multiline agent envelope, and whitespace-only input.
- The default workspace gate is blocked locally by unavailable WebKit development dependencies; CI runs that configuration.
