### PR TITLE
fix: select terminal OpenGL context before shutdown

### DIFF
--- a/docs/maintainability.md
+++ b/docs/maintainability.md
@@ -16,6 +16,32 @@ That script is the source of truth for the repository quality gate and currently
 - `cargo clippy --workspace --all-targets -- -D warnings`
 - `cargo test --workspace`
 
+## Live GTK Regression Tests
+
+For changes to terminal rendering, surface lifetime, or the live control bridge,
+also run the maintained headless Weston harness from the repository root:
+
+```bash
+LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh
+```
+
+It requires Weston, `jq`, `setsid`, the host build dependencies, and the embedded
+Ghostty library built as described in the README. It builds the CLI and host,
+uses a private socket and temporary session/configuration directories, and
+retains logs on failure. The `Rust Quality` workflow runs this harness as well.
+
+Tests that require a graphical display are marked `#[ignore]` so the ordinary
+`cargo test --workspace` run can work without a display. They must be explicitly
+invoked by the harness under Weston; an ignored test alone does not provide
+coverage in the quality gate.
+
+The terminal shutdown regression checks that freeing a terminal selects its
+own OpenGL context even when another widget's context is current. The harness
+then exercises ten multi-pane workspace cycles: it waits for the target shell
+to execute a readiness command, sends Ctrl+D at an empty prompt, checks that
+only that terminal disappears and the other two remain healthy, and closes
+the workspace to check that its child processes are released.
+
 ## Ground Rules
 
 - Keep one source of truth for command metadata, flags, and business rules.

--- a/rust/limux-host-linux/src/main.rs
+++ b/rust/limux-host-linux/src/main.rs
@@ -193,14 +193,9 @@ fn gtk_runtime_at_least(major: u32, minor: u32, micro: u32) -> bool {
     gtk_runtime_version() >= (major, minor, micro)
 }
 
