### PR TITLE
fix(host): preserve concurrent session changes

### DIFF
--- a/rust/limux-host-linux/src/layout_state.rs
+++ b/rust/limux-host-linux/src/layout_state.rs
@@ -333,15 +333,15 @@ pub fn load_session_from_dir(dir: &Path) -> LoadedSession {
     }
 }
 
-pub fn save_session_atomic(state: &AppSessionState) -> io::Result<PathBuf> {
-    save_session_atomic_in(&persistence_dir(), state)
-}
-
 pub fn save_session_atomic_in(dir: &Path, state: &AppSessionState) -> io::Result<PathBuf> {
     fs::create_dir_all(dir)?;
     let path = canonical_session_path_in(dir);
+    save_session_atomic_to(&path, state)
+}
+
+pub(crate) fn save_session_atomic_to(path: &Path, state: &AppSessionState) -> io::Result<PathBuf> {
     // Write to a sibling temp file first so a crash never leaves a truncated canonical session.
-    let temp_path = temp_session_path(&path);
+    let temp_path = temp_session_path(path);
     let normalized = normalize_session(state.clone());
     let json = serde_json::to_vec_pretty(&normalized)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
@@ -357,8 +357,8 @@ pub fn save_session_atomic_in(dir: &Path, state: &AppSessionState) -> io::Result
         .open(&temp_path)?;
     temp_file.write_all(&json)?;
     drop(temp_file);
-    fs::rename(&temp_path, &path)?;
-    Ok(path)
+    fs::rename(&temp_path, path)?;
+    Ok(path.to_path_buf())
 }
 
 pub fn clamp_split_ratio(ratio: f64) -> f64 {

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -7,6 +7,7 @@ mod keybind_editor;
 mod layout_state;
 mod link_uri;
 mod pane;
+mod session_store;
 mod settings_editor;
 mod shortcut_config;
 mod split_tree;

--- a/rust/limux-host-linux/src/session_store.rs
+++ b/rust/limux-host-linux/src/session_store.rs
@@ -53,14 +53,43 @@ impl SessionStore {
         if changed {
             layout_state::save_session_atomic_in(directory, &loaded.state)?;
         }
-        let store = Self {
+        let store = Self::from_snapshot(directory, &loaded.state);
+        Ok((store, loaded))
+    }
+
+    /// Keep a strictly read startup snapshot when a temporary writer lock or
+    /// write-permission failure prevents normal loading. No migration is safe
+    /// without the lock, so this requires already stable workspace identities.
+    pub(crate) fn load_for_retry() -> io::Result<(Self, LoadedSession)> {
+        Self::load_for_retry_from_dir(&layout_state::persistence_dir())
+    }
+
+    fn load_for_retry_from_dir(directory: &Path) -> io::Result<(Self, LoadedSession)> {
+        let loaded = read_session(directory)?;
+        let mut ids = BTreeSet::new();
+        if loaded.state.workspaces.iter().any(|workspace| {
+            workspace
+                .id
+                .as_deref()
+                .is_none_or(|id| uuid::Uuid::parse_str(id).is_err() || !ids.insert(id.to_string()))
+        }) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Session workspace identities require migration before saving. Restart after resolving the storage error.",
+            ));
+        }
+        let store = Self::from_snapshot(directory, &loaded.state);
+        Ok((store, loaded))
+    }
+
+    fn from_snapshot(directory: &Path, snapshot: &AppSessionState) -> Self {
+        Self {
             directory: directory.to_path_buf(),
             recovery: directory.join(format!("session-recovery-{}.json", uuid::Uuid::new_v4())),
-            local: loaded.state.clone(),
-            ancestry: loaded.state.clone(),
+            local: snapshot.clone(),
+            ancestry: snapshot.clone(),
             first_save: true,
-        };
-        Ok((store, loaded))
+        }
     }
 
     pub(crate) fn restored(&mut self, local: AppSessionState) {

--- a/rust/limux-host-linux/src/session_store.rs
+++ b/rust/limux-host-linux/src/session_store.rs
@@ -1,0 +1,394 @@
+//! Serialize session writers and apply only changes made by this window.
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+use crate::layout_state::{self, AppSessionState, LoadedSession, WorkspaceState};
+
+pub(crate) enum SaveOutcome {
+    Saved,
+    Conflict {
+        recovery: PathBuf,
+        workspaces: Vec<String>,
+    },
+}
+
+pub(crate) struct SessionStore {
+    directory: PathBuf,
+    recovery: PathBuf,
+    // GTK can materialize missing pane IDs or update restoration metadata.
+    // Compare local changes with the actual restored UI, not its serialized input.
+    local: AppSessionState,
+    // Keep ancestry for each locally known workspace. Preserving an unseen remote
+    // edit must not make that edit the baseline for a later stale local change.
+    ancestry: AppSessionState,
+    first_save: bool,
+}
+
+impl SessionStore {
+    pub(crate) fn load() -> io::Result<(Self, LoadedSession)> {
+        Self::load_from_dir(&layout_state::persistence_dir())
+    }
+
+    pub(crate) fn load_from_dir(directory: &Path) -> io::Result<(Self, LoadedSession)> {
+        let _lock = lock_directory(directory)?;
+        let mut loaded = read_session(directory)?;
+        let mut changed = false;
+        let mut ids = BTreeSet::new();
+        for workspace in &mut loaded.state.workspaces {
+            if workspace
+                .id
+                .as_deref()
+                .is_none_or(|id| uuid::Uuid::parse_str(id).is_err() || !ids.insert(id.to_string()))
+            {
+                let id = uuid::Uuid::new_v4().to_string();
+                ids.insert(id.clone());
+                workspace.id = Some(id);
+                changed = true;
+            }
+        }
+        // Migrate identity once, under the writer lock, before another window loads.
+        if changed {
+            layout_state::save_session_atomic_in(directory, &loaded.state)?;
+        }
+        let store = Self {
+            directory: directory.to_path_buf(),
+            recovery: directory.join(format!("session-recovery-{}.json", uuid::Uuid::new_v4())),
+            local: loaded.state.clone(),
+            ancestry: loaded.state.clone(),
+            first_save: true,
+        };
+        Ok((store, loaded))
+    }
+
+    pub(crate) fn restored(&mut self, local: AppSessionState) {
+        self.local = layout_state::normalize_session(local);
+    }
+
+    pub(crate) fn save(&mut self, local: &AppSessionState) -> io::Result<SaveOutcome> {
+        let _lock = lock_directory(&self.directory)?;
+        let disk = read_session(&self.directory)?.state;
+        let local = layout_state::normalize_session(local.clone());
+        match merge_session(&self.local, &self.ancestry, &local, &disk, self.first_save) {
+            Ok((merged, ancestry)) => {
+                layout_state::save_session_atomic_in(&self.directory, &merged)?;
+                self.local = local;
+                self.ancestry = ancestry;
+                self.first_save = false;
+                Ok(SaveOutcome::Saved)
+            }
+            Err(workspaces) => {
+                layout_state::save_session_atomic_to(&self.recovery, &local)?;
+                Ok(SaveOutcome::Conflict {
+                    recovery: self.recovery.clone(),
+                    workspaces,
+                })
+            }
+        }
+    }
+}
+
+fn lock_directory(directory: &Path) -> io::Result<File> {
+    fs::create_dir_all(directory)?;
+    // Never unlink or replace this inode: all writers must lock the same file,
+    // including while session.json itself is replaced by an atomic rename.
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .open(directory.join("session.lock"))?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        match lock.try_lock() {
+            Ok(()) => return Ok(lock),
+            Err(std::fs::TryLockError::WouldBlock) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(std::fs::TryLockError::WouldBlock) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "Another Limux window is saving the session. Try again shortly.",
+                ))
+            }
+            Err(std::fs::TryLockError::Error(error)) => return Err(error),
+        }
+    }
+}
+
+fn read_session(directory: &Path) -> io::Result<LoadedSession> {
+    let canonical = layout_state::canonical_session_path_in(directory);
+    match fs::read(&canonical) {
+        Ok(bytes) => {
+            let state = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+            Ok(LoadedSession {
+                state: layout_state::normalize_session(state),
+                source: layout_state::SessionLoadSource::Canonical,
+            })
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let legacy = layout_state::legacy_workspaces_path_in(directory);
+            match fs::read(legacy) {
+                Ok(bytes) => {
+                    let workspaces = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+                    Ok(LoadedSession {
+                        state: AppSessionState::from_legacy(workspaces),
+                        source: layout_state::SessionLoadSource::Legacy,
+                    })
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(LoadedSession {
+                    state: AppSessionState::default(),
+                    source: layout_state::SessionLoadSource::Empty,
+                }),
+                Err(error) => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn workspace_map(state: &AppSessionState) -> BTreeMap<&str, &WorkspaceState> {
+    state
+        .workspaces
+        .iter()
+        .filter_map(|workspace| workspace.id.as_deref().map(|id| (id, workspace)))
+        .collect()
+}
+
+fn workspace_order(state: &AppSessionState) -> Vec<String> {
+    state
+        .workspaces
+        .iter()
+        .filter_map(|workspace| workspace.id.clone())
+        .collect()
+}
+
+fn selected_id(state: &AppSessionState) -> Option<&str> {
+    state
+        .workspaces
+        .get(state.active_workspace_index)
+        .and_then(|workspace| workspace.id.as_deref())
+}
+
+fn merge_session(
+    previous_local: &AppSessionState,
+    previous_disk: &AppSessionState,
+    local: &AppSessionState,
+    disk: &AppSessionState,
+    first_save: bool,
+) -> Result<(AppSessionState, AppSessionState), Vec<String>> {
+    let old_local = workspace_map(previous_local);
+    let old_disk = workspace_map(previous_disk);
+    let current_local = workspace_map(local);
+    let current_disk = workspace_map(disk);
+    let ids: BTreeSet<_> = old_local
+        .keys()
+        .chain(old_disk.keys())
+        .chain(current_local.keys())
+        .chain(current_disk.keys())
+        .copied()
+        .collect();
+    let mut merged = BTreeMap::new();
+    let mut ancestry = old_disk.clone();
+    let mut conflicts = Vec::new();
+    let mut accepted = BTreeSet::new();
+    for id in ids {
+        let before = old_local.get(id).copied();
+        let ancestor = old_disk.get(id).copied();
+        let ours = current_local.get(id).copied();
+        let theirs = current_disk.get(id).copied();
+        let changed = ours != before || (first_save && ours.is_some() && ancestor.is_none());
+        let normalize_own = first_save && ours.is_some() && theirs == ancestor;
+        let chosen = if ours == theirs || ((changed || normalize_own) && theirs == ancestor) {
+            accepted.insert(id.to_string());
+            match ours {
+                Some(workspace) => {
+                    ancestry.insert(id, workspace);
+                }
+                None => {
+                    ancestry.remove(id);
+                }
+            }
+            ours
+        } else if !changed {
+            // Do not advance ancestry to a remote edit that this UI never saw.
+            theirs
+        } else {
+            conflicts.push(
+                ours.or(theirs)
+                    .or(ancestor)
+                    .map(|workspace| workspace.name.clone())
+                    .unwrap_or_else(|| id.to_string()),
+            );
+            continue;
+        };
+        if let Some(workspace) = chosen {
+            merged.insert(id.to_string(), workspace.clone());
+        }
+    }
+    if !conflicts.is_empty() {
+        return Err(conflicts);
+    }
+
+    // Respect explicit local reordering while retaining remotely added workspaces.
+    // Two incompatible reorderings are a conflict rather than an implicit winner.
+    let common: BTreeSet<_> = old_local
+        .keys()
+        .filter(|id| current_local.contains_key(**id) && current_disk.contains_key(**id))
+        .copied()
+        .collect();
+    let relative = |state: &AppSessionState| {
+        workspace_order(state)
+            .into_iter()
+            .filter(|id| common.contains(id.as_str()))
+            .collect::<Vec<_>>()
+    };
+    let local_reordered = relative(local) != relative(previous_local);
+    if local_reordered
+        && relative(disk) != relative(previous_disk)
+        && relative(local) != relative(disk)
+    {
+        return Err(vec!["workspace order".to_string()]);
+    }
+    let mut order = if local_reordered {
+        workspace_order(local)
+    } else {
+        workspace_order(disk)
+    };
+    order.extend(workspace_order(local));
+    let mut workspaces = Vec::new();
+    for id in order {
+        if let Some(workspace) = merged.remove(&id) {
+            workspaces.push(workspace);
+        }
+    }
+    workspaces.extend(merged.into_values());
+    workspaces.sort_by_key(|workspace| !workspace.favorite);
+
+    // Selection and window chrome are view preferences, not workspace contents.
+    let selected = if selected_id(local) != selected_id(previous_local) {
+        selected_id(local)
+    } else {
+        selected_id(disk)
+    };
+    let active_workspace_index = workspaces
+        .iter()
+        .position(|workspace| workspace.id.as_deref() == selected)
+        .unwrap_or(0);
+    let mut result = AppSessionState {
+        workspaces,
+        active_workspace_index,
+        top_bar_visible: if local.top_bar_visible != previous_local.top_bar_visible {
+            local.top_bar_visible
+        } else {
+            disk.top_bar_visible
+        },
+        sidebar: if local.sidebar != previous_local.sidebar {
+            local.sidebar.clone()
+        } else {
+            disk.sidebar.clone()
+        },
+        ..AppSessionState::default()
+    };
+    normalize_pane_ids(&mut result, disk);
+    for workspace in &result.workspaces {
+        let id = workspace.id.as_deref().expect("merged workspace identity");
+        if accepted.contains(id) {
+            ancestry.insert(id, workspace);
+        }
+    }
+    let mut ancestry_order = if local_reordered {
+        workspace_order(local)
+    } else {
+        workspace_order(previous_disk)
+    };
+    ancestry_order.extend(workspace_order(local));
+    let mut ancestral_workspaces = Vec::new();
+    for id in ancestry_order {
+        if let Some(workspace) = ancestry.remove(id.as_str()) {
+            ancestral_workspaces.push(workspace.clone());
+        }
+    }
+    ancestral_workspaces.extend(ancestry.into_values().cloned());
+    let ancestry = AppSessionState {
+        workspaces: ancestral_workspaces,
+        ..previous_disk.clone()
+    };
+    Ok((result, ancestry))
+}
+
+// Pane IDs are process-local counters. Independent workspace additions in two
+// windows can collide even though their workspace and tab UUIDs remain unique.
+fn normalize_pane_ids(state: &mut AppSessionState, disk: &AppSessionState) {
+    fn collect(layout: &crate::layout_state::LayoutNodeState, reserved: &mut BTreeSet<u32>) {
+        match layout {
+            crate::layout_state::LayoutNodeState::Pane(pane) => {
+                if let Some(id) = pane.pane_id.filter(|id| *id > 0) {
+                    reserved.insert(id);
+                }
+            }
+            crate::layout_state::LayoutNodeState::Split(split) => {
+                collect(&split.start, reserved);
+                collect(&split.end, reserved);
+            }
+        }
+    }
+    fn assign(
+        layout: &mut crate::layout_state::LayoutNodeState,
+        reserved: &mut BTreeSet<u32>,
+        seen: &mut BTreeSet<u32>,
+    ) {
+        match layout {
+            crate::layout_state::LayoutNodeState::Pane(pane) => {
+                if pane
+                    .pane_id
+                    .filter(|id| *id > 0)
+                    .is_none_or(|id| !seen.insert(id))
+                {
+                    let id = (1..=u32::MAX)
+                        .find(|id| !reserved.contains(id))
+                        .expect("available pane identity");
+                    pane.pane_id = Some(id);
+                    reserved.insert(id);
+                    seen.insert(id);
+                }
+            }
+            crate::layout_state::LayoutNodeState::Split(split) => {
+                assign(&mut split.start, reserved, seen);
+                assign(&mut split.end, reserved, seen);
+            }
+        }
+    }
+    let mut reserved = BTreeSet::new();
+    let mut seen = BTreeSet::new();
+    for workspace in &state.workspaces {
+        collect(&workspace.layout, &mut reserved);
+    }
+    let persisted = workspace_map(disk);
+    let mut order: Vec<_> = (0..state.workspaces.len()).collect();
+    // Reserve unchanged remote panes first, so a newly created local pane can
+    // never renumber a workspace belonging to another writer.
+    order.sort_by_key(|index| {
+        let workspace = &state.workspaces[*index];
+        workspace
+            .id
+            .as_deref()
+            .and_then(|id| persisted.get(id))
+            .copied()
+            != Some(workspace)
+    });
+    for index in order {
+        assign(
+            &mut state.workspaces[index].layout,
+            &mut reserved,
+            &mut seen,
+        );
+    }
+}
+
+#[cfg(test)]
+#[path = "session_store_tests.rs"]
+mod tests;

--- a/rust/limux-host-linux/src/session_store.rs
+++ b/rust/limux-host-linux/src/session_store.rs
@@ -287,7 +287,11 @@ fn merge_session(
     } else {
         workspace_order(disk)
     };
-    order.extend(workspace_order(local));
+    order.extend(if local_reordered {
+        workspace_order(disk)
+    } else {
+        workspace_order(local)
+    });
     let mut workspaces = Vec::new();
     for id in order {
         if let Some(workspace) = merged.remove(&id) {

--- a/rust/limux-host-linux/src/session_store_tests.rs
+++ b/rust/limux-host-linux/src/session_store_tests.rs
@@ -270,6 +270,28 @@ fn merge_keeps_selected_workspace_by_identity_and_local_reordering() {
 }
 
 #[test]
+fn local_reorder_preserves_remote_addition_order() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut remote_store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut local_store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut remote = base.clone();
+    remote.workspaces.extend([workspace(40), workspace(30)]);
+    saved(&mut remote_store, &remote);
+    let mut local = base;
+    local.workspaces.swap(0, 1);
+    saved(&mut local_store, &local);
+    assert_eq!(
+        disk(dir.path())
+            .workspaces
+            .iter()
+            .map(|workspace| workspace.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["workspace-2", "workspace-1", "workspace-40", "workspace-30"]
+    );
+}
+
+#[test]
 fn concurrent_workspace_reorders_do_not_silently_overwrite_each_other() {
     let dir = tempdir().unwrap();
     let mut base = initial(dir.path());

--- a/rust/limux-host-linux/src/session_store_tests.rs
+++ b/rust/limux-host-linux/src/session_store_tests.rs
@@ -322,6 +322,84 @@ fn busy_lock_has_a_bounded_wait() {
 }
 
 #[test]
+fn startup_lock_failure_can_retry_without_losing_independent_remote_edits() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let owner = lock_directory(dir.path()).unwrap();
+    assert_eq!(
+        SessionStore::load_from_dir(dir.path())
+            .err()
+            .unwrap()
+            .kind(),
+        io::ErrorKind::WouldBlock
+    );
+    let (mut local_store, loaded) = SessionStore::load_for_retry_from_dir(dir.path()).unwrap();
+    local_store.restored(loaded.state.clone());
+    drop(owner);
+
+    let (mut remote_store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut remote = base;
+    remote.workspaces[0].name = "remote change after startup".into();
+    saved(&mut remote_store, &remote);
+    let mut local = loaded.state;
+    local.workspaces[1].name = "local change after startup".into();
+    saved(&mut local_store, &local);
+    saved(&mut local_store, &local);
+    let result = disk(dir.path());
+    assert_eq!(result.workspaces[0].name, "remote change after startup");
+    assert_eq!(result.workspaces[1].name, "local change after startup");
+}
+
+#[test]
+fn startup_retry_does_not_adopt_concurrent_same_workspace_edit_as_ancestry() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let owner = lock_directory(dir.path()).unwrap();
+    let (mut local_store, loaded) = SessionStore::load_for_retry_from_dir(dir.path()).unwrap();
+    local_store.restored(loaded.state.clone());
+    drop(owner);
+
+    let (mut remote_store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut remote = base;
+    remote.workspaces[0].name = "remote".into();
+    saved(&mut remote_store, &remote);
+    let mut local = loaded.state;
+    local.workspaces[0].name = "local".into();
+    let SaveOutcome::Conflict { recovery, .. } = local_store.save(&local).unwrap() else {
+        panic!("expected conflict after startup retry")
+    };
+    assert_eq!(disk(dir.path()), remote);
+    let recovered: AppSessionState = serde_json::from_slice(&fs::read(recovery).unwrap()).unwrap();
+    assert_eq!(recovered, local);
+}
+
+#[test]
+fn startup_retry_rejects_unreadable_corrupt_or_ambiguous_snapshots() {
+    let dir = tempdir().unwrap();
+    let mut base = initial(dir.path());
+    let path = layout_state::canonical_session_path_in(dir.path());
+    fs::write(&path, "invalid json").unwrap();
+    assert!(SessionStore::load_for_retry_from_dir(dir.path()).is_err());
+    assert_eq!(fs::read_to_string(&path).unwrap(), "invalid json");
+
+    fs::remove_file(&path).unwrap();
+    fs::create_dir(&path).unwrap();
+    assert!(SessionStore::load_for_retry_from_dir(dir.path()).is_err());
+    assert!(path.is_dir());
+    fs::remove_dir(&path).unwrap();
+
+    base.workspaces[1].id = base.workspaces[0].id.clone();
+    layout_state::save_session_atomic_in(dir.path(), &base).unwrap();
+    assert!(SessionStore::load_for_retry_from_dir(dir.path()).is_err());
+    assert_eq!(disk(dir.path()), base);
+
+    base.workspaces[1].id = None;
+    layout_state::save_session_atomic_in(dir.path(), &base).unwrap();
+    assert!(SessionStore::load_for_retry_from_dir(dir.path()).is_err());
+    assert_eq!(disk(dir.path()), base);
+}
+
+#[test]
 fn identity_migration_is_shared_by_independent_loaders() {
     let dir = tempdir().unwrap();
     let mut initial = initial(dir.path());

--- a/rust/limux-host-linux/src/session_store_tests.rs
+++ b/rust/limux-host-linux/src/session_store_tests.rs
@@ -1,0 +1,353 @@
+use super::*;
+use crate::layout_state::{LayoutNodeState, PaneState, TabState};
+use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, Barrier};
+use tempfile::tempdir;
+
+fn workspace(number: u32) -> WorkspaceState {
+    WorkspaceState {
+        id: Some(format!("00000000-0000-4000-8000-{number:012}")),
+        name: format!("workspace-{number}"),
+        favorite: false,
+        cwd: Some("/tmp".into()),
+        folder_path: None,
+        autostart_command: None,
+        layout: LayoutNodeState::Pane(PaneState {
+            pane_id: Some(number),
+            active_tab_id: Some(format!("tab-{number}")),
+            tabs: vec![TabState::terminal(format!("tab-{number}"), Some("/tmp"))],
+        }),
+    }
+}
+fn initial(directory: &Path) -> AppSessionState {
+    let state = AppSessionState {
+        workspaces: vec![workspace(1), workspace(2)],
+        ..AppSessionState::default()
+    };
+    layout_state::save_session_atomic_in(directory, &state).unwrap();
+    state
+}
+fn saved(store: &mut SessionStore, state: &AppSessionState) {
+    assert!(matches!(store.save(state).unwrap(), SaveOutcome::Saved));
+}
+fn disk(directory: &Path) -> AppSessionState {
+    read_session(directory).unwrap().state
+}
+
+#[test]
+fn independent_additions_survive_repeated_saves_and_reverse_close_order() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    ours.workspaces.push(workspace(3));
+    saved(&mut a, &ours);
+    let mut theirs = base;
+    theirs.workspaces[0].name = "renamed by b".into();
+    saved(&mut b, &theirs);
+    saved(&mut a, &ours);
+    saved(&mut b, &theirs);
+    let result = disk(dir.path());
+    assert_eq!(result.workspaces.len(), 3);
+    assert_eq!(result.workspaces[0].name, "renamed by b");
+    assert_eq!(result.workspaces[2].name, "workspace-3");
+}
+
+#[test]
+fn intentional_deletion_is_not_resurrected_by_stale_noop_saves() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    ours.workspaces.remove(1);
+    saved(&mut a, &ours);
+    saved(&mut b, &base);
+    saved(&mut b, &base);
+    assert_eq!(disk(dir.path()).workspaces.len(), 1);
+}
+
+#[test]
+fn stale_edit_after_observing_remote_edit_still_conflicts() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut theirs = base.clone();
+    theirs.workspaces[0].name = "remote".into();
+    saved(&mut b, &theirs);
+    saved(&mut a, &base);
+    saved(&mut a, &base);
+    let mut ours = base;
+    ours.workspaces[0].name = "local".into();
+    let SaveOutcome::Conflict { recovery, .. } = a.save(&ours).unwrap() else {
+        panic!("expected conflict")
+    };
+    assert_eq!(disk(dir.path()).workspaces[0].name, "remote");
+    let recovered: AppSessionState = serde_json::from_slice(&fs::read(&recovery).unwrap()).unwrap();
+    assert_eq!(recovered, ours);
+    assert_eq!(
+        fs::metadata(&recovery).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    ours.workspaces[1].name = "later local change".into();
+    let SaveOutcome::Conflict {
+        recovery: latest, ..
+    } = a.save(&ours).unwrap()
+    else {
+        panic!("expected conflict")
+    };
+    assert_eq!(latest, recovery);
+    let recovered: AppSessionState = serde_json::from_slice(&fs::read(latest).unwrap()).unwrap();
+    assert_eq!(recovered, ours);
+}
+
+#[test]
+fn concurrent_delete_and_edit_conflict_in_both_directions() {
+    for delete_first in [false, true] {
+        let dir = tempdir().unwrap();
+        let base = initial(dir.path());
+        let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+        let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+        let mut deleted = base.clone();
+        deleted.workspaces.remove(0);
+        let mut edited = base;
+        edited.workspaces[0].name = "edited".into();
+        let (first, second) = if delete_first {
+            (&deleted, &edited)
+        } else {
+            (&edited, &deleted)
+        };
+        saved(&mut a, first);
+        assert!(matches!(
+            b.save(second).unwrap(),
+            SaveOutcome::Conflict { .. }
+        ));
+        assert_eq!(disk(dir.path()), *first);
+    }
+}
+
+#[test]
+fn restored_layout_differences_are_not_user_edits() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut restored = base.clone();
+    restored.workspaces[0].cwd = Some("/restored".into());
+    a.restored(restored.clone());
+    let mut remote = base;
+    remote.workspaces[0].name = "remote".into();
+    saved(&mut b, &remote);
+    saved(&mut a, &restored);
+    saved(&mut a, &restored);
+    assert_eq!(disk(dir.path()).workspaces[0], remote.workspaces[0]);
+    restored.workspaces[0].name = "explicit local edit".into();
+    assert!(matches!(
+        a.save(&restored).unwrap(),
+        SaveOutcome::Conflict { .. }
+    ));
+}
+
+#[test]
+fn simultaneous_writers_do_not_lose_independent_workspaces() {
+    let dir = tempdir().unwrap();
+    initial(dir.path());
+    let barrier = Arc::new(Barrier::new(8));
+    let handles: Vec<_> = (10..18)
+        .map(|number| {
+            let path = dir.path().to_path_buf();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                let (mut store, loaded) = SessionStore::load_from_dir(&path).unwrap();
+                let mut state = loaded.state;
+                state.workspaces.push(workspace(number));
+                barrier.wait();
+                saved(&mut store, &state);
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(disk(dir.path()).workspaces.len(), 10);
+}
+
+#[test]
+fn lock_inode_survives_atomic_replacements_and_blocks_other_writers() {
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::mpsc;
+    use std::time::Duration;
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let first = lock_directory(dir.path()).unwrap();
+    let inode = first.metadata().unwrap().ino();
+    let path = dir.path().to_path_buf();
+    let (tx, rx) = mpsc::channel();
+    let writer = std::thread::spawn(move || {
+        let lock = lock_directory(&path).unwrap();
+        tx.send(lock.metadata().unwrap().ino()).unwrap();
+    });
+    assert!(rx.recv_timeout(Duration::from_millis(100)).is_err());
+    layout_state::save_session_atomic_in(dir.path(), &base).unwrap();
+    drop(first);
+    assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), inode);
+    writer.join().unwrap();
+}
+
+#[test]
+fn invalid_canonical_file_is_not_overwritten() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let path = layout_state::canonical_session_path_in(dir.path());
+    fs::write(&path, "not json").unwrap();
+    assert!(store.save(&base).is_err());
+    assert_eq!(fs::read_to_string(path).unwrap(), "not json");
+}
+
+#[test]
+fn colliding_pane_ids_are_unique_and_remain_editable_after_saving() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    ours.workspaces.push(workspace(3));
+    let mut theirs = base;
+    let mut addition = workspace(4);
+    if let LayoutNodeState::Pane(pane) = &mut addition.layout {
+        pane.pane_id = Some(3);
+    }
+    theirs.workspaces.push(addition);
+    saved(&mut a, &ours);
+    saved(&mut b, &theirs);
+    let result = disk(dir.path());
+    let ids: BTreeSet<_> = result
+        .workspaces
+        .iter()
+        .map(|workspace| match &workspace.layout {
+            LayoutNodeState::Pane(pane) => pane.pane_id.unwrap(),
+            _ => unreachable!(),
+        })
+        .collect();
+    assert_eq!(ids.len(), 4);
+    theirs.workspaces[2].name = "renamed after normalized save".into();
+    saved(&mut b, &theirs);
+    saved(&mut a, &ours);
+    saved(&mut b, &theirs);
+    assert_eq!(
+        disk(dir.path()).workspaces[3].name,
+        "renamed after normalized save"
+    );
+}
+
+#[test]
+fn merge_keeps_selected_workspace_by_identity_and_local_reordering() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    ours.workspaces.push(workspace(3));
+    saved(&mut a, &ours);
+    let mut theirs = base;
+    theirs.workspaces.swap(0, 1);
+    theirs.active_workspace_index = 0;
+    saved(&mut b, &theirs);
+    saved(&mut b, &theirs);
+    let result = disk(dir.path());
+    assert_eq!(
+        result
+            .workspaces
+            .iter()
+            .map(|workspace| workspace.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["workspace-2", "workspace-1", "workspace-3"]
+    );
+    assert_eq!(selected_id(&result), selected_id(&theirs));
+}
+
+#[test]
+fn concurrent_workspace_reorders_do_not_silently_overwrite_each_other() {
+    let dir = tempdir().unwrap();
+    let mut base = initial(dir.path());
+    base.workspaces.push(workspace(3));
+    layout_state::save_session_atomic_in(dir.path(), &base).unwrap();
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    ours.workspaces.swap(0, 1);
+    saved(&mut a, &ours);
+    saved(&mut b, &base);
+    let mut theirs = base;
+    theirs.workspaces.swap(1, 2);
+    assert!(matches!(
+        b.save(&theirs).unwrap(),
+        SaveOutcome::Conflict { .. }
+    ));
+    assert_eq!(disk(dir.path()), ours);
+}
+
+#[test]
+fn accepted_reorder_retains_nonlexical_ancestry_on_later_edits() {
+    let dir = tempdir().unwrap();
+    let base = AppSessionState {
+        workspaces: vec![workspace(30), workspace(10), workspace(20)],
+        ..AppSessionState::default()
+    };
+    layout_state::save_session_atomic_in(dir.path(), &base).unwrap();
+    let (mut store, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    saved(&mut store, &base);
+    let mut local = base;
+    local.workspaces.swap(0, 1);
+    saved(&mut store, &local);
+    local.workspaces.swap(1, 2);
+    saved(&mut store, &local);
+    saved(&mut store, &local);
+    assert_eq!(disk(dir.path()), local);
+}
+
+#[test]
+fn busy_lock_has_a_bounded_wait() {
+    let dir = tempdir().unwrap();
+    let _owner = lock_directory(dir.path()).unwrap();
+    let start = std::time::Instant::now();
+    assert_eq!(
+        lock_directory(dir.path()).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+    assert!(start.elapsed() < std::time::Duration::from_secs(4));
+}
+
+#[test]
+fn identity_migration_is_shared_by_independent_loaders() {
+    let dir = tempdir().unwrap();
+    let mut initial = initial(dir.path());
+    initial.workspaces[0].id = None;
+    layout_state::save_session_atomic_in(dir.path(), &initial).unwrap();
+    let (_, a) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (_, b) = SessionStore::load_from_dir(dir.path()).unwrap();
+    assert_eq!(a.state, b.state);
+    assert!(uuid::Uuid::parse_str(a.state.workspaces[0].id.as_deref().unwrap()).is_ok());
+}
+
+#[test]
+fn remote_favorite_stays_above_locally_reordered_workspaces() {
+    let dir = tempdir().unwrap();
+    let base = initial(dir.path());
+    let (mut a, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let (mut b, _) = SessionStore::load_from_dir(dir.path()).unwrap();
+    let mut ours = base.clone();
+    let mut addition = workspace(3);
+    addition.favorite = true;
+    ours.workspaces.insert(0, addition);
+    saved(&mut a, &ours);
+    let mut theirs = base;
+    theirs.workspaces.swap(0, 1);
+    saved(&mut b, &theirs);
+    let result = disk(dir.path());
+    assert!(result.workspaces[0].favorite);
+    assert_eq!(result.workspaces[1].name, "workspace-2");
+}

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -85,7 +85,7 @@ pub(crate) struct AppState {
     sidebar_expanded_width: i32,
     persistence_suspended: bool,
     save_queued: bool,
-    session_store: Option<crate::session_store::SessionStore>,
+    session_store: Result<crate::session_store::SessionStore, String>,
     session_save_notice: Option<String>,
     session_close_dialog_open: bool,
     close_after_recovery: bool,
@@ -877,9 +877,8 @@ fn try_save_session(state: &State) -> Result<crate::session_store::SaveOutcome, 
         .borrow_mut()
         .session_store
         .as_mut()
-        .ok_or_else(|| {
-            "Session storage could not be opened. The window remains open to preserve your work."
-                .to_string()
+        .map_err(|error| {
+            format!("Session storage could not be opened: {error}. Resolve the storage error and restart before making session changes.")
         })?
         .save(&session)
         .map_err(|error| error.to_string())
@@ -1019,7 +1018,7 @@ fn apply_loaded_session(state: &State, mut loaded: LoadedSession) {
     apply_sidebar_state_immediately(state, &loaded.state.sidebar);
 
     let restored = snapshot_session_state(state);
-    if let Some(store) = state.borrow_mut().session_store.as_mut() {
+    if let Ok(store) = state.borrow_mut().session_store.as_mut() {
         store.restored(restored);
     }
     suspend_persistence(state, false);
@@ -1719,7 +1718,7 @@ pub fn build_window(app: &adw::Application) {
         sidebar_expanded_width: SIDEBAR_WIDTH,
         persistence_suspended: false,
         save_queued: false,
-        session_store: None,
+        session_store: Err("Session storage has not been initialized".to_string()),
         session_save_notice: None,
         session_close_dialog_open: false,
         close_after_recovery: false,
@@ -1898,12 +1897,25 @@ pub fn build_window(app: &adw::Application) {
 
     match crate::session_store::SessionStore::load() {
         Ok((store, loaded)) => {
-            state.borrow_mut().session_store = Some(store);
+            state.borrow_mut().session_store = Ok(store);
             apply_loaded_session(&state, loaded);
         }
         Err(error) => {
             eprintln!("limux: failed to open session storage: {error}");
-            apply_loaded_session(&state, layout_state::load_session());
+            match crate::session_store::SessionStore::load_for_retry() {
+                Ok((store, loaded)) => {
+                    // This is the snapshot we actually show, not a new disk
+                    // baseline adopted after the user has begun making edits.
+                    state.borrow_mut().session_store = Ok(store);
+                    apply_loaded_session(&state, loaded);
+                }
+                Err(retry_error) => {
+                    state.borrow_mut().session_store = Err(format!(
+                        "{error}. A safe startup snapshot could not be read: {retry_error}"
+                    ));
+                    apply_loaded_session(&state, layout_state::load_session());
+                }
+            }
         }
     }
 

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -85,6 +85,10 @@ pub(crate) struct AppState {
     sidebar_expanded_width: i32,
     persistence_suspended: bool,
     save_queued: bool,
+    session_store: Option<crate::session_store::SessionStore>,
+    session_save_notice: Option<String>,
+    session_close_dialog_open: bool,
+    close_after_recovery: bool,
     workspace_dragging: Option<String>,
     desktop_notification_routes: HashMap<u32, DesktopNotificationRoute>,
     _theme_portal_signal: Option<gio::SignalSubscription>,
@@ -867,10 +871,112 @@ fn request_session_save(state: &State) {
     }
 }
 
-fn save_session_now(state: &State) {
+fn try_save_session(state: &State) -> Result<crate::session_store::SaveOutcome, String> {
     let session = snapshot_session_state(state);
-    if let Err(err) = layout_state::save_session_atomic(&session) {
-        eprintln!("limux: failed to save session state: {err}");
+    state
+        .borrow_mut()
+        .session_store
+        .as_mut()
+        .ok_or_else(|| {
+            "Session storage could not be opened. The window remains open to preserve your work."
+                .to_string()
+        })?
+        .save(&session)
+        .map_err(|error| error.to_string())
+}
+
+fn session_conflict_detail(recovery: &Path, workspaces: &[String]) -> String {
+    format!("Another Limux window changed the same workspace(s): {}. The shared session was not overwritten. This window's complete session was saved to {}.", workspaces.join(", "), recovery.display())
+}
+
+fn report_session_save_notice(state: &State, detail: String) {
+    if state.borrow().session_save_notice.as_ref() == Some(&detail) {
+        return;
+    }
+    state.borrow_mut().session_save_notice = Some(detail.clone());
+    eprintln!("limux: {detail}");
+    show_runtime_error(state, "Session could not be merged", &detail);
+}
+
+fn save_session_now(state: &State) {
+    match try_save_session(state) {
+        Ok(crate::session_store::SaveOutcome::Saved) => {
+            state.borrow_mut().session_save_notice = None
+        }
+        Ok(crate::session_store::SaveOutcome::Conflict {
+            recovery,
+            workspaces,
+        }) => {
+            report_session_save_notice(state, session_conflict_detail(&recovery, &workspaces));
+        }
+        Err(error) => report_session_save_notice(state, format!("Failed to save session: {error}")),
+    }
+}
+
+fn prepare_session_close(state: &State) -> bool {
+    if std::mem::take(&mut state.borrow_mut().close_after_recovery) {
+        return true;
+    }
+    if state.borrow().session_close_dialog_open {
+        return false;
+    }
+    match try_save_session(state) {
+        Ok(crate::session_store::SaveOutcome::Saved) => true,
+        Err(error) => {
+            let window = state.borrow().window.clone();
+            let dialog = gtk::AlertDialog::builder().modal(true)
+                .message("Close without saving this session?")
+                .detail(format!("The session could not be saved: {error}. Closing will discard this window's unsaved session changes."))
+                .buttons(["Cancel", "Close without Saving"]).cancel_button(0).default_button(0).build();
+            state.borrow_mut().session_close_dialog_open = true;
+            let state = state.clone();
+            dialog.choose(Some(&window), gio::Cancellable::NONE, move |answer| {
+                state.borrow_mut().session_close_dialog_open = false;
+                if answer == Ok(1) {
+                    state.borrow_mut().close_after_recovery = true;
+                    let window = state.borrow().window.clone();
+                    window.close();
+                }
+            });
+            false
+        }
+        Ok(crate::session_store::SaveOutcome::Conflict {
+            recovery,
+            workspaces,
+        }) => {
+            let detail = session_conflict_detail(&recovery, &workspaces);
+            let window = state.borrow().window.clone();
+            let dialog = gtk::AlertDialog::builder()
+                .modal(true)
+                .message("Close with a saved recovery session?")
+                .detail(&detail)
+                .buttons(["Cancel", "Close after Saving Recovery"])
+                .cancel_button(0)
+                .default_button(0)
+                .build();
+            state.borrow_mut().session_close_dialog_open = true;
+            let state = state.clone();
+            dialog.choose(Some(&window), gio::Cancellable::NONE, move |answer| {
+                state.borrow_mut().session_close_dialog_open = false;
+                if answer != Ok(1) {
+                    return;
+                }
+                // Control-socket commands can still change the session while the
+                // dialog is open. Capture the latest state before allowing close.
+                match try_save_session(&state) {
+                    Ok(_) => {
+                        state.borrow_mut().close_after_recovery = true;
+                        let window = state.borrow().window.clone();
+                        window.close();
+                    }
+                    Err(error) => report_session_save_notice(
+                        &state,
+                        format!("Failed to save recovery session: {error}"),
+                    ),
+                }
+            });
+            false
+        }
     }
 }
 
@@ -912,6 +1018,10 @@ fn apply_loaded_session(state: &State, mut loaded: LoadedSession) {
     }
     apply_sidebar_state_immediately(state, &loaded.state.sidebar);
 
+    let restored = snapshot_session_state(state);
+    if let Some(store) = state.borrow_mut().session_store.as_mut() {
+        store.restored(restored);
+    }
     suspend_persistence(state, false);
 
     save_session_now(state);
@@ -1609,6 +1719,10 @@ pub fn build_window(app: &adw::Application) {
         sidebar_expanded_width: SIDEBAR_WIDTH,
         persistence_suspended: false,
         save_queued: false,
+        session_store: None,
+        session_save_notice: None,
+        session_close_dialog_open: false,
+        close_after_recovery: false,
         workspace_dragging: None,
         desktop_notification_routes: HashMap::new(),
         _theme_portal_signal: None,
@@ -1762,7 +1876,9 @@ pub fn build_window(app: &adw::Application) {
     {
         let state = state.clone();
         window.connect_close_request(move |_| {
-            save_session_now(&state);
+            if !prepare_session_close(&state) {
+                return glib::Propagation::Stop;
+            }
             stop_session_saves_for_shutdown(&state);
             let split_containers: Vec<_> = state
                 .borrow()
@@ -1780,7 +1896,16 @@ pub fn build_window(app: &adw::Application) {
         });
     }
 
-    apply_loaded_session(&state, layout_state::load_session());
+    match crate::session_store::SessionStore::load() {
+        Ok((store, loaded)) => {
+            state.borrow_mut().session_store = Some(store);
+            apply_loaded_session(&state, loaded);
+        }
+        Err(error) => {
+            eprintln!("limux: failed to open session storage: {error}");
+            apply_loaded_session(&state, layout_state::load_session());
+        }
+    }
 
     crate::control_bridge::start(dispatch_control_command);
 


### PR DESCRIPTION
Two Limux instances restore the same session, then independently replace `session.json` with their whole local snapshot. A workspace added in the first instance disappears when the second instance closes normally, even if the first instance already saved and closed successfully.

Merge changes by workspace identity under a persistent writer lock. Each instance retains its own UI baseline and the corresponding disk ancestry, so repeated saves preserve unseen remote changes while intentional deletions remain deleted. Normalize colliding process-local pane IDs without changing tab identities, and preserve workspace order, favorites, and selected workspace identity.

Conflicting edits leave the shared session intact and save this window's complete snapshot to a recovery file. The UI reports its location and asks before closing. A temporary startup lock failure retains the exact loaded snapshot so later saves can retry safely. Corrupt or ambiguous startup snapshots remain unsavable with the underlying error shown. A storage failure offers Cancel or an explicit Close without Saving.

## Reproduction

1. Start Limux with a workspace named BASE, then open another instance with Ctrl+Alt+N.
2. In the first instance, add another workspace. In the second, rename BASE.
3. Close both instances normally, then reopen Limux.

Previously, the second instance's snapshot removed the added workspace. Both changes now survive, including repeated saves and restart.

Run the persistence regressions with `cargo test --locked -p limux-host-linux session_store::tests`.

## Validation

- 268 native host tests passed, including 19 persistence regressions.
- Strict host test-target Clippy and formatting passed.
- Full maintained GTK smoke harness passed, including terminal lifecycle and session restart. Local host validation used the pinned Ghostty library, Bash, and disabled default WebKit features because WebKit development dependencies are unavailable here.
- Live private GTK/Xvfb reproduction confirmed both windows' changes survive normal close and restart.
- Live conflicting-edit test confirmed canonical and recovery snapshots retain both versions, Cancel keeps the window open, and explicit recovery close succeeds.
- Live startup-contention test held the session lock through startup, then released it: the same window saved its changes, preserved another instance's added workspace, and closed normally.
- Independent correctness review completed.

## Downsides

Workspace contents merge as a unit. Concurrent edits within the same workspace can require manual recovery from the reported JSON file, even if the edits affect different tabs. The save lock can delay the UI for up to two seconds under contention before reporting an error. Recovery files are retained for the user rather than automatically deleted.