### PR TITLE
fix(host): inherit the active terminal directory

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -119,7 +119,10 @@ jobs:
             libwebkitgtk-6.0-dev \
             pkg-config \
             util-linux \
-            weston
+            weston \
+            xauth \
+            xdotool \
+            xvfb
 
       - name: Build libghostty for embedding
         run: |
@@ -130,3 +133,6 @@ jobs:
         env:
           LIMUX_SMOKE_PROFILE: debug
         run: ./scripts/xvfb-smoke-test.sh
+
+      - name: Check terminal directory inheritance
+        run: ./scripts/tests/test-terminal-cwd.sh

--- a/rust/limux-host-linux/src/pane.rs
+++ b/rust/limux-host-linux/src/pane.rs
@@ -604,11 +604,11 @@ pub fn create_pane(
     }
 
     {
-        let internals = internals.clone();
-        let wd = ws_wd.clone();
+        let pane_widget = outer.downgrade();
         new_term_btn.connect_clicked(move |_| {
-            let dir = wd.borrow().clone();
-            add_terminal_tab_inner(&internals, dir.as_deref(), None);
+            if let Some(pane_widget) = pane_widget.upgrade() {
+                add_terminal_tab_to_pane(&pane_widget.upcast());
+            }
         });
     }
     {
@@ -1821,8 +1821,15 @@ fn add_keybind_editor_tab_inner(internals: &Rc<PaneInternals>, input: KeybindsTa
 #[allow(dead_code)]
 pub fn add_terminal_tab_to_pane(pane_widget: &gtk::Widget) {
     if let Some(internals) = find_pane_internals(pane_widget) {
-        let dir = internals.working_directory.borrow().clone();
+        let dir = active_tab_working_directory(pane_widget)
+            .or_else(|| internals.working_directory.borrow().clone());
         add_terminal_tab_inner(&internals, dir.as_deref(), None);
+    }
+}
+
+pub fn add_terminal_tab_to_pane_in_directory(pane_widget: &gtk::Widget, directory: Option<&str>) {
+    if let Some(internals) = find_pane_internals(pane_widget) {
+        add_terminal_tab_inner(&internals, directory, None);
     }
 }
 
@@ -1989,6 +1996,11 @@ pub fn tab_working_directory(pane_widget: &gtk::Widget, tab_id: &str) -> Option<
         TabKind::Terminal { state } => state.cwd.borrow().clone(),
         TabKind::Browser { .. } | TabKind::Keybinds => None,
     }
+}
+
+pub fn active_tab_working_directory(pane_widget: &gtk::Widget) -> Option<String> {
+    let tab_id = active_tab_in_pane(pane_widget)?;
+    tab_working_directory(pane_widget, &tab_id)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rust/limux-host-linux/src/window.rs
+++ b/rust/limux-host-linux/src/window.rs
@@ -3269,12 +3269,17 @@ fn next_active_workspace_index(
 }
 
 fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::ListBoxRow) {
+    let preferred_pane_id = find_leaf_focused_pane(state)
+        .filter(|(id, _)| id == workspace_id)
+        .and_then(|(_, pane)| pane::active_surface_summary(&pane).map(|surface| surface.pane_id));
     let menu_box = gtk::Box::new(gtk::Orientation::Vertical, 2);
     menu_box.set_margin_top(4);
     menu_box.set_margin_bottom(4);
     menu_box.set_margin_start(4);
     menu_box.set_margin_end(4);
 
+    let new_tab_btn = gtk::Button::with_label("New tab from workspace directory");
+    new_tab_btn.add_css_class("flat");
     let rename_btn = gtk::Button::with_label("Rename");
     rename_btn.add_css_class("flat");
     let has_autostart = {
@@ -3295,6 +3300,7 @@ fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::Lis
     delete_btn.add_css_class("flat");
     delete_btn.add_css_class("destructive-action");
 
+    menu_box.append(&new_tab_btn);
     menu_box.append(&rename_btn);
     menu_box.append(&autostart_btn);
     menu_box.append(&delete_btn);
@@ -3304,6 +3310,56 @@ fn show_workspace_context_menu(state: &State, workspace_id: &str, row: &gtk::Lis
     popover.set_parent(row);
     popover.set_position(gtk::PositionType::Right);
 
+    {
+        let state = state.clone();
+        let ws_id = workspace_id.to_string();
+        let pop = popover.clone();
+        new_tab_btn.connect_clicked(move |_| {
+            pop.popdown();
+            let (index, directory, row, sidebar_list, target_pane) = {
+                let app_state = state.borrow();
+                let Some(index) = app_state
+                    .workspaces
+                    .iter()
+                    .position(|workspace| workspace.id == ws_id)
+                else {
+                    return;
+                };
+                let workspace = &app_state.workspaces[index];
+                let target_pane = preferred_pane_id
+                    .and_then(|id| pane::pane_widget_for_root(&workspace.root, id))
+                    .or_else(|| {
+                        let first = first_leaf_pane(&workspace.root);
+                        pane::active_surface_summary(&first).and_then(|surface| {
+                            pane::pane_widget_for_root(&workspace.root, surface.pane_id)
+                        })
+                    })
+                    .or_else(|| {
+                        let first = pane::pane_summaries_for_root(&workspace.root)
+                            .first()?
+                            .pane_id;
+                        pane::pane_widget_for_root(&workspace.root, first)
+                    });
+                let Some(target_pane) = target_pane else {
+                    return;
+                };
+                let directory = workspace
+                    .folder_path
+                    .clone()
+                    .or_else(|| workspace.cwd.borrow().clone());
+                (
+                    index,
+                    directory,
+                    workspace.sidebar_row.clone(),
+                    app_state.sidebar_list.clone(),
+                    target_pane,
+                )
+            };
+            switch_workspace(&state, index);
+            sidebar_list.select_row(Some(&row));
+            pane::add_terminal_tab_to_pane_in_directory(&target_pane, directory.as_deref());
+        });
+    }
     {
         let state = state.clone();
         let ws_id = workspace_id.to_string();
@@ -4517,6 +4573,7 @@ fn handle_control_command(state: &State, command: ControlCommand) {
                 SplitPaneOptions {
                     initial_state: None,
                     skip_default_tab: false,
+                    inherit_active_directory: false,
                     new_pane_first: resolved.placement.new_pane_first,
                     persist: true,
                     suppress_initial_autostart: request.command.is_some(),
@@ -5058,6 +5115,7 @@ pub(crate) fn create_pane_for_workspace(
                 SplitPaneOptions {
                     initial_state: None,
                     skip_default_tab: false,
+                    inherit_active_directory: true,
                     new_pane_first: false,
                     persist: true,
                     suppress_initial_autostart: false,
@@ -5549,6 +5607,7 @@ fn toggle_sidebar(state: &State) {
 struct SplitPaneOptions {
     initial_state: Option<PaneState>,
     skip_default_tab: bool,
+    inherit_active_directory: bool,
     new_pane_first: bool,
     persist: bool,
     suppress_initial_autostart: bool,
@@ -5585,10 +5644,17 @@ fn split_pane(
         autostart_command,
         PaneCreationOptions {
             initial_state: options.initial_state.as_ref(),
-            skip_default_tab: options.skip_default_tab,
+            skip_default_tab: options.skip_default_tab || options.inherit_active_directory,
             suppress_initial_autostart: options.suppress_initial_autostart,
         },
     );
+    if options.inherit_active_directory {
+        let directory = pane::active_tab_working_directory(pane_widget).or(wd);
+        pane::add_terminal_tab_to_pane_in_directory(
+            &new_pane.clone().upcast(),
+            directory.as_deref(),
+        );
+    }
 
     // Mutate the data model and trigger async widget tree rebuild.
     // The existing pane's GLArea will be unrealized then re-realized
@@ -5622,6 +5688,7 @@ fn open_url_in_browser_tab(state: &State, ws_id: &str, pane_widget: &gtk::Widget
                 SplitPaneOptions {
                     initial_state: Some(PaneState::browser_only(Some(url))),
                     skip_default_tab: false,
+                    inherit_active_directory: false,
                     new_pane_first: false,
                     persist: true,
                     suppress_initial_autostart: false,
@@ -5714,6 +5781,7 @@ fn handle_split_with_tab(
         SplitPaneOptions {
             initial_state: None,
             skip_default_tab: true,
+            inherit_active_directory: false,
             new_pane_first,
             persist: false,
             suppress_initial_autostart: false,
@@ -5911,6 +5979,7 @@ fn dispatch_browser_command(state: &State, command: ShortcutCommand) -> bool {
             SplitPaneOptions {
                 initial_state: Some(PaneState::browser_only(uri.as_deref())),
                 skip_default_tab: false,
+                inherit_active_directory: false,
                 new_pane_first: false,
                 persist: true,
                 suppress_initial_autostart: false,
@@ -5949,6 +6018,7 @@ fn split_focused_pane(state: &State, orientation: gtk::Orientation) {
             SplitPaneOptions {
                 initial_state: None,
                 skip_default_tab: false,
+                inherit_active_directory: true,
                 new_pane_first: false,
                 persist: true,
                 suppress_initial_autostart: false,

--- a/scripts/tests/test-terminal-cwd.sh
+++ b/scripts/tests/test-terminal-cwd.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Exercise real GTK tab/split actions in an isolated X11 session.
+# Requires prebuilt host/CLI, Xvfb, xdotool, dbus-run-session, and jq.
+# LIMUX_TEST_PROFILE=release selects release binaries; LIMUX_TEST_HOST and
+# LIMUX_TEST_CLI can point to another checkout for a before/after comparison.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+for dependency in xvfb-run xdotool dbus-run-session jq setsid; do
+  command -v "$dependency" >/dev/null || { echo "Missing dependency: $dependency"; exit 2; }
+done
+if [ "${1:-}" != --inside ]; then
+  exec xvfb-run -a -s '-screen 0 1440x1000x24 -nolisten tcp' \
+    dbus-run-session -- bash "$0" --inside
+fi
+
+PROFILE="${LIMUX_TEST_PROFILE:-debug}"
+HOST="${LIMUX_TEST_HOST:-$ROOT_DIR/target/$PROFILE/limux}"
+CLI="${LIMUX_TEST_CLI:-$ROOT_DIR/target/$PROFILE/limux-cli}"
+if [ ! -x "$HOST" ] || [ ! -x "$CLI" ]; then echo "Build the host and CLI first"; exit 2; fi
+RUN_DIR="$(mktemp -d -t limux-terminal-cwd-XXXXXX)"
+echo "Test artifacts: $RUN_DIR"
+export XDG_DATA_HOME="$RUN_DIR/data" XDG_STATE_HOME="$RUN_DIR/state"
+export XDG_CONFIG_HOME="$RUN_DIR/config" XDG_RUNTIME_DIR="$RUN_DIR/runtime"
+mkdir -p "$XDG_DATA_HOME/limux" "$XDG_STATE_HOME" "$XDG_CONFIG_HOME/ghostty" \
+  "$XDG_RUNTIME_DIR" "$RUN_DIR/workspace/nested" "$RUN_DIR/other/nested"
+chmod 700 "$XDG_RUNTIME_DIR"
+export LIMUX_SOCKET="$RUN_DIR/limux.sock" LIMUX_SOCKET_PATH="$RUN_DIR/limux.sock"
+export LIMUX_SOCKET_MODE=runtime GDK_BACKEND=x11 GDK_SCALE=1 GTK_THEME=Adwaita
+export LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe LP_NUM_THREADS=1 SHELL=/bin/sh
+export GTK_USE_PORTAL=0 GTK_A11Y=none GIO_USE_VFS=local
+export LD_LIBRARY_PATH="$ROOT_DIR/ghostty/zig-out/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export GHOSTTY_RESOURCES_DIR="$ROOT_DIR/ghostty/zig-out/share/ghostty"
+export TERMINFO="$ROOT_DIR/ghostty/zig-out/share/terminfo"
+unset LIMUX_WORKSPACE_ID LIMUX_PANE_ID LIMUX_SURFACE_ID LIMUX_TAB_ID WAYLAND_DISPLAY
+unset LD_PRELOAD GDK_DPI_SCALE
+printf 'command = /bin/sh\nshell-integration = none\nfont-size = 12\n' \
+  >"$XDG_CONFIG_HOME/ghostty/config"
+jq -n --arg base "$RUN_DIR" '{
+  version: 1, active_workspace_index: 0, top_bar_visible: true,
+  sidebar: {visible: true, width: 220},
+  workspaces: [
+    {id: "cwd-main", name: "cwd-main", folder_path: ($base + "/workspace"),
+     autostart_command: ("printf '\''%s\\n'\'' \"$LIMUX_SURFACE_ID\" >> " + $base + "/autostart.log"),
+     cwd: ($base + "/workspace"), layout: {kind: "pane", pane_id: 1,
+     active_tab_id: "main", tabs: [{id: "main", tab_kind: "terminal", cwd: ($base + "/workspace")}] }},
+    {id: "cwd-other", name: "cwd-other", folder_path: ($base + "/other"),
+     cwd: ($base + "/other"), layout: {kind: "split", orientation: "horizontal", ratio: 0.5,
+       start: {kind: "pane", pane_id: 6, active_tab_id: "other-left",
+         tabs: [{id: "other-left", tab_kind: "terminal", cwd: ($base + "/other/nested")}]},
+       end: {kind: "pane", pane_id: 2, active_tab_id: "other-right",
+         tabs: [{id: "other-right", tab_kind: "terminal", cwd: ($base + "/other/nested")}]}
+     }}
+  ]
+}' >"$XDG_DATA_HOME/limux/session.json"
+
+HOST_PID=""
+cleanup() {
+  local result=$?
+  if [ "$result" -ne 0 ] && command -v import >/dev/null; then
+    import -window root "$RUN_DIR/window.png" || true
+  fi
+  if [ -n "$HOST_PID" ]; then
+    kill -TERM -- "-$HOST_PID" 2>/dev/null || true
+    wait "$HOST_PID" 2>/dev/null || true
+  fi
+  if [ "$result" -ne 0 ]; then tail -40 "$RUN_DIR/host.stderr"; fi
+}
+trap cleanup EXIT
+setsid "$HOST" >"$RUN_DIR/host.stdout" 2>"$RUN_DIR/host.stderr" &
+HOST_PID=$!
+WINDOW=""
+for _ in $(seq 1 450); do
+  kill -0 "$HOST_PID" || { echo "Host exited during startup"; exit 1; }
+  WINDOW="$(xdotool search --onlyvisible --pid "$HOST_PID" 2>/dev/null | head -1 || true)"
+  [ -n "$WINDOW" ] && [ -S "$LIMUX_SOCKET" ] && break
+  sleep 0.1
+done
+if [ -z "$WINDOW" ] || [ ! -S "$LIMUX_SOCKET" ]; then echo "Host startup timed out"; exit 1; fi
+# Keep split ratios at exactly 0.5 to isolate cwd behavior from the existing
+# session-save conflict caused by fractional-ratio JSON round trips.
+xdotool windowsize --sync "$WINDOW" 1201 760 windowfocus --sync "$WINDOW"
+sleep 1
+
+wait_for_count() {
+  local workspace=$1 expected=$2 expected_type=${3:-terminal}
+  local surface_id surface_type
+  for _ in $(seq 1 100); do
+    "$CLI" --json --id-format both list-panels --workspace "$workspace" \
+      >"$RUN_DIR/surfaces.json"
+    if [ "$(jq '.surfaces | length' "$RUN_DIR/surfaces.json")" -eq "$expected" ]; then
+      if [ "$expected_type" = browser ] \
+        && jq -e '.surfaces[] | select(.type == "browser" and .selected)' \
+          "$RUN_DIR/surfaces.json" >/dev/null; then return; fi
+      surface_id="$(jq -r '.surfaces[] | select(.focused) | .surface_id' "$RUN_DIR/surfaces.json")"
+      surface_type="$(jq -r '.surfaces[] | select(.focused) | .type' "$RUN_DIR/surfaces.json")"
+      if [ "$surface_type" = terminal ] \
+        && "$CLI" --json --id-format both surface-health --workspace "$workspace" \
+          >"$RUN_DIR/health.json" \
+        && jq -e --arg id "$surface_id" '.surfaces[] | select(.surface_id == $id) |
+          .healthy and .realized and (.process_exited == false) and
+          .columns > 0 and .rows > 0' "$RUN_DIR/health.json" >/dev/null; then return; fi
+    fi
+    sleep 0.1
+  done
+  echo "FAIL: $workspace expected $expected surfaces with a ready focused target"
+  exit 1
+}
+assert_directory() {
+  local expected=$1 label=$2 workspace=${3:-cwd-main}
+  local proof="$RUN_DIR/$label.pwd"
+  "$CLI" send --workspace "$workspace" "pwd > '$proof'" >/dev/null
+  "$CLI" send-key --workspace "$workspace" Enter >/dev/null
+  for _ in $(seq 1 50); do [ -s "$proof" ] && break; sleep 0.1; done
+  if [ ! -s "$proof" ] || [ "$(<"$proof")" != "$expected" ]; then
+    echo "FAIL: $label expected $expected, got $(cat "$proof" 2>/dev/null || true)"
+    exit 1
+  fi
+  echo "PASS: $label"
+}
+set_directory() {
+  local directory=$1
+  "$CLI" send --workspace cwd-main \
+    "cd '$directory'; printf '\033]7;file://localhost%s\007' \"\$PWD\"" >/dev/null
+  "$CLI" send-key --workspace cwd-main Enter >/dev/null
+  for _ in $(seq 1 50); do
+    if "$CLI" --json list-panels --workspace cwd-main \
+      | jq -e --arg cwd "$directory" '.surfaces[] | select(.focused and .cwd == $cwd)' >/dev/null; then return; fi
+    sleep 0.1
+  done
+  echo "FAIL: OSC 7 directory was not tracked"
+  exit 1
+}
+key() { xdotool key --clearmodifiers "$1"; }
+click() { xdotool mousemove --window "$WINDOW" "$1" "$2" click "${3:-1}"; }
+
+wait_for_count cwd-main 1
+assert_directory "$RUN_DIR/workspace" initial-directory
+set_directory "$RUN_DIR/workspace/nested"
+key ctrl+shift+t
+wait_for_count cwd-main 2
+assert_directory "$RUN_DIR/workspace/nested" new-tab-shortcut
+click 1045 65
+wait_for_count cwd-main 3
+assert_directory "$RUN_DIR/workspace/nested" new-tab-button
+key ctrl+alt+d
+wait_for_count cwd-main 4
+assert_directory "$RUN_DIR/workspace/nested" split-shortcut
+
+# Browser focus has no cwd. In a newly inherited split, fallback must still
+# be the workspace root, not the first terminal's inherited directory.
+click 1072 65
+wait_for_count cwd-main 5 browser
+click 1045 65
+wait_for_count cwd-main 6
+assert_directory "$RUN_DIR/workspace" browser-fallback-after-split
+set_directory "$RUN_DIR/workspace/nested"
+click 1126 65
+wait_for_count cwd-main 7
+assert_directory "$RUN_DIR/workspace/nested" split-button
+if [ "$(wc -l <"$RUN_DIR/autostart.log")" -ne 6 ] \
+  || [ "$(sort -u "$RUN_DIR/autostart.log" | wc -l)" -ne 6 ]; then
+  echo "FAIL: workspace autostart did not run exactly once per terminal"
+  exit 1
+fi
+
+# On the active workspace, keep the pane that had focus before the menu.
+PREFERRED_PANE="$("$CLI" --json --id-format both identify | jq -r '.focused.pane_id')"
+click 70 120 3
+sleep 0.2
+click 360 65
+wait_for_count cwd-main 8
+assert_directory "$RUN_DIR/workspace" active-workspace-context-root
+"$CLI" --json --id-format both identify \
+  | jq -e --arg pane "$PREFERRED_PANE" '.focused.pane_id == $pane' >/dev/null \
+  || { echo "FAIL: context action did not preserve the focused pane"; exit 1; }
+
+# The sidebar action explicitly ignores terminal cwd, including when its
+# workspace was inactive and restores a terminal in a nested directory.
+click 70 185 3
+sleep 0.2
+click 360 135
+wait_for_count cwd-other 3
+assert_directory "$RUN_DIR/other" workspace-context-root cwd-other
+"$CLI" --json --id-format both identify >"$RUN_DIR/context-focus.json"
+jq -e '.focused.name == "cwd-other" and .focused.pane_id == "6"' "$RUN_DIR/context-focus.json" >/dev/null \
+  || { echo "FAIL: context action did not activate its workspace"; exit 1; }
+echo "Terminal cwd regression checks passed"


### PR DESCRIPTION
## Summary

Fixes #162. New terminal tabs and user-created splits inherit the selected terminal's tracked directory instead of the pane's original directory.

Right-clicking a workspace also offers **New tab from workspace directory**, for an explicit way to start at the workspace directory.

## Changes

- Share directory selection between the new-tab button and shortcut. Apply inheritance to split buttons and shortcuts without changing the pane's fallback directory.
- Keep restored tabs, tab drags, browser splits, and explicit CLI pane creation unchanged.
- Preserve the focused pane for the workspace menu action, activate background workspaces, and resolve the target pane again if it closes while the menu is open.
- Add a real GTK regression test under Xvfb and run it in the GTK smoke CI job.

## Testing

- `./scripts/check.sh`: passed.
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh`: passed, including session restart and repeated teardown.
- `./scripts/tests/test-terminal-cwd.sh`: passed for tab/split buttons and shortcuts, browser fallback, autostart, and active/background workspace context actions.
- The v0.1.27 release reproduced the original failure: a new tab started in the workspace directory instead of the selected terminal's nested directory.

The focused UI fixture uses exact 0.5 split ratios to avoid a separate existing session-save bug: fractional ratios can change by one ULP on JSON readback and trigger a false concurrent-edit conflict. This PR does not change persistence.