-fn main() {
+/// Configure the embedded renderer before GTK initializes, including in tests.
+fn prepare_ghostty_runtime() {
     limux_ghostty_sys::ensure_glad_symbols_linked();
-
-    // Handle --version flag
-    if std::env::args().any(|a| a == "--version" || a == "-v") {
-        println!("Limux {VERSION}");
-        return;
-    }
 
     // Ghostty requires desktop OpenGL, not GLES. Must set the GTK renderer
     // environment before GTK initializes, and the exact knobs differ by GTK
@@ -218,6 +213,16 @@ fn main() {
     // terminfo, and shell integration. Prefer Limux-bundled resources but
     // fall back to common system Ghostty install locations.
     set_ghostty_runtime_env();
+}
+
+fn main() {
+    // Handle --version flag
+    if std::env::args().any(|a| a == "--version" || a == "-v") {
+        println!("Limux {VERSION}");
+        return;
+    }
+
+    prepare_ghostty_runtime();
     sanitize_terminal_child_env();
 
     // WebKitGTK's bubblewrap sandbox requires unprivileged user namespaces,

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -275,7 +275,7 @@ impl TerminalHandle {
         self.im_fallback.set_client_widget(gtk::Widget::NONE);
 
         if let Some(surface) = self.surface_cell.borrow_mut().take() {
-            free_terminal_surface(surface, &self.clipboard_context_cell);
+            free_terminal_surface(surface, &self.clipboard_context_cell, &self.gl_area);
         } else {
             let clipboard_context = self.clipboard_context_cell.replace(ptr::null_mut());
             if !clipboard_context.is_null() {
@@ -1368,6 +1368,7 @@ pub(crate) fn default_font_size() -> f32 {
 fn free_terminal_surface(
     surface: ghostty_surface_t,
     clipboard_context_cell: &Cell<*mut ClipboardContext>,
+    gl_area: &gtk::GLArea,
 ) {
     let surface_key = surface as usize;
     let entry = SURFACE_MAP.with(|map| map.borrow_mut().remove(&surface_key));
@@ -1383,6 +1384,14 @@ fn free_terminal_surface(
     }
 
     clipboard::cancel_surface_requests(surface_key);
+
+    // The Linux C API frees GL objects in the caller's current context. A
+    // shell exit runs from an idle callback, where another terminal's context
+    // (or none) may be current. Bind this terminal before freeing its renderer.
+    // An unrealized surface already released its GL resources in unrealize.
+    if gl_area.is_realized() {
+        gl_area.make_current();
+    }
 
     // Ghostty can invoke callbacks while its worker threads stop. Keep callback
     // userdata and widgets alive until deinitialization finishes.
@@ -2842,6 +2851,46 @@ fn translate_mouse_mods(state: gtk::gdk::ModifierType) -> c_int {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "requires a graphical display and Ghostty resources"]
+    fn shutdown_uses_the_terminal_gl_context() {
+        gtk::init().expect("GTK display required");
+        init_ghostty();
+        let terminal = create_terminal(
+            Some("/tmp"),
+            TerminalOptions {
+                startup_command: Some("/bin/sh".to_string()),
+                ..TerminalOptions::default()
+            },
+            TerminalCallbacks::disconnected(),
+        );
+        let other_area = gtk::GLArea::new();
+        let contents = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        contents.append(&terminal.root);
+        contents.append(&other_area);
+        let window = gtk::Window::builder()
+            .default_width(640)
+            .default_height(480)
+            .child(&contents)
+            .build();
+        window.present();
+        assert!(terminal.handle.surface_cell.borrow().is_some());
+        let terminal_context = terminal.handle.gl_area.context().expect("terminal context");
+        other_area.make_current();
+        assert!(other_area.error().is_none());
+        assert_ne!(
+            gtk::gdk::GLContext::current(),
+            Some(terminal_context.clone())
+        );
+
+        terminal.handle.shutdown();
+
+        assert_eq!(gtk::gdk::GLContext::current(), Some(terminal_context));
+        assert!(terminal.handle.surface_cell.borrow().is_none());
+        terminal.handle.shutdown(); // A second close must remain harmless.
+        window.close();
+    }
 
     #[test]
     fn physical_size_matches_logical_allocation_times_scale_factor() {

--- a/rust/limux-host-linux/src/terminal.rs
+++ b/rust/limux-host-linux/src/terminal.rs
@@ -2855,6 +2855,7 @@ mod tests {
     #[test]
     #[ignore = "requires a graphical display and Ghostty resources"]
     fn shutdown_uses_the_terminal_gl_context() {
+        crate::prepare_ghostty_runtime();
         gtk::init().expect("GTK display required");
         init_ghostty();
         let terminal = create_terminal(
@@ -2877,6 +2878,7 @@ mod tests {
         window.present();
         assert!(terminal.handle.surface_cell.borrow().is_some());
         let terminal_context = terminal.handle.gl_area.context().expect("terminal context");
+        assert_eq!(terminal_context.api(), gtk::gdk::GLAPI::GL);
         other_area.make_current();
         assert!(other_area.error().is_none());
         assert_ne!(

--- a/scripts/xvfb-smoke-test.sh
+++ b/scripts/xvfb-smoke-test.sh
@@ -269,6 +269,9 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 start_compositor
+cargo test --locked $CARGO_FLAGS -p limux-host-linux shutdown_uses_the_terminal_gl_context \
+  -- --ignored --test-threads=1 >"$LOG_DIR/terminal-gl-context.txt" 2>&1 \
+  || { cat "$LOG_DIR/terminal-gl-context.txt"; exit 1; }
 start_host host
 
 echo
@@ -353,16 +356,33 @@ for cycle in $(seq 1 10); do
 
   "$LIMUX_CLI" --json new-pane --workspace "$TEARDOWN_WORKSPACE" --direction right \
     >"$LOG_DIR/stage1c-pane-$cycle-1.json"
+  # Use a clean shell so Ctrl+D is EOF regardless of personal key bindings.
   "$LIMUX_CLI" --json new-pane --workspace "$TEARDOWN_WORKSPACE" --direction down \
+    --command "exec /bin/bash --noprofile --norc" \
     >"$LOG_DIR/stage1c-pane-$cycle-2.json"
   wait_for_host_child_count "$((BASELINE_CHILDREN + 3))"
 
   EXIT_SURFACE="$(jq -r '.surface_ref' "$LOG_DIR/stage1c-pane-$cycle-2.json")"
-  "$LIMUX_CLI" send --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" exit \
-    >"$LOG_DIR/stage1c-exit-$cycle.txt"
+  wait_for_healthy_surfaces "$TEARDOWN_WORKSPACE" "$LOG_DIR/stage1c-health-before-$cycle.json"
+  # A realized renderer does not imply that the shell has reached its prompt.
+  READY_FILE="$DEMO_DIR/ctrl-d-ready-$cycle"
+  "$LIMUX_CLI" send --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" \
+    "printf ready > '$READY_FILE'" >"$LOG_DIR/stage1c-ready-send-$cycle.txt"
   "$LIMUX_CLI" send-key --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" Enter \
-    >"$LOG_DIR/stage1c-exit-enter-$cycle.txt"
+    >"$LOG_DIR/stage1c-ready-enter-$cycle.txt"
+  for _ in $(seq 1 50); do
+    [ -f "$READY_FILE" ] && break
+    sleep 0.1
+  done
+  [ -f "$READY_FILE" ] || { echo "FAIL: Ctrl+D shell did not become ready"; exit 1; }
+  "$LIMUX_CLI" send-key --workspace "$TEARDOWN_WORKSPACE" --surface "$EXIT_SURFACE" '<Ctrl>d' \
+    >"$LOG_DIR/stage1c-ctrl-d-$cycle.txt"
   wait_for_host_child_count "$((BASELINE_CHILDREN + 2))"
+  wait_for_healthy_surfaces "$TEARDOWN_WORKSPACE" "$LOG_DIR/stage1c-health-after-$cycle.json"
+  jq -e --arg closed "$EXIT_SURFACE" '
+    .surfaces | length == 2 and all(.[]; .surface_ref != $closed)
+  ' "$LOG_DIR/stage1c-health-after-$cycle.json" >/dev/null \
+    || { echo "FAIL: Ctrl+D did not close only its terminal"; exit 1; }
 
   "$LIMUX_CLI" close-workspace --workspace "$TEARDOWN_WORKSPACE" \
     >"$LOG_DIR/stage1c-close-$cycle.txt"


### PR DESCRIPTION
Closing a shell with Ctrl+D queues terminal teardown on the GTK idle loop, where another widget's OpenGL context (or none) may be current. The Linux Ghostty C API uses the caller's current context when freeing renderer resources. Select the closing terminal's context before freeing its surface to avoid destroying GL objects in the wrong context.

Add a graphical regression that selects another widget's context before shutting down a terminal, and run it under the existing Weston smoke harness. The test shares the host's pre-GTK setup for desktop OpenGL, GLAD linkage, and Ghostty resources, so it also initializes correctly on Ubuntu 24.04. The harness also exercises ten Ctrl+D cycles, checks that only the intended terminal closes and its peers remain healthy, and verifies process cleanup. Document the graphical test workflow in the maintainability guide.

Validation:

- The targeted graphical regression failed before the fix and passed after it on the local NVIDIA display.
- `./scripts/check.sh` passed.
- `LIMUX_SMOKE_PROFILE=debug ./scripts/xvfb-smoke-test.sh` passed under headless Weston, including all ten Ctrl+D cycles. It also passed in a separate Ubuntu 24.04 container after the test initialization fix.
- `cargo fmt --check` passed after rebasing onto the latest upstream main.

Local validation used the installed `libghostty-internal.so`; the existing CI workflow rebuilds the vendored Ghostty library. A reported NVIDIA SIGSEGV prompted this fix, but its incomplete core dump did not establish the exact crash stack.

Addresses #180.
